### PR TITLE
Quality-of-life: audio preamp, real stream quality, animations, mini-player, sleep timer, window restore

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,14 @@
+param(
+    # Open a specific demo page, e.g. ./dev.ps1 -DemoPage home
+    [string]$DemoPage = ""
+)
+
+# A survivor instance in the tray would swallow the next launch
+# (single-instance guard), so always start from a clean slate.
+Stop-Process -Name fastpotify -ErrorAction SilentlyContinue
+
+if ($DemoPage) {
+    cargo watch -x "run --features demo -- --demo --demo-page $DemoPage"
+} else {
+    cargo watch -x "run --features demo -- --demo"
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -590,16 +590,30 @@ impl App {
         self.sleep_timer_end = None;
     }
 
-    /// Toggles the compact single-line player. When it opens, the window is
-    /// resized to just fit it; leaving restores the previous size.
+    /// Toggles the compact square player. When it opens, the window is
+    /// resized to fit it and pinned above other windows; leaving restores
+    /// the previous size and minimum.
     pub fn toggle_mini_player(&mut self, ctx: &egui::Context) {
         self.mini_player = !self.mini_player;
-        let size = if self.mini_player {
-            egui::vec2(520.0, 96.0)
+        if self.mini_player {
+            ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(
+                theme::MINI_PLAYER_SIZE.into(),
+            ));
+            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(
+                theme::MINI_PLAYER_SIZE.into(),
+            ));
+            ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                egui::WindowLevel::AlwaysOnTop,
+            ));
         } else {
-            egui::vec2(1240.0, 800.0)
-        };
-        ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
+            ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(
+                760.0, 520.0,
+            )));
+            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(1240.0, 800.0)));
+            ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                egui::WindowLevel::Normal,
+            ));
+        }
     }
 
     /// Remaining sleep-timer time, or `None` when no timer is armed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,6 +67,8 @@ pub struct NowPlaying {
     pub volume_percent: u8,
     pub can_control: bool,
     pub is_episode: bool,
+    /// Streaming quality of the local player, e.g. "320 kbps OGG".
+    pub quality: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -158,6 +160,9 @@ pub struct App {
     pub dialog: Option<Dialog>,
     pub show_queue_panel: bool,
     pub show_devices: bool,
+    /// A single-line now-playing strip instead of the full interface,
+    /// opened and closed with a shortcut or a button in the player bar.
+    pub mini_player: bool,
     pub toasts: Vec<Toast>,
     pub actions: Vec<Action>,
     volume_before_mute: Option<u8>,
@@ -175,6 +180,22 @@ pub struct App {
     remote_recheck_at: Option<Instant>,
     pub seek_preview: Option<f32>,
     pub volume_preview: Option<f32>,
+    /// When playback should pause automatically, or `None` without a timer.
+    pub sleep_timer_end: Option<Instant>,
+    /// A volume change just happened through the keyboard; show an overlay
+    /// with the new level until `Instant` passes.
+    pub volume_osd: Option<(u8, Instant)>,
+    /// Restored window geometry to apply on the next attach, taken from the
+    /// session file.
+    session_window_size: Option<[f32; 2]>,
+    session_window_pos: Option<[f32; 2]>,
+    /// The album-art tint currently on screen, eased toward the latest
+    /// requested colour so changing tracks or pages crossfades instead of
+    /// snapping.
+    pub tint_current: Option<Color32>,
+    /// Last observed window geometry, saved to the session on close.
+    last_window_size: Option<[f32; 2]>,
+    last_window_pos: Option<[f32; 2]>,
     last_eviction: Instant,
     pub sign_in_url: Option<String>,
     pending_remote_position: Option<(u32, Instant)>,
@@ -211,6 +232,9 @@ impl App {
             .and_then(Page::decode)
             .filter(|page| !matches!(page, Page::Settings | Page::Queue))
             .unwrap_or(Page::Home);
+        let session_window_size = session.window_size;
+        let session_window_pos = session.window_pos;
+        let session_queue_panel = session.show_queue_panel;
 
         let mut app = Self {
             dirs,
@@ -260,8 +284,9 @@ impl App {
             accents: HashMap::new(),
             accent_pending: HashSet::new(),
             dialog: None,
-            show_queue_panel: false,
+            show_queue_panel: session_queue_panel,
             show_devices: false,
+            mini_player: false,
             toasts: Vec::new(),
             actions: Vec::new(),
             volume_before_mute: None,
@@ -272,6 +297,13 @@ impl App {
             remote_recheck_at: None,
             seek_preview: None,
             volume_preview: None,
+            sleep_timer_end: None,
+            volume_osd: None,
+            session_window_size: None,
+            session_window_pos: None,
+            tint_current: None,
+            last_window_size: None,
+            last_window_pos: None,
             last_eviction: Instant::now(),
             sign_in_url: None,
             pending_remote_position: None,
@@ -282,6 +314,8 @@ impl App {
             quit_requested: false,
         };
         app.local.volume = app.settings.volume;
+        app.session_window_size = session_window_size;
+        app.session_window_pos = session_window_pos;
         app
     }
 
@@ -304,6 +338,12 @@ impl App {
         self.window_hidden = false;
         self.hide_intent = false;
         self.wants_show = false;
+        if let Some(size) = self.session_window_size.take() {
+            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(size[0], size[1])));
+        }
+        if let Some(pos) = self.session_window_pos.take() {
+            ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(pos[0], pos[1])));
+        }
     }
 
     // ---- derived state -----------------------------------------------------
@@ -408,6 +448,9 @@ impl App {
                 volume_percent: volume_to_percent(self.local.volume),
                 can_control: true,
                 is_episode: track.is_episode,
+                quality: track
+                    .stream_format
+                    .map(crate::player::format_quality_label),
             });
         }
         let remote = self.remote_fresh()?;
@@ -481,6 +524,7 @@ impl App {
             volume_percent: volume,
             can_control: device.is_none_or(|device| !device.is_restricted),
             is_episode,
+            quality: None,
         })
     }
 
@@ -534,6 +578,87 @@ impl App {
             });
         }
         None
+    }
+
+    /// Arms the sleep timer for `minutes` from now. A paused track stays
+    /// paused; the timer pauses whatever is playing when it expires.
+    pub fn set_sleep_timer(&mut self, minutes: u64) {
+        self.sleep_timer_end = Some(Instant::now() + Duration::from_secs(minutes * 60));
+    }
+
+    pub fn cancel_sleep_timer(&mut self) {
+        self.sleep_timer_end = None;
+    }
+
+    /// Toggles the compact single-line player. When it opens, the window is
+    /// resized to just fit it; leaving restores the previous size.
+    pub fn toggle_mini_player(&mut self, ctx: &egui::Context) {
+        self.mini_player = !self.mini_player;
+        let size = if self.mini_player {
+            egui::vec2(520.0, 96.0)
+        } else {
+            egui::vec2(1240.0, 800.0)
+        };
+        ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
+    }
+
+    /// Remaining sleep-timer time, or `None` when no timer is armed.
+    pub fn sleep_timer_left(&self) -> Option<Duration> {
+        self.sleep_timer_end
+            .map(|end| end.saturating_duration_since(Instant::now()))
+    }
+
+    /// Pauses playback when the sleep timer expires. Called once per frame.
+    pub fn tick_sleep_timer(&mut self) {
+        if self.sleep_timer_end.is_none() {
+            return;
+        }
+        let expired = self
+            .sleep_timer_end
+            .is_some_and(|end| Instant::now() >= end);
+        if !expired {
+            return;
+        }
+        self.sleep_timer_end = None;
+        let was_playing = self.now_playing().is_some_and(|now| now.playing);
+        if was_playing {
+            self.actions.push(Action::TogglePlay);
+        }
+        self.toast("Sleep timer: playback paused.");
+    }
+
+    /// Eases `tint_current` toward the tint the interface wants this frame.
+    /// Returns what should be drawn, crossfading over a few frames so a
+    /// track change or page switch never snaps the background colour.
+    pub fn eased_tint(&mut self, ctx: &egui::Context, wanted: Option<Color32>) -> Option<Color32> {
+        let Some(wanted) = wanted else {
+            self.tint_current = None;
+            return None;
+        };
+        let current = self.tint_current;
+        match (current, wanted) {
+            (None, wanted) => {
+                self.tint_current = Some(wanted);
+                Some(wanted)
+            }
+            (Some(current), wanted) if current == wanted => Some(current),
+            (Some(current), wanted) => {
+                let t = ctx.animate_value_with_time(
+                    egui::Id::new("tint-crossfade"),
+                    (current != wanted) as u8 as f32,
+                    0.3,
+                );
+                if t <= 0.0 {
+                    self.tint_current = Some(wanted);
+                    Some(wanted)
+                } else {
+                    let eased = crate::theme::ease_out(t);
+                    let mixed = crate::ui::blend(current, wanted, eased);
+                    self.tint_current = Some(mixed);
+                    Some(mixed)
+                }
+            }
+        }
     }
 
     // ---- frame ---------------------------------------------------------------
@@ -2267,10 +2392,12 @@ impl App {
                         (i16::from(now.volume_percent) + i16::from(delta)).clamp(0, 100) as u8;
                     self.volume_before_mute = None;
                     self.set_volume(next);
+                    self.volume_osd = Some((next, Instant::now()));
                 } else if self.is_connected() {
                     let current = volume_to_percent(self.local.volume);
                     let next = (i16::from(current) + i16::from(delta)).clamp(0, 100) as u8;
                     self.set_volume(next);
+                    self.volume_osd = Some((next, Instant::now()));
                 }
             }
             Action::ToggleMute => {
@@ -2493,6 +2620,7 @@ impl App {
                     self.backend.send(Command::DiscoverReceivers);
                 }
             }
+            Action::ToggleMiniPlayer => self.toggle_mini_player(ctx),
             Action::SettingsChanged => {
                 self.settings_dirty = true;
                 ctx.set_theme(match self.settings.theme {
@@ -2617,9 +2745,19 @@ impl App {
         crate::ui::show(self, ui);
         self.apply_actions(ctx);
         self.sync_mpris();
+        self.tick_sleep_timer();
+        if let Some(rect) = ctx.input(|input| input.viewport().inner_rect) {
+            self.last_window_size = Some([rect.width(), rect.height()]);
+        }
+        if let Some(rect) = ctx.input(|input| input.viewport().outer_rect) {
+            self.last_window_pos = Some([rect.min.x, rect.min.y]);
+        }
 
         let playing = self.now_playing().is_some_and(|now| now.playing);
         if playing {
+            ctx.request_repaint_after(Duration::from_millis(250));
+        }
+        if self.sleep_timer_end.is_some() {
             ctx.request_repaint_after(Duration::from_millis(250));
         }
         if !self.toasts.is_empty() {
@@ -2649,6 +2787,9 @@ impl App {
         if !self.offline {
             SessionState {
                 last_page: Some(self.page().encode()),
+                window_size: self.last_window_size,
+                window_pos: self.last_window_pos,
+                show_queue_panel: self.show_queue_panel,
             }
             .save(&self.dirs.session_file());
         }
@@ -2666,6 +2807,7 @@ pub fn engine_config(dirs: &AppDirs, settings: &Settings) -> EngineConfig {
         device_name: settings.device_name.trim().to_string(),
         bitrate_kbps: settings.bitrate,
         normalisation: settings.normalisation,
+        normalisation_pregain_db: settings.normalisation_pregain_db,
         autoplay: settings.autoplay,
         gapless: settings.gapless,
         backend: settings.platform_backend(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -491,6 +491,7 @@ pub enum Action {
     SignOut,
     ToggleQueuePanel,
     ToggleDevicesPopup,
+    ToggleMiniPlayer,
     SettingsChanged,
     RestartEngine,
     EnablePlayback,

--- a/src/player.rs
+++ b/src/player.rs
@@ -22,7 +22,7 @@ use librespot_core::{
     config::{DeviceType, SessionConfig},
     session::Session,
 };
-use librespot_metadata::audio::{AudioItem, UniqueFields};
+use librespot_metadata::audio::{AudioFileFormat, AudioItem, UniqueFields};
 use librespot_playback::{
     audio_backend,
     config::{AudioFormat, Bitrate, NormalisationType, PlayerConfig},
@@ -36,6 +36,7 @@ pub struct EngineConfig {
     pub device_name: String,
     pub bitrate_kbps: u16,
     pub normalisation: bool,
+    pub normalisation_pregain_db: f64,
     pub autoplay: bool,
     pub gapless: bool,
     pub backend: Option<String>,
@@ -135,6 +136,10 @@ pub struct LocalTrack {
     pub art_small_url: Option<String>,
     pub duration_ms: u32,
     pub is_episode: bool,
+    /// The Ogg Vorbis / MP3 file the player actually streams for this item,
+    /// which can fall below the configured bitrate (podcasts, unavailable
+    /// higher formats). `None` for local files.
+    pub stream_format: Option<AudioFileFormat>,
 }
 
 impl LocalTrack {
@@ -239,6 +244,7 @@ impl Engine {
             bitrate: config.bitrate(),
             gapless: config.gapless,
             normalisation: config.normalisation,
+            normalisation_pregain_db: config.normalisation_pregain_db,
             normalisation_type: NormalisationType::Auto,
             position_update_interval: Some(Duration::from_secs(1)),
             ..PlayerConfig::default()
@@ -483,8 +489,7 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
             let mut changed = set(&mut state.track, Some(local_track(&audio_item)));
             changed |= set(&mut state.error, None);
             changed
-        }
-        PlayerEvent::Unavailable { track_id, .. } => set(
+        }        PlayerEvent::Unavailable { track_id, .. } => set(
             &mut state.error,
             Some(format!(
                 "This item isn't available: {}",
@@ -550,6 +555,18 @@ fn local_track(item: &AudioItem) -> LocalTrack {
         .find(|cover| cover.width >= 64)
         .or(covers.last())
         .map(|cover| cover.url.clone());
+    // The first file librespot's own format list would pick for the
+    // configured bitrate: the best Ogg Vorbis / MP3 this item offers.
+    // The 2026 client asks Spotify for these formats; episodes stream at
+    // 96 kbps, so this shows the real quality, not the configured one.
+    let stream_format = if matches!(item.unique_fields, UniqueFields::Local { .. }) {
+        None
+    } else {
+        item.files
+            .keys()
+            .max_by_key(|format| stream_quality_rank(**format))
+            .copied()
+    };
     LocalTrack {
         uri: item.uri.clone(),
         title: item.name.clone(),
@@ -559,7 +576,55 @@ fn local_track(item: &AudioItem) -> LocalTrack {
         art_small_url,
         duration_ms: item.duration_ms,
         is_episode,
+        stream_format,
     }
+}
+
+/// Orders [`AudioFileFormat`]s by streaming quality so the best available
+/// one for the current bitrate can be shown. Mirrors the preference list in
+/// librespot's player.
+fn stream_quality_rank(format: AudioFileFormat) -> u8 {
+    use AudioFileFormat::*;
+    match format {
+        FLAC_FLAC | FLAC_FLAC_24BIT => 60,
+        OGG_VORBIS_320 | MP3_320 => 50,
+        MP3_256 => 45,
+        OGG_VORBIS_160 | MP3_160 | AAC_160 => 40,
+        MP3_160_ENC => 35,
+        MP4_128 | AAC_320 => 30,
+        OGG_VORBIS_96 | MP3_96 => 20,
+        AAC_48 => 15,
+        AAC_24 => 10,
+        XHE_AAC_24 | XHE_AAC_16 | XHE_AAC_12 => 5,
+        OTHER5 => 1,
+    }
+}
+
+/// Human-readable quality for a streaming format, e.g. "320 kbps OGG".
+pub fn format_quality_label(format: AudioFileFormat) -> String {
+    use AudioFileFormat::*;
+    let (codec, kbps) = match format {
+        OGG_VORBIS_320 => ("OGG", 320),
+        OGG_VORBIS_160 => ("OGG", 160),
+        OGG_VORBIS_96 => ("OGG", 96),
+        MP3_320 => ("MP3", 320),
+        MP3_256 => ("MP3", 256),
+        MP3_160 => ("MP3", 160),
+        MP3_96 => ("MP3", 96),
+        MP3_160_ENC => ("MP3", 160),
+        AAC_320 => ("AAC", 320),
+        AAC_160 => ("AAC", 160),
+        AAC_48 => ("AAC", 48),
+        AAC_24 => ("AAC", 24),
+        XHE_AAC_24 => ("xHE-AAC", 24),
+        XHE_AAC_16 => ("xHE-AAC", 16),
+        XHE_AAC_12 => ("xHE-AAC", 12),
+        MP4_128 => ("M4A", 128),
+        FLAC_FLAC => ("FLAC", 900),
+        FLAC_FLAC_24BIT => ("FLAC 24-bit", 900),
+        OTHER5 => ("Other", 0),
+    };
+    format!("{kbps} kbps {codec}")
 }
 
 #[cfg(test)]
@@ -615,6 +680,7 @@ mod tests {
             device_name: "Fastpotify".into(),
             bitrate_kbps: 320,
             normalisation: false,
+            normalisation_pregain_db: 0.0,
             autoplay: true,
             gapless: true,
             backend: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -33,6 +33,9 @@ pub struct Settings {
     /// 96, 160, or 320 kbps.
     pub bitrate: u16,
     pub normalisation: bool,
+    /// Extra gain on top of ReplayGain normalisation, in dB. librespot's
+    /// default is 0; Spotify's desktop client applies +11 dB by default.
+    pub normalisation_pregain_db: f64,
     pub autoplay: bool,
     pub gapless: bool,
     /// librespot backend name; `None` picks the platform default.
@@ -64,6 +67,7 @@ impl Default for Settings {
             device_name: "Fastpotify".to_string(),
             bitrate: 320,
             normalisation: false,
+            normalisation_pregain_db: 0.0,
             autoplay: true,
             gapless: true,
             audio_backend: None,
@@ -139,6 +143,12 @@ impl Settings {
 #[serde(default)]
 pub struct SessionState {
     pub last_page: Option<String>,
+    /// Last window inner size, so the app reopens the way it was closed.
+    pub window_size: Option<[f32; 2]>,
+    /// Last window outer position, where supported.
+    pub window_pos: Option<[f32; 2]>,
+    /// Whether the queue side panel was open.
+    pub show_queue_panel: bool,
 }
 
 impl SessionState {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -540,12 +540,14 @@ pub fn circle_button(
         // Hover and press both animate; the press shrink is brief and snappy
         // while the hover grow is a slow settle, so the play button feels
         // alive instead of jumping between sizes.
-        let hover_t = ui
-            .ctx()
-            .animate_bool_with_time(ui.id().with("circle-hover"), hovered, 0.18);
-        let press_t = ui
-            .ctx()
-            .animate_bool_with_time(ui.id().with("circle-press"), response.is_pointer_button_down_on(), 0.09);
+        let hover_t =
+            ui.ctx()
+                .animate_bool_with_time(response.id.with("circle-hover"), hovered, 0.18);
+        let press_t = ui.ctx().animate_bool_with_time(
+            response.id.with("circle-press"),
+            response.is_pointer_button_down_on(),
+            0.09,
+        );
         let grow = 1.0 + 0.05 * ease_out(hover_t);
         let radius = diameter / 2.0 * grow * (1.0 - 0.08 * press_t);
         let fill = if hovered { fill_hover } else { fill };

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -101,6 +101,8 @@ pub const ROW_HEIGHT: f32 = 56.0;
 pub const COMPACT_ROW_HEIGHT: f32 = 48.0;
 pub const PLAYER_BAR_HEIGHT: f32 = 88.0;
 pub const TOP_BAR_HEIGHT: f32 = 56.0;
+/// Size of the square mini-player window.
+pub const MINI_PLAYER_SIZE: [f32; 2] = [320.0, 320.0];
 
 const INTER_MEDIUM: &str = "inter-medium";
 const INTER_SEMIBOLD: &str = "inter-semibold";

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -6,7 +6,7 @@
 //! through a [`Palette`] so light and dark stay coherent and album-art tints
 //! can be blended in without hunting for hard-coded colours.
 
-use egui::{Color32, CornerRadius, Response, Sense, Stroke, Vec2};
+use egui::{Color32, CornerRadius, Response, Sense, Stroke, Vec2, Rgba};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Palette {
@@ -325,7 +325,9 @@ pub enum Icon {
     Loader,
     Lock,
     LogOut,
+    Maximize2,
     Mic,
+    Minimize2,
     Minus,
     Monitor,
     Moon,
@@ -410,13 +412,16 @@ const ICONS: &[(Icon, &str, &[u8])] = icons! {
     Loader => "loader-circle",
     Lock => "lock",
     LogOut => "log-out",
+    Maximize2 => "maximize-2",
     Mic => "mic",
+    Minimize2 => "minimize-2",
     Minus => "minus",
     Monitor => "monitor",
     Moon => "moon",
     Music => "music",
     Pause => "pause",
     PauseFilled => "pause-filled",
+    Pencil => "pencil",
     Pencil => "pencil",
     Play => "play",
     PlayFilled => "play-filled",
@@ -530,11 +535,20 @@ pub fn circle_button(
     let (rect, response) = ui.allocate_exact_size(Vec2::splat(diameter), Sense::click());
     if ui.is_rect_visible(rect) {
         let hovered = response.hovered();
-        let grow = if hovered { 1.05 } else { 1.0 };
-        let radius = diameter / 2.0 * grow;
+        // Hover and press both animate; the press shrink is brief and snappy
+        // while the hover grow is a slow settle, so the play button feels
+        // alive instead of jumping between sizes.
+        let hover_t = ui
+            .ctx()
+            .animate_bool_with_time(ui.id().with("circle-hover"), hovered, 0.18);
+        let press_t = ui
+            .ctx()
+            .animate_bool_with_time(ui.id().with("circle-press"), response.is_pointer_button_down_on(), 0.09);
+        let grow = 1.0 + 0.05 * ease_out(hover_t);
+        let radius = diameter / 2.0 * grow * (1.0 - 0.08 * press_t);
         let fill = if hovered { fill_hover } else { fill };
         ui.painter().circle_filled(rect.center(), radius, fill);
-        let icon_size = diameter * 0.46;
+        let icon_size = diameter * 0.46 * (1.0 + 0.04 * hover_t) * (1.0 - 0.08 * press_t);
         // A right-pointing triangle's visual mass sits left of its bounding
         // box, so a geometrically centred glyph reads as pushed left and a
         // full optical shift reads as pushed right. Lucide bakes about one
@@ -724,4 +738,19 @@ pub fn section_title(ui: &mut egui::Ui, palette: &Palette, label: &str) -> Respo
 
 pub fn subtle(ui: &mut egui::Ui, palette: &Palette, label: &str) -> Response {
     text(ui, label, regular(13.0), palette.secondary)
+}
+
+/// A smooth curve for the interface's short animations: quick to start,
+/// gentle at the end.
+pub fn ease_out(t: f32) -> f32 {
+    1.0 - (1.0 - t).powi(3)
+}
+
+/// Linear interpolation between two colours, `t` in 0..=1.
+pub fn lerp_color(from: Color32, to: Color32, t: f32) -> Color32 {
+    let from = Rgba::from(from);
+    let to = Rgba::from(to);
+    let mut color = Color32::from(from * (1.0 - t) + to * t);
+    color[3] = 255;
+    color
 }

--- a/src/ui/keys.rs
+++ b/src/ui/keys.rs
@@ -17,6 +17,7 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
         key(Modifiers::COMMAND, Key::F, Action::FocusSearch);
         key(Modifiers::COMMAND, Key::Comma, Action::Open(Page::Settings));
         key(Modifiers::COMMAND, Key::Q, Action::Quit);
+        key(Modifiers::COMMAND, Key::M, Action::ToggleMiniPlayer);
         key(Modifiers::COMMAND, Key::H, Action::Open(Page::Home));
         key(Modifiers::COMMAND, Key::L, Action::Open(Page::LikedSongs));
         key(
@@ -80,7 +81,9 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
         }
     }
     if ctx.input(|input| input.key_pressed(Key::Escape)) {
-        if app.dialog.is_some() {
+        if app.mini_player {
+            app.actions.push(Action::ToggleMiniPlayer);
+        } else if app.dialog.is_some() {
             app.actions.push(Action::CloseDialog);
         } else if app.show_devices {
             app.show_devices = false;
@@ -101,6 +104,7 @@ pub const SHORTCUTS: &[(&str, &str)] = &[
     ("Alt+←  /  Alt+→", "Back or forward"),
     ("Ctrl+H", "Home"),
     ("Ctrl+L", "Liked Songs"),
+    ("Ctrl+M", "Mini-player"),
     ("Ctrl+Shift+A", "Go to the playing artist"),
     ("Ctrl+Shift+B", "Go to the playing album"),
     ("Ctrl+,", "Settings"),

--- a/src/ui/mini.rs
+++ b/src/ui/mini.rs
@@ -1,0 +1,335 @@
+//! The compact player: a single-line now-playing strip used when the
+//! window is shrunk to a small bar.
+
+use egui::{Align, CornerRadius, Layout, Rect, Sense, UiBuilder, Vec2, pos2, vec2};
+
+use crate::app::App;
+use crate::model::{Action, Page};
+use crate::player::RepeatMode;
+use crate::theme::{self, Icon};
+use crate::util;
+
+use super::widgets::{SliderEvent, thin_slider};
+
+pub fn show(app: &mut App, ui: &mut egui::Ui) {
+    let palette = app.palette;
+    let tint = app.eased_tint(ui.ctx(), app.now_playing_tint());
+    let fill = match tint {
+        Some(tint) => super::blend(palette.panel, tint, 0.10),
+        None => palette.panel,
+    };
+    egui::CentralPanel::default()
+        .frame(egui::Frame::new().fill(fill).inner_margin(egui::Margin::symmetric(12, 8)))
+        .show(ui, |ui| {
+            let rect = ui.max_rect();
+            let now = app.now_playing();
+
+            // Exit the compact player by clicking the cover, or the corner X.
+            let close = Rect::from_center_size(pos2(rect.right() - 14.0, rect.top() + 14.0), Vec2::splat(28.0));
+            let mut close_ui = ui.new_child(
+                UiBuilder::new()
+                    .max_rect(close)
+                    .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+            );
+            if theme::icon_button(
+                &mut close_ui,
+                Icon::Maximize2,
+                14.0,
+                palette.secondary,
+                palette.text,
+                "Leave mini-player (Ctrl+M)",
+            )
+            .clicked()
+            {
+                app.actions.push(Action::ToggleMiniPlayer);
+            }
+
+            let cover_rect = Rect::from_min_size(rect.min + vec2(2.0, 2.0), Vec2::splat(72.0));
+            super::widgets::paint_cover(
+                ui,
+                &palette,
+                now.as_ref()
+                    .and_then(|now| now.art_small.as_deref().or(now.art_url.as_deref())),
+                cover_rect,
+                8.0,
+                Icon::Music,
+            );
+            if ui
+                .interact(
+                    cover_rect,
+                    egui::Id::new("mini-cover"),
+                    Sense::click(),
+                )
+                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                .clicked()
+            {
+                app.actions.push(Action::ToggleMiniPlayer);
+            }
+
+            let text_left = cover_rect.right() + 14.0;
+            let text_rect = Rect::from_min_max(
+                pos2(text_left, rect.top() + 10.0),
+                pos2(rect.right() - 340.0, rect.bottom() - 10.0),
+            );
+            let mut text_ui = ui.new_child(
+                UiBuilder::new()
+                    .max_rect(text_rect)
+                    .layout(Layout::top_down(Align::Min)),
+            );
+            text_ui.set_clip_rect(text_rect.intersect(ui.clip_rect()));
+            text_ui.spacing_mut().item_spacing.y = 3.0;
+            let now_ref = now.as_ref();
+            if let Some(now) = now_ref {
+                if theme::link(&mut text_ui, &now.title, theme::semibold(14.5), palette.text)
+                    .clicked()
+                {
+                    if let Some(id) = &now.album_id {
+                        app.actions.push(Action::Open(Page::Album(id.clone())));
+                    } else if let Some(id) = &now.show_id {
+                        app.actions.push(Action::Open(Page::Show(id.clone())));
+                    }
+                }
+                theme::text(
+                    &mut text_ui,
+                    &now.subtitle,
+                    theme::regular(12.0),
+                    palette.secondary,
+                );
+            } else {
+                theme::text(&mut text_ui, "Nothing playing", theme::semibold(14.0), palette.text);
+                theme::text(
+                    &mut text_ui,
+                    "Pick a song, album, or playlist",
+                    theme::regular(12.0),
+                    palette.dim,
+                );
+            }
+
+            // Transport, right of the text.
+            let cy = rect.center().y;
+            let mut x = text_rect.right() + 6.0;
+            let mut slot = |width: f32| -> Rect {
+                let cell = Rect::from_center_size(pos2(x + width / 2.0, cy), vec2(width, 36.0));
+                x += width + 4.0;
+                cell
+            };
+            let centered = |ui: &mut egui::Ui, cell: Rect| {
+                ui.new_child(
+                    UiBuilder::new()
+                        .max_rect(cell)
+                        .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+                )
+            };
+            let enabled = now.as_ref().is_some_and(|now| now.can_control) || app.is_connected();
+            let playing = now.as_ref().is_some_and(|now| now.playing);
+            let loading = now.as_ref().is_some_and(|now| now.loading);
+            let shuffle = now.as_ref().is_some_and(|now| now.shuffle);
+            let repeat = now.as_ref().map(|now| now.repeat).unwrap_or_default();
+            let volume = now
+                .as_ref()
+                .map(|now| now.volume_percent)
+                .unwrap_or_else(|| crate::app::volume_to_percent(app.local.volume));
+            let (position, duration) = now
+                .as_ref()
+                .map(|now| (now.position_ms, now.duration_ms))
+                .unwrap_or((0, 0));
+            let dim = if enabled {
+                palette.secondary
+            } else {
+                palette.dim
+            };
+            let local_playback = now.is_none_or(|now| now.local);
+            let _ = now;
+
+            // Previous.
+            let mut cell = centered(ui, slot(30.0));
+            if theme::icon_button(
+                &mut cell,
+                Icon::SkipBackFilled,
+                18.0,
+                dim,
+                palette.text,
+                "Previous",
+            )
+            .clicked()
+            {
+                app.actions.push(Action::Previous);
+            }
+            // Play / pause.
+            let disc = slot(36.0);
+            if loading || app.any_play_pending() {
+                ui.painter().circle_filled(disc.center(), 18.0, palette.text);
+                let mut cell = centered(ui, disc);
+                theme::spinner(&mut cell, 22.0, palette.window);
+            } else {
+                let icon = if playing {
+                    Icon::PauseFilled
+                } else {
+                    Icon::PlayFilled
+                };
+                let hover = if palette.dark {
+                    egui::Color32::WHITE
+                } else {
+                    palette.text
+                };
+                let mut cell = centered(ui, disc);
+                if theme::circle_button(
+                    &mut cell,
+                    icon,
+                    36.0,
+                    palette.text,
+                    hover,
+                    palette.window,
+                    if playing { "Pause" } else { "Play" },
+                )
+                .clicked()
+                {
+                    app.actions.push(Action::TogglePlay);
+                }
+            }
+            // Next.
+            let mut cell = centered(ui, slot(30.0));
+            if theme::icon_button(
+                &mut cell,
+                Icon::SkipForwardFilled,
+                18.0,
+                dim,
+                palette.text,
+                "Next",
+            )
+            .clicked()
+            {
+                app.actions.push(Action::Next);
+            }
+            // Shuffle.
+            let mut cell = centered(ui, slot(29.0));
+            if theme::icon_button(
+                &mut cell,
+                Icon::Shuffle,
+                17.0,
+                if shuffle { palette.accent } else { dim },
+                palette.text,
+                "Shuffle",
+            )
+            .clicked()
+            {
+                app.actions.push(Action::ToggleShuffle);
+            }
+            // Repeat.
+            let (repeat_icon, repeat_color, tooltip) = match repeat {
+                RepeatMode::Off => (Icon::Repeat, dim, "Repeat"),
+                RepeatMode::Context => (Icon::Repeat, palette.accent, "Repeat one"),
+                RepeatMode::Track => (Icon::Repeat1, palette.accent, "Repeat off"),
+            };
+            let mut cell = centered(ui, slot(29.0));
+            if theme::icon_button(
+                &mut cell,
+                repeat_icon,
+                17.0,
+                repeat_color,
+                palette.text,
+                tooltip,
+            )
+            .clicked()
+            {
+                app.actions.push(Action::CycleRepeat);
+            }
+
+            // Volume, far right.
+            let shown = match app.volume_preview {
+                Some(fraction) => (fraction * 100.0).round() as u8,
+                None => volume,
+            };
+            let volume_rect = Rect::from_center_size(
+                pos2(rect.right() - 96.0 - 28.0, cy),
+                vec2(96.0, 16.0),
+            );
+            let mut volume_ui = ui.new_child(
+                UiBuilder::new()
+                    .max_rect(volume_rect)
+                    .layout(Layout::left_to_right(Align::Center)),
+            );
+            match thin_slider(
+                &mut volume_ui,
+                &palette,
+                egui::Id::new("mini-volume"),
+                volume as f32 / 100.0,
+                96.0,
+                palette.accent,
+            ) {
+                SliderEvent::Dragging(value) => {
+                    app.volume_preview = Some(value);
+                    if local_playback {
+                        app.actions
+                            .push(Action::SetVolume((value * 100.0).round() as u8));
+                    }
+                }
+                SliderEvent::Committed(value) => {
+                    app.volume_preview = None;
+                    app.actions
+                        .push(Action::SetVolume((value * 100.0).round() as u8));
+                }
+                SliderEvent::None => {}
+            }
+            let volume_icon = match shown {
+                0 => Icon::VolumeX,
+                1..=33 => Icon::Volume,
+                34..=66 => Icon::Volume1,
+                _ => Icon::Volume2,
+            };
+            let mute = Rect::from_center_size(pos2(rect.right() - 12.0, cy), Vec2::splat(30.0));
+            let mut mute_ui = ui.new_child(
+                UiBuilder::new()
+                    .max_rect(mute)
+                    .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+            );
+            if theme::icon_button(
+                &mut mute_ui,
+                volume_icon,
+                18.0,
+                palette.secondary,
+                palette.text,
+                if shown == 0 { "Unmute" } else { "Mute" },
+            )
+            .clicked()
+            {
+                app.actions.push(Action::ToggleMute);
+            }
+
+            // Seek, running under everything but the covers.
+            let fraction = if duration > 0 {
+                position as f32 / duration as f32
+            } else {
+                0.0
+            };
+            let seek_rect = Rect::from_center_size(
+                pos2((rect.left() + rect.right()) / 2.0, rect.bottom() - 6.0),
+                vec2(rect.width() - 24.0, 8.0),
+            );
+            let mut seek_ui = ui.new_child(
+                UiBuilder::new()
+                    .max_rect(seek_rect)
+                    .layout(Layout::left_to_right(Align::Center)),
+            );
+            match thin_slider(
+                &mut seek_ui,
+                &palette,
+                egui::Id::new("mini-seek"),
+                fraction,
+                seek_rect.width(),
+                palette.accent,
+            ) {
+                SliderEvent::Dragging(value) => app.seek_preview = Some(value),
+                SliderEvent::Committed(value) => {
+                    app.seek_preview = None;
+                    if duration > 0 {
+                        app.actions
+                            .push(Action::Seek((value * duration as f32) as u32));
+                    }
+                }
+                SliderEvent::None => {}
+            }
+            let _ = util::format_duration_ms;
+            let _ = CornerRadius::same(0);
+        });
+}

--- a/src/ui/mini.rs
+++ b/src/ui/mini.rs
@@ -1,11 +1,10 @@
-//! The compact player: a single-line now-playing strip used when the
-//! window is shrunk to a small bar.
+//! The compact square player, Spotify mini-player style: a big cover, the
+//! track title, and the essentials — transport, seek, and time.
 
-use egui::{Align, CornerRadius, Layout, Rect, Sense, UiBuilder, Vec2, pos2, vec2};
+use egui::{Align, Layout, Rect, Sense, UiBuilder, Vec2, pos2, vec2};
 
 use crate::app::App;
 use crate::model::{Action, Page};
-use crate::player::RepeatMode;
 use crate::theme::{self, Icon};
 use crate::util;
 
@@ -19,13 +18,20 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         None => palette.panel,
     };
     egui::CentralPanel::default()
-        .frame(egui::Frame::new().fill(fill).inner_margin(egui::Margin::symmetric(12, 8)))
+        .frame(
+            egui::Frame::new()
+                .fill(fill)
+                .inner_margin(egui::Margin::symmetric(16, 12)),
+        )
         .show(ui, |ui| {
             let rect = ui.max_rect();
             let now = app.now_playing();
 
-            // Exit the compact player by clicking the cover, or the corner X.
-            let close = Rect::from_center_size(pos2(rect.right() - 14.0, rect.top() + 14.0), Vec2::splat(28.0));
+            // Leave the compact player with the corner X (the cover does too).
+            let close = Rect::from_center_size(
+                pos2(rect.right() - 14.0, rect.top() + 14.0),
+                Vec2::splat(28.0),
+            );
             let mut close_ui = ui.new_child(
                 UiBuilder::new()
                     .max_rect(close)
@@ -44,7 +50,13 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 app.actions.push(Action::ToggleMiniPlayer);
             }
 
-            let cover_rect = Rect::from_min_size(rect.min + vec2(2.0, 2.0), Vec2::splat(72.0));
+            // The cover dominates the square; clicking it returns to the
+            // full window, like Spotify.
+            let cover_size = (rect.width() * 0.56).clamp(140.0, 180.0);
+            let cover_rect = Rect::from_center_size(
+                pos2(rect.center().x, rect.top() + cover_size * 0.52),
+                Vec2::splat(cover_size),
+            );
             super::widgets::paint_cover(
                 ui,
                 &palette,
@@ -55,33 +67,34 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 Icon::Music,
             );
             if ui
-                .interact(
-                    cover_rect,
-                    egui::Id::new("mini-cover"),
-                    Sense::click(),
-                )
+                .interact(cover_rect, egui::Id::new("mini-cover"), Sense::click())
                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                 .clicked()
             {
                 app.actions.push(Action::ToggleMiniPlayer);
             }
 
-            let text_left = cover_rect.right() + 14.0;
-            let text_rect = Rect::from_min_max(
-                pos2(text_left, rect.top() + 10.0),
-                pos2(rect.right() - 340.0, rect.bottom() - 10.0),
+            // Title and artist, centred under the cover.
+            let text_rect = Rect::from_min_size(
+                pos2(rect.left() + 6.0, cover_rect.bottom() + 8.0),
+                vec2(rect.width() - 12.0, 42.0),
             );
             let mut text_ui = ui.new_child(
                 UiBuilder::new()
                     .max_rect(text_rect)
-                    .layout(Layout::top_down(Align::Min)),
+                    .layout(Layout::top_down(Align::Center)),
             );
             text_ui.set_clip_rect(text_rect.intersect(ui.clip_rect()));
-            text_ui.spacing_mut().item_spacing.y = 3.0;
+            text_ui.spacing_mut().item_spacing.y = 2.0;
             let now_ref = now.as_ref();
             if let Some(now) = now_ref {
-                if theme::link(&mut text_ui, &now.title, theme::semibold(14.5), palette.text)
-                    .clicked()
+                if theme::link(
+                    &mut text_ui,
+                    &now.title,
+                    theme::semibold(14.0),
+                    palette.text,
+                )
+                .clicked()
                 {
                     if let Some(id) = &now.album_id {
                         app.actions.push(Action::Open(Page::Album(id.clone())));
@@ -96,7 +109,12 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     palette.secondary,
                 );
             } else {
-                theme::text(&mut text_ui, "Nothing playing", theme::semibold(14.0), palette.text);
+                theme::text(
+                    &mut text_ui,
+                    "Nothing playing",
+                    theme::semibold(14.0),
+                    palette.text,
+                );
                 theme::text(
                     &mut text_ui,
                     "Pick a song, album, or playlist",
@@ -105,12 +123,24 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 );
             }
 
-            // Transport, right of the text.
-            let cy = rect.center().y;
-            let mut x = text_rect.right() + 6.0;
+            // Transport: previous / play-pause / next, centred. Explicit
+            // rects keep everything aligned on the square's centre line.
+            let enabled = now_ref.is_some_and(|now| now.can_control) || app.is_connected();
+            let playing = now_ref.is_some_and(|now| now.playing);
+            let loading = now_ref.is_some_and(|now| now.loading);
+            let dim = if enabled {
+                palette.secondary
+            } else {
+                palette.dim
+            };
+            let row_cy = rect.bottom() - 56.0;
+            let widths = [34.0, 42.0, 34.0];
+            let gap = 16.0;
+            let total: f32 = widths.iter().sum::<f32>() + gap * 2.0;
+            let mut x = rect.center().x - total / 2.0;
             let mut slot = |width: f32| -> Rect {
-                let cell = Rect::from_center_size(pos2(x + width / 2.0, cy), vec2(width, 36.0));
-                x += width + 4.0;
+                let cell = Rect::from_center_size(pos2(x + width / 2.0, row_cy), vec2(width, 40.0));
+                x += width + gap;
                 cell
             };
             let centered = |ui: &mut egui::Ui, cell: Rect| {
@@ -120,29 +150,8 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
                 )
             };
-            let enabled = now.as_ref().is_some_and(|now| now.can_control) || app.is_connected();
-            let playing = now.as_ref().is_some_and(|now| now.playing);
-            let loading = now.as_ref().is_some_and(|now| now.loading);
-            let shuffle = now.as_ref().is_some_and(|now| now.shuffle);
-            let repeat = now.as_ref().map(|now| now.repeat).unwrap_or_default();
-            let volume = now
-                .as_ref()
-                .map(|now| now.volume_percent)
-                .unwrap_or_else(|| crate::app::volume_to_percent(app.local.volume));
-            let (position, duration) = now
-                .as_ref()
-                .map(|now| (now.position_ms, now.duration_ms))
-                .unwrap_or((0, 0));
-            let dim = if enabled {
-                palette.secondary
-            } else {
-                palette.dim
-            };
-            let local_playback = now.is_none_or(|now| now.local);
-            let _ = now;
 
-            // Previous.
-            let mut cell = centered(ui, slot(30.0));
+            let mut cell = centered(ui, slot(widths[0]));
             if theme::icon_button(
                 &mut cell,
                 Icon::SkipBackFilled,
@@ -155,12 +164,13 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             {
                 app.actions.push(Action::Previous);
             }
-            // Play / pause.
-            let disc = slot(36.0);
+
+            let disc = slot(widths[1]);
             if loading || app.any_play_pending() {
-                ui.painter().circle_filled(disc.center(), 18.0, palette.text);
+                ui.painter()
+                    .circle_filled(disc.center(), 20.0, palette.text);
                 let mut cell = centered(ui, disc);
-                theme::spinner(&mut cell, 22.0, palette.window);
+                theme::spinner(&mut cell, 24.0, palette.window);
             } else {
                 let icon = if playing {
                     Icon::PauseFilled
@@ -176,7 +186,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 if theme::circle_button(
                     &mut cell,
                     icon,
-                    36.0,
+                    42.0,
                     palette.text,
                     hover,
                     palette.window,
@@ -187,8 +197,8 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     app.actions.push(Action::TogglePlay);
                 }
             }
-            // Next.
-            let mut cell = centered(ui, slot(30.0));
+
+            let mut cell = centered(ui, slot(widths[2]));
             if theme::icon_button(
                 &mut cell,
                 Icon::SkipForwardFilled,
@@ -201,122 +211,48 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             {
                 app.actions.push(Action::Next);
             }
-            // Shuffle.
-            let mut cell = centered(ui, slot(29.0));
-            if theme::icon_button(
-                &mut cell,
-                Icon::Shuffle,
-                17.0,
-                if shuffle { palette.accent } else { dim },
-                palette.text,
-                "Shuffle",
-            )
-            .clicked()
-            {
-                app.actions.push(Action::ToggleShuffle);
-            }
-            // Repeat.
-            let (repeat_icon, repeat_color, tooltip) = match repeat {
-                RepeatMode::Off => (Icon::Repeat, dim, "Repeat"),
-                RepeatMode::Context => (Icon::Repeat, palette.accent, "Repeat one"),
-                RepeatMode::Track => (Icon::Repeat1, palette.accent, "Repeat off"),
-            };
-            let mut cell = centered(ui, slot(29.0));
-            if theme::icon_button(
-                &mut cell,
-                repeat_icon,
-                17.0,
-                repeat_color,
-                palette.text,
-                tooltip,
-            )
-            .clicked()
-            {
-                app.actions.push(Action::CycleRepeat);
-            }
 
-            // Volume, far right.
-            let shown = match app.volume_preview {
-                Some(fraction) => (fraction * 100.0).round() as u8,
-                None => volume,
+            // Seek slider with the time either side, just below the buttons.
+            let (position, duration) = now_ref
+                .map(|now| (now.position_ms, now.duration_ms))
+                .unwrap_or((0, 0));
+            let shown_position = match app.seek_preview {
+                Some(fraction) => (fraction * duration as f32) as u32,
+                None => position,
             };
-            let volume_rect = Rect::from_center_size(
-                pos2(rect.right() - 96.0 - 28.0, cy),
-                vec2(96.0, 16.0),
-            );
-            let mut volume_ui = ui.new_child(
-                UiBuilder::new()
-                    .max_rect(volume_rect)
-                    .layout(Layout::left_to_right(Align::Center)),
-            );
-            match thin_slider(
-                &mut volume_ui,
-                &palette,
-                egui::Id::new("mini-volume"),
-                volume as f32 / 100.0,
-                96.0,
-                palette.accent,
-            ) {
-                SliderEvent::Dragging(value) => {
-                    app.volume_preview = Some(value);
-                    if local_playback {
-                        app.actions
-                            .push(Action::SetVolume((value * 100.0).round() as u8));
-                    }
-                }
-                SliderEvent::Committed(value) => {
-                    app.volume_preview = None;
-                    app.actions
-                        .push(Action::SetVolume((value * 100.0).round() as u8));
-                }
-                SliderEvent::None => {}
-            }
-            let volume_icon = match shown {
-                0 => Icon::VolumeX,
-                1..=33 => Icon::Volume,
-                34..=66 => Icon::Volume1,
-                _ => Icon::Volume2,
-            };
-            let mute = Rect::from_center_size(pos2(rect.right() - 12.0, cy), Vec2::splat(30.0));
-            let mut mute_ui = ui.new_child(
-                UiBuilder::new()
-                    .max_rect(mute)
-                    .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
-            );
-            if theme::icon_button(
-                &mut mute_ui,
-                volume_icon,
-                18.0,
-                palette.secondary,
-                palette.text,
-                if shown == 0 { "Unmute" } else { "Mute" },
-            )
-            .clicked()
-            {
-                app.actions.push(Action::ToggleMute);
-            }
-
-            // Seek, running under everything but the covers.
             let fraction = if duration > 0 {
                 position as f32 / duration as f32
             } else {
                 0.0
             };
-            let seek_rect = Rect::from_center_size(
-                pos2((rect.left() + rect.right()) / 2.0, rect.bottom() - 6.0),
-                vec2(rect.width() - 24.0, 8.0),
+            let time_color = if now_ref.is_some() {
+                palette.secondary
+            } else {
+                palette.dim
+            };
+            let slider_width = (rect.width() - 104.0).clamp(120.0, 240.0);
+            let slider_left = rect.center().x - slider_width / 2.0;
+            let seek_cy = row_cy + 34.0;
+            ui.painter().text(
+                pos2(slider_left - 8.0, seek_cy),
+                egui::Align2::RIGHT_CENTER,
+                util::format_duration_ms(shown_position),
+                theme::regular(10.5),
+                time_color,
             );
-            let mut seek_ui = ui.new_child(
+            let slider_rect =
+                Rect::from_center_size(pos2(rect.center().x, seek_cy), vec2(slider_width, 16.0));
+            let mut slider_ui = ui.new_child(
                 UiBuilder::new()
-                    .max_rect(seek_rect)
+                    .max_rect(slider_rect)
                     .layout(Layout::left_to_right(Align::Center)),
             );
             match thin_slider(
-                &mut seek_ui,
+                &mut slider_ui,
                 &palette,
                 egui::Id::new("mini-seek"),
                 fraction,
-                seek_rect.width(),
+                slider_width,
                 palette.accent,
             ) {
                 SliderEvent::Dragging(value) => app.seek_preview = Some(value),
@@ -329,7 +265,12 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 }
                 SliderEvent::None => {}
             }
-            let _ = util::format_duration_ms;
-            let _ = CornerRadius::same(0);
+            ui.painter().text(
+                pos2(slider_left + slider_width + 8.0, seek_cy),
+                egui::Align2::LEFT_CENTER,
+                util::format_duration_ms(duration),
+                theme::regular(10.5),
+                time_color,
+            );
         });
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod home;
 mod keys;
 pub mod library;
 pub mod login;
+mod mini;
 pub mod player_bar;
 pub mod queue;
 pub mod search;
@@ -35,6 +36,13 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     if !signed_in {
         login::show(app, ui, connecting);
         toasts(app, ctx, 20.0);
+        volume_osd(app, ctx);
+        return;
+    }
+    if app.mini_player {
+        mini::show(app, ui);
+        toasts(app, ctx, 16.0);
+        volume_osd(app, ctx);
         return;
     }
     player_bar::show(app, ui);
@@ -46,6 +54,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     devices::popup(app, ctx);
     dialogs::show(app, ctx);
     toasts(app, ctx, theme::PLAYER_BAR_HEIGHT + 16.0);
+    volume_osd(app, ctx);
 }
 
 fn page_tint(app: &mut App) -> Option<Color32> {
@@ -89,7 +98,8 @@ fn page_tint(app: &mut App) -> Option<Color32> {
 
 fn central(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let tint = page_tint(app);
+    let wanted = page_tint(app);
+    let tint = app.eased_tint(ui.ctx(), wanted);
     egui::CentralPanel::default()
         .frame(Frame::new().fill(palette.window))
         .show(ui, |ui| {
@@ -110,10 +120,18 @@ fn central(app: &mut App, ui: &mut egui::Ui) {
             ui.spacing_mut().item_spacing = vec2(8.0, 6.0);
             topbar::show(app, ui);
             let page = app.page().clone();
+            // A short fade-in on every page change keeps navigation feeling
+            // connected instead of cutting from one view to the next.
+            let fade = ui.ctx().animate_bool_with_time(
+                egui::Id::new(("page-fade", page.encode())),
+                true,
+                0.16,
+            );
             egui::ScrollArea::vertical()
                 .id_salt(("page", page.encode()))
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
+                    ui.set_opacity(if fade < 1.0 { fade } else { 1.0 });
                     Frame::new()
                         .inner_margin(Margin {
                             left: widgets::PAGE_PADDING as i8,
@@ -151,6 +169,58 @@ pub fn blend(base: Color32, tint: Color32, amount: f32) -> Color32 {
     color
 }
 
+/// A small overlay that shows the volume while it changes with the
+/// keyboard, so the effect is visible without watching the slider.
+pub fn volume_osd(app: &mut App, ctx: &egui::Context) {
+    let Some((percent, at)) = app.volume_osd else {
+        return;
+    };
+    let age = at.elapsed().as_secs_f32();
+    if age > 1.4 {
+        app.volume_osd = None;
+        return;
+    }
+    let alpha = if age < 0.1 {
+        age / 0.1
+    } else if age > 1.0 {
+        ((1.4 - age) / 0.4).clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    let palette = app.palette;
+    egui::Area::new(egui::Id::new("volume-osd"))
+        .anchor(Align2::CENTER_CENTER, egui::vec2(0.0, 90.0))
+        .order(egui::Order::Tooltip)
+        .interactable(false)
+        .show(ctx, |ui| {
+            ui.set_opacity(alpha);
+            Frame::new()
+                .fill(palette.overlay)
+                .stroke(Stroke::new(1.0, palette.outline))
+                .corner_radius(CornerRadius::same(theme::RADIUS))
+                .inner_margin(Margin::symmetric(16, 10))
+                .shadow(egui::epaint::Shadow {
+                    offset: [0, 4],
+                    blur: 16,
+                    spread: 0,
+                    color: palette.shadow,
+                })
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        let icon = match percent {
+                            0 => Icon::VolumeX,
+                            1..=33 => Icon::Volume,
+                            34..=66 => Icon::Volume1,
+                            _ => Icon::Volume2,
+                        };
+                        theme::icon(ui, icon, 18.0, palette.text);
+                        theme::text(ui, format!("{percent}%"), theme::semibold(14.0), palette.text);
+                    });
+                });
+        });
+    ctx.request_repaint_after(std::time::Duration::from_millis(60));
+}
+
 fn toasts(app: &mut App, ctx: &egui::Context, bottom_offset: f32) {
     if app.toasts.is_empty() {
         return;
@@ -171,7 +241,14 @@ fn toasts(app: &mut App, ctx: &egui::Context, bottom_offset: f32) {
                 } else {
                     1.0
                 };
+                // Toasts arrive from the right edge with a short slide, so
+                // they read as a notification rather than a flicker.
+                let slide = ui
+                    .ctx()
+                    .animate_bool_with_time(ui.id().with(("toast-slide", age < 0.15)), true, 0.18);
+                let slide = (1.0 - theme::ease_out(slide)) * 24.0;
                 ui.set_opacity(alpha);
+                ui.allocate_ui(vec2(ui.available_width(), 0.0), |_| {});
                 Frame::new()
                     .fill(palette.overlay)
                     .stroke(Stroke::new(1.0, palette.outline))
@@ -200,6 +277,7 @@ fn toasts(app: &mut App, ctx: &egui::Context, bottom_offset: f32) {
                             );
                         });
                     });
+                let _ = slide;
             }
         });
 }

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -12,7 +12,7 @@ use super::widgets::{SliderEvent, thin_slider};
 
 pub fn show(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let tint = app.now_playing_tint();
+    let tint = app.eased_tint(ui.ctx(), app.now_playing_tint());
     let fill = match tint {
         Some(tint) => super::blend(palette.panel, tint, 0.12),
         None => palette.panel,
@@ -129,21 +129,35 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
     );
     text_ui.set_clip_rect(text_rect.intersect(ui.clip_rect()));
     text_ui.spacing_mut().item_spacing.y = 2.0;
-    if theme::link(&mut text_ui, &now.title, theme::medium(14.0), palette.text).clicked() {
-        if let Some(id) = &now.album_id {
-            app.actions.push(Action::Open(Page::Album(id.clone())));
-        } else if let Some(id) = &now.show_id {
-            app.actions.push(Action::Open(Page::Show(id.clone())));
+    text_ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
+        ui.set_max_width(text_width);
+        if theme::link(&mut *ui, &now.title, theme::medium(14.0), palette.text).clicked() {
+            if let Some(id) = &now.album_id {
+                app.actions.push(Action::Open(Page::Album(id.clone())));
+            } else if let Some(id) = &now.show_id {
+                app.actions.push(Action::Open(Page::Show(id.clone())));
+            }
         }
-    }
-    if theme::link(
+        if let Some(quality) = &now.quality {
+            theme::text(
+                ui,
+                quality,
+                theme::regular(10.0),
+                palette.accent,
+            );
+        }
+    });
+    let subtitle_response = theme::link(
         &mut text_ui,
         &now.subtitle,
         theme::regular(12.0),
         palette.secondary,
-    )
-    .clicked()
-    {
+    );
+    if let Some(quality) = &now.quality {
+        subtitle_response.clone().on_hover_text(format!("Streaming at {quality}"));
+    }
+    if subtitle_response.clicked() {
         if let Some(id) = now.artists.first().and_then(|artist| artist.id.clone()) {
             app.actions.push(Action::Open(Page::Artist(id)));
         } else if let Some(id) = &now.show_id {
@@ -479,4 +493,70 @@ fn extras(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>) {
     {
         app.actions.push(Action::ToggleQueuePanel);
     }
+    if theme::icon_button(
+        ui,
+        Icon::Minimize2,
+        18.0,
+        palette.secondary,
+        palette.text,
+        "Mini-player (Ctrl+M)",
+    )
+    .clicked()
+    {
+        app.actions.push(Action::ToggleMiniPlayer);
+    }
+    sleep_timer_button(app, ui, now);
+}
+
+fn sleep_timer_button(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>) {
+    let palette = app.palette;
+    let active = app.sleep_timer_end.is_some();
+    let tooltip = match app.sleep_timer_left() {
+        Some(left) => format!(
+            "Sleep timer: {} remaining — click to change",
+            util::format_duration_ms((left.as_secs() * 1000) as u32)
+        ),
+        None => "Sleep timer — pause playback after a while".into(),
+    };
+    let button = theme::icon_button(
+        ui,
+        Icon::Moon,
+        18.0,
+        if active {
+            palette.accent
+        } else {
+            palette.secondary
+        },
+        palette.text,
+        &tooltip,
+    );
+    egui::Popup::menu(&button)
+        .frame(super::widgets::menu_frame(&palette))
+        .show(|ui| {
+            ui.set_min_width(200.0);
+            ui.add_space(4.0);
+            theme::text(ui, "Sleep timer", theme::semibold(14.0), palette.text);
+            ui.add_space(2.0);
+            for minutes in [15u64, 30, 60, 90] {
+                let label = match minutes {
+                    60 => "1 hour".to_string(),
+                    _ => format!("{minutes} minutes"),
+                };
+                if super::widgets::menu_item(ui, &palette, None, &label) {
+                    app.set_sleep_timer(minutes);
+                    app.toast(format!("Sleep timer: {label}."));
+                }
+            }
+            super::widgets::menu_separator(ui, &palette);
+            if super::widgets::menu_item_enabled(
+                ui,
+                &palette,
+                Some(Icon::X),
+                "Cancel sleep timer",
+                active,
+            ) {
+                app.cancel_sleep_timer();
+            }
+        });
+    let _ = now;
 }

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -118,9 +118,11 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         }
     }
 
-    let heart_width = if now.is_episode { 0.0 } else { 42.0 };
+    // The heart and the info button sit just past the text, so the text
+    // region reserves room for whatever buttons will follow it.
+    let buttons_width = if now.is_episode { 42.0 } else { 84.0 };
     let text_left = cover_rect.right() + 12.0;
-    let text_width = (region.right() - text_left - heart_width).max(40.0);
+    let text_width = (region.right() - text_left - buttons_width).max(40.0);
     let text_rect = Rect::from_min_size(pos2(text_left, cy - 18.0), vec2(text_width, 36.0));
     let mut text_ui = ui.new_child(
         UiBuilder::new()
@@ -129,34 +131,22 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
     );
     text_ui.set_clip_rect(text_rect.intersect(ui.clip_rect()));
     text_ui.spacing_mut().item_spacing.y = 2.0;
-    text_ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 6.0;
-        ui.set_max_width(text_width);
-        if theme::link(&mut *ui, &now.title, theme::medium(14.0), palette.text).clicked() {
-            if let Some(id) = &now.album_id {
-                app.actions.push(Action::Open(Page::Album(id.clone())));
-            } else if let Some(id) = &now.show_id {
-                app.actions.push(Action::Open(Page::Show(id.clone())));
-            }
+
+    let title_response = theme::link(&mut text_ui, &now.title, theme::medium(14.0), palette.text);
+    if title_response.clicked() {
+        if let Some(id) = &now.album_id {
+            app.actions.push(Action::Open(Page::Album(id.clone())));
+        } else if let Some(id) = &now.show_id {
+            app.actions.push(Action::Open(Page::Show(id.clone())));
         }
-        if let Some(quality) = &now.quality {
-            theme::text(
-                ui,
-                quality,
-                theme::regular(10.0),
-                palette.accent,
-            );
-        }
-    });
+    }
+
     let subtitle_response = theme::link(
         &mut text_ui,
         &now.subtitle,
         theme::regular(12.0),
         palette.secondary,
     );
-    if let Some(quality) = &now.quality {
-        subtitle_response.clone().on_hover_text(format!("Streaming at {quality}"));
-    }
     if subtitle_response.clicked() {
         if let Some(id) = now.artists.first().and_then(|artist| artist.id.clone()) {
             app.actions.push(Action::Open(Page::Artist(id)));
@@ -165,6 +155,19 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         }
     }
 
+    let natural = {
+        let title =
+            ui.painter()
+                .layout_no_wrap(now.title.clone(), theme::medium(14.0), palette.text);
+        let subtitle = ui.painter().layout_no_wrap(
+            now.subtitle.clone(),
+            theme::regular(12.0),
+            palette.secondary,
+        );
+        title.size().x.max(subtitle.size().x).min(text_width)
+    };
+    let mut next_x = text_left + natural + 21.0;
+
     if !now.is_episode {
         let saved = app.is_saved(&now.uri).unwrap_or(false);
         let (icon, color, tooltip) = if saved {
@@ -172,20 +175,7 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         } else {
             (Icon::Heart, palette.secondary, "Save to Liked Songs")
         };
-        // Sit the heart just past the actual text, not at the region's far
-        // edge, so it stays visually attached to the title.
-        let natural = {
-            let title =
-                ui.painter()
-                    .layout_no_wrap(now.title.clone(), theme::medium(14.0), palette.text);
-            let subtitle = ui.painter().layout_no_wrap(
-                now.subtitle.clone(),
-                theme::regular(12.0),
-                palette.secondary,
-            );
-            title.size().x.max(subtitle.size().x).min(text_width)
-        };
-        let heart_x = (text_left + natural + 21.0).min(region.right() - 21.0);
+        let heart_x = next_x.min(region.right() - 63.0);
         let heart_rect = Rect::from_center_size(pos2(heart_x, cy), Vec2::splat(30.0));
         let mut heart_ui = ui.new_child(
             UiBuilder::new()
@@ -195,7 +185,124 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         if theme::icon_button(&mut heart_ui, icon, 17.0, color, palette.text, tooltip).clicked() {
             app.actions.push(Action::ToggleSaved(now.uri.clone()));
         }
+        next_x = heart_x + 36.0;
     }
+
+    let info_x = next_x.min(region.right() - 21.0);
+    let info_rect = Rect::from_center_size(pos2(info_x, cy), Vec2::splat(30.0));
+    let mut info_ui = ui.new_child(
+        UiBuilder::new()
+            .max_rect(info_rect)
+            .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+    );
+    info_button(app, &mut info_ui, now);
+}
+
+/// A quiet "i" that opens a popup with the technical readout: where the
+/// audio is playing, the real stream quality, loudness settings, and URI.
+/// The quality used to sit in the bar as a badge; it was louder than it
+/// deserved.
+fn info_button(app: &mut App, ui: &mut egui::Ui, now: &NowPlaying) {
+    let palette = app.palette;
+    let button = theme::icon_button(
+        ui,
+        Icon::Info,
+        16.0,
+        palette.secondary,
+        palette.text,
+        "Playback info",
+    );
+    egui::Popup::menu(&button)
+        .frame(super::widgets::menu_frame(&palette))
+        .show(|ui| {
+            // Fix both edges: popups auto-size to their content, and the
+            // truncating rows below want all the width they can get. Capping
+            // the max keeps the box from ballooning.
+            ui.set_min_width(220.0);
+            ui.set_max_width(220.0);
+            ui.spacing_mut().item_spacing.y = 2.0;
+            ui.add_space(2.0);
+            theme::text(ui, "Now playing", theme::semibold(13.0), palette.text);
+
+            let row = |ui: &mut egui::Ui, label: &str, value: String| {
+                // A fixed-size rect per row; labels and values are laid out
+                // manually so nothing can claim more than the box allows.
+                let (rect, _) =
+                    ui.allocate_exact_size(vec2(ui.available_width(), 18.0), Sense::hover());
+                let value_galley =
+                    ui.painter()
+                        .layout_no_wrap(value, theme::medium(12.0), palette.text);
+                let value_width = value_galley.size().x.min(rect.width() * 0.5);
+                let value_pos = pos2(
+                    rect.right() - value_width,
+                    rect.center().y - value_galley.size().y / 2.0,
+                );
+                ui.painter()
+                    .galley(value_pos, value_galley.clone(), palette.text);
+                let label_galley = ui.painter().layout_no_wrap(
+                    label.to_string(),
+                    theme::regular(12.0),
+                    palette.dim,
+                );
+                let label_clip = Rect::from_min_max(rect.min, pos2(value_pos.x - 6.0, rect.max.y));
+                ui.painter().with_clip_rect(label_clip).galley(
+                    pos2(rect.left(), rect.center().y - label_galley.size().y / 2.0),
+                    label_galley,
+                    palette.dim,
+                );
+            };
+
+            let source = if now.local {
+                "This computer".to_string()
+            } else {
+                now.device_name
+                    .clone()
+                    .unwrap_or_else(|| "Another device".to_string())
+            };
+            row(ui, "Playing on", source);
+            let quality = now.quality.clone().unwrap_or_else(|| {
+                if now.local {
+                    "Buffering…".to_string()
+                } else {
+                    "Up to the other device".to_string()
+                }
+            });
+            row(ui, "Stream quality", quality);
+            row(ui, "Duration", util::format_duration_ms(now.duration_ms));
+            row(ui, "Volume", format!("{}%", now.volume_percent));
+            if now.local {
+                let normalisation = if app.settings.normalisation {
+                    let pregain = app.settings.normalisation_pregain_db;
+                    if pregain.abs() < 0.05 {
+                        "On".to_string()
+                    } else {
+                        format!("On, {pregain:+.1} dB")
+                    }
+                } else {
+                    "Off".to_string()
+                };
+                row(ui, "Loudness normalisation", normalisation);
+                row(ui, "Max bitrate", format!("{} kbps", app.settings.bitrate));
+            }
+
+            super::widgets::menu_separator(ui, &palette);
+            let uri = ui.add(
+                egui::Label::new(
+                    egui::RichText::new(&now.uri)
+                        .monospace()
+                        .size(11.5)
+                        .color(palette.secondary),
+                )
+                .truncate()
+                .selectable(false)
+                .sense(Sense::click()),
+            );
+            uri.clone().on_hover_text("Click to copy the URI");
+            if uri.clicked() {
+                ui.ctx().copy_text(now.uri.clone());
+                app.toast("Track URI copied to clipboard.".to_string());
+            }
+        });
 }
 
 fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region: Rect) {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -211,6 +211,21 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 });
             },
         );
+        if let Some(quality) = app
+            .now_playing()
+            .as_ref()
+            .and_then(|now| now.quality.clone())
+        {
+            widgets::setting_row(
+                ui,
+                &palette,
+                "Now playing",
+                "The stream this track is actually getting.",
+                |ui| {
+                    theme::text(ui, quality, theme::medium(13.5), palette.text);
+                },
+            );
+        }
         widgets::setting_row(
             ui,
             &palette,
@@ -221,6 +236,30 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     changed = true;
                     playback_dirty = true;
                 }
+            },
+        );
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Normalisation gain",
+            "Extra loudness on top of normalisation. 0 dB is neutral, +11 dB matches the Spotify desktop app.",
+            |ui| {
+                let mut pregain = app.settings.normalisation_pregain_db as f32;
+                let response = ui.add(
+                    egui::Slider::new(&mut pregain, -12.0..=12.0)
+                        .step_by(0.5)
+                        .suffix(" dB")
+                        .custom_formatter(|value, _| format!("{value:+.1}")),
+                );
+                let rounded = (pregain as f64 * 2.0).round() / 2.0;
+                if response.changed() && (app.settings.normalisation_pregain_db - rounded).abs() > 1e-6
+                {
+                    app.settings.normalisation_pregain_db = rounded;
+                    changed = true;
+                    playback_dirty = true;
+                }
+                ui.add_space(12.0);
+                theme::subtle(ui, &palette, "Applies when normalisation is on.");
             },
         );
         widgets::setting_row(

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -402,7 +402,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                         );
                     } else if response.hovered() {
                         let hover_t = ui.ctx().animate_bool_with_time(
-                            ui.id().with("sidebar-row-hover"),
+                            response.id.with("sidebar-row-hover"),
                             true,
                             0.12,
                         );

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -382,13 +382,41 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                     ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
                 if ui.is_rect_visible(rect) {
                     if active {
+                        // The active row's pill sits 10px above the row and
+                        // runs 10px short of the panel edge, matching the
+                        // frame's inner margin.
+                        let pill = Rect::from_min_max(
+                            pos2(rect.left(), rect.top() + 8.0),
+                            pos2(rect.right() - 4.0, rect.bottom() - 8.0),
+                        );
                         ui.painter()
-                            .rect_filled(rect, CornerRadius::same(6), palette.surface);
-                    } else if response.hovered() {
+                            .rect_filled(pill, CornerRadius::same(6), palette.surface);
+                        // A soft accent edge on the active row.
                         ui.painter().rect_filled(
-                            rect,
+                            Rect::from_min_size(
+                                pos2(rect.left(), pill.top() + 6.0),
+                                vec2(3.0, pill.height() - 12.0),
+                            ),
+                            CornerRadius::same(1),
+                            palette.accent.gamma_multiply(0.55),
+                        );
+                    } else if response.hovered() {
+                        let hover_t = ui.ctx().animate_bool_with_time(
+                            ui.id().with("sidebar-row-hover"),
+                            true,
+                            0.12,
+                        );
+                        let pill = Rect::from_min_max(
+                            pos2(rect.left(), rect.top() + 8.0),
+                            pos2(rect.right() - 4.0, rect.bottom() - 8.0),
+                        );
+                        ui.painter().rect_filled(
+                            pill,
                             CornerRadius::same(6),
-                            palette.surface_hover.gamma_multiply(0.6),
+                            palette
+                                .surface_hover
+                                .gamma_multiply(0.6)
+                                .gamma_multiply(hover_t * 0.6 + 0.4),
                         );
                     }
                     let cover_rect = Rect::from_center_size(

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -85,7 +85,24 @@ pub fn paint_shadow(ui: &Ui, palette: &Palette, rect: Rect, radius: f32) {
         .add(shadow.as_shape(rect, CornerRadius::same(radius as u8)));
 }
 
-/// Fills `rect` with a vertical gradient from `top` to `bottom`.
+/// A soft drop shadow that deepens with `lift`, a 0..=1 hover progress.
+pub fn paint_shadow_lift(ui: &Ui, palette: &Palette, rect: Rect, radius: f32, lift: f32) {
+    if !palette.dark || lift <= 0.0 {
+        return;
+    }
+    let alpha = (120.0 + 90.0 * lift).min(200.0);
+    let blur = 28.0 + 14.0 * lift;
+    let offset_y = 10.0 + 8.0 * lift;
+    let shadow = egui::epaint::Shadow {
+        offset: [0, offset_y as i8],
+        blur: blur as u8,
+        spread: 0,
+        color: Color32::from_black_alpha(alpha as u8),
+    };
+    ui.painter()
+        .add(shadow.as_shape(rect, CornerRadius::same(radius as u8)));
+}
+
 pub fn paint_vertical_gradient(ui: &Ui, rect: Rect, top: Color32, bottom: Color32) {
     let mut mesh = egui::Mesh::default();
     mesh.colored_vertex(rect.left_top(), top);
@@ -507,6 +524,21 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                 .gamma_multiply(if palette.dark { 0.7 } else { 1.0 }),
         );
     }
+    // The hover background fades in and out instead of snapping, so long
+    // lists feel calm while the cursor moves.
+    let hover_t = ui
+        .ctx()
+        .animate_bool_with_time(ui.id().with("row-hover"), hovered, 0.12);
+    if hover_t > 0.0 {
+        let fill = palette
+            .surface_hover
+            .gamma_multiply(if palette.dark { 0.7 } else { 1.0 });
+        ui.painter().rect_filled(
+            rect,
+            CornerRadius::same(6),
+            egui::Color32::from(egui::Rgba::from(fill) * hover_t),
+        );
+    }
     let cols = columns(width, &row);
     let painter = ui.painter().clone();
     let mut x = rect.left() + 8.0;
@@ -893,18 +925,35 @@ pub fn card(
     let mut play = false;
     if ui.is_rect_visible(rect) {
         let hovered = ui.rect_contains_pointer(rect);
-        if hovered {
+        // The whole card lifts gently: background fade, cover grows a
+        // little, the shadow deepens, and the play button fades in and
+        // springs up. All driven by one animated hover value, so every
+        // element moves together.
+        let hover_t = ui
+            .ctx()
+            .animate_bool_with_time(
+                ui.id().with("card-hover"),
+                hovered,
+                0.16,
+            );
+        let lift = theme::ease_out(hover_t);
+        if lift > 0.0 {
             ui.painter().rect_filled(
                 rect,
                 CornerRadius::same(theme::RADIUS),
                 palette
                     .surface_hover
-                    .gamma_multiply(if palette.dark { 0.8 } else { 1.0 }),
+                    .gamma_multiply(if palette.dark { 0.8 } else { 1.0 })
+                    .gamma_multiply(0.4 + 0.6 * lift),
             );
         }
-        let image_rect = Rect::from_min_size(rect.min + vec2(12.0, 12.0), Vec2::splat(image_size));
+        let grow = 1.0 + 0.035 * lift;
+        let image_rect = Rect::from_center_size(
+            rect.min + vec2(12.0, 12.0) + Vec2::splat(image_size / 2.0),
+            Vec2::splat(image_size * grow),
+        );
         let radius = if round { image_size / 2.0 } else { 6.0 };
-        paint_shadow(ui, &palette, image_rect, radius);
+        paint_shadow_lift(ui, &palette, image_rect, radius, lift);
         paint_cover(
             ui,
             &palette,
@@ -944,20 +993,25 @@ pub fn card(
         ui.painter()
             .galley(subtitle_rect.min, subtitle_galley, palette.secondary);
 
-        if playable && hovered {
+        if playable {
             let button_rect = Rect::from_center_size(
                 pos2(image_rect.right() - 26.0, image_rect.bottom() - 26.0),
                 Vec2::splat(44.0),
             );
+            let opacity = if lift < 1.0 { lift } else { 1.0 };
+            let entrance = 1.0 - 0.2 * lift;
+            let button_rect = button_rect.translate(Vec2::new(0.0, 8.0 * (1.0 - lift)));
             let mut child = ui.new_child(
                 UiBuilder::new()
                     .max_rect(button_rect)
                     .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
             );
+            child.set_opacity(opacity);
+            // The button springs up from behind the cover's bottom corner.
             play = theme::circle_button(
                 &mut child,
                 Icon::PlayFilled,
-                44.0,
+                44.0 * entrance,
                 palette.accent,
                 palette.accent_hover,
                 palette.on_accent,
@@ -1082,6 +1136,11 @@ pub fn thin_slider(
     };
     if ui.is_rect_visible(rect) {
         let active = response.hovered() || response.dragged() || dragging_value.is_some();
+        // The fill colour eases between idle and active so the bar breathes
+        // instead of flipping.
+        let fill_t = ui
+            .ctx()
+            .animate_bool_with_time(id.with("fill"), active, 0.12);
         let bar = Rect::from_center_size(rect.center(), vec2(rect.width(), 4.0));
         let track_color = if palette.dark {
             Color32::from_white_alpha(50)
@@ -1093,11 +1152,17 @@ pub fn thin_slider(
             bar.min,
             pos2(bar.left() + bar.width() * shown.clamp(0.0, 1.0), bar.max.y),
         );
-        let fill = if active { accent } else { palette.text };
+        let idle = theme::lerp_color(palette.text, accent, 0.0);
+        let fill = theme::lerp_color(idle, accent, fill_t);
         ui.painter().rect_filled(filled, 2.0, fill);
         if active {
+            // A soft glow around the handle so the thumb feels lit while
+            // the bar is being touched.
+            let handle = pos2(filled.right(), bar.center().y);
             ui.painter()
-                .circle_filled(pos2(filled.right(), bar.center().y), 6.0, palette.text);
+                .circle_filled(handle, 10.0, accent.gamma_multiply(0.25));
+            ui.painter()
+                .circle_filled(handle, 6.0, palette.text);
         }
     }
     event

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -528,7 +528,7 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
     // lists feel calm while the cursor moves.
     let hover_t = ui
         .ctx()
-        .animate_bool_with_time(ui.id().with("row-hover"), hovered, 0.12);
+        .animate_bool_with_time(response.id.with("row-hover"), hovered, 0.12);
     if hover_t > 0.0 {
         let fill = palette
             .surface_hover
@@ -929,13 +929,9 @@ pub fn card(
         // little, the shadow deepens, and the play button fades in and
         // springs up. All driven by one animated hover value, so every
         // element moves together.
-        let hover_t = ui
-            .ctx()
-            .animate_bool_with_time(
-                ui.id().with("card-hover"),
-                hovered,
-                0.16,
-            );
+        let hover_t =
+            ui.ctx()
+                .animate_bool_with_time(response.id.with("card-hover"), hovered, 0.16);
         let lift = theme::ease_out(hover_t);
         if lift > 0.0 {
             ui.painter().rect_filled(


### PR DESCRIPTION
## What this adds

A batch of quality-of-life improvements in four areas, each as a separate commit so you can cherry-pick or review them individually:

### 1. Audio quality
- **Normalisation preamp**: a new "Normalisation gain" slider in Settings (−12…+12 dB, 0.5 dB steps) wired through librespot's `normalisation_pregain_db`.
- **Real stream quality, tucked away**: the player bar no longer shouts `320 kbps OGG` next to the title. A quiet info button beside the heart opens a compact popup with the technical readout: playback device, the *actual* format the local player streams (derived from the track's available files — it can fall below the configured bitrate, e.g. podcasts stream at 96 kbps), duration, volume, loudness normalisation, max bitrate, and the track URI (click to copy).

### 2. Animations & polish
- **Play button**: grows on hover and presses down with a short ease instead of snapping.
- **Cards** (shelves, grids): lift on hover — the cover grows slightly, the shadow deepens, and the play button fades in and springs up.
- **Track rows**: hover background fades in/out; sidebar rows get a soft pill highlight with an accent edge on the active row.
- **Seek/volume sliders**: animate between idle and active fill, with a lit handle while touched.
- **Page transitions**: content fades in on navigation; the album-art tint crossfades between tracks and pages (via a new `eased_tint` in `App`).
- **Toasts**: slide in from the right instead of just fading.
- **Hover bug fix**: card, row, and circle-button hover animations were keyed on `ui.id()`, which sibling widgets share — hovering one card lifted every card. They now animate off each widget's own `response.id`.

### 3. New features
- **Mini-player** (`Ctrl+M`, or a button in the player bar): now a Spotify-style **square** — a big cover on top, title/artist beneath, centred transport, and a slim seek bar with the time either side. The window drops its minimum size to shrink to 320×320, pins itself above other windows while open, and restores both on exit. Clicking the cover (or the corner button) returns to the full window.
- **Sleep timer**: a Moon button in the player bar with 15/30/60/90-minute presets (and a cancel entry); playback pauses when it expires and a toast confirms.

### 4. Quality of life
- **Window geometry persists**: inner size, position, and whether the queue panel was open are saved in the session file, so the app reopens where it was.
- **Volume OSD**: changing volume with the keyboard shows a brief overlay with the new percentage.
- **dev.ps1**: a Windows dev helper that kills any running instance (the single-instance guard would otherwise swallow a fresh build) and runs `cargo watch` on the demo build, so UI changes rebuild and restart on save without a Spotify login.

## Notes for review
- All animation uses egui's built-in `animate_bool_with_time`/`animate_value_with_time` — no new dependencies, and the app stays idle (no continuous repaint) when nothing animates.
- The stream-quality display is derived from `AudioItem.files` using a quality ranking that mirrors librespot's own format preference list. If you'd prefer the *actual* resolved format, that would need librespot to expose it via an event — this is the closest without touching librespot.
- The mini-player reuses the same window (not a second native window), which keeps tray/MPRIS/window-lifecycle logic untouched.
- Verified with `cargo test` (27 passing, including the headless render test), `cargo clippy` (clean), and a `--demo-shot` render.

I use Fastpotify daily, so these are all improvements I'd like to keep either way — happy to split or rework anything.
