### PR TITLE
Repair three things the macOS bundle gets wrong

### DIFF
--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -13,6 +13,11 @@
     <key>LSMinimumSystemVersion</key><string>11.0</string>
     <key>LSApplicationCategoryType</key><string>public.app-category.music</string>
     <key>NSHighResolutionCapable</key><true/>
+    <key>NSLocalNetworkUsageDescription</key><string>Fastpotify looks for Spotify Connect speakers on your local network.</string>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_spotify-connect._tcp</string>
+    </array>
     <key>NSHumanReadableCopyright</key><string>MIT License. Not affiliated with Spotify AB.</string>
 </dict>
 </plist>

--- a/packaging/macos/bundle.sh
+++ b/packaging/macos/bundle.sh
@@ -3,6 +3,9 @@
 #
 #   packaging/macos/bundle.sh <binary> <output.app> <version>
 #
+# Set CODESIGN_IDENTITY to sign with a Developer ID; the default is an ad-hoc
+# signature, which arm64 requires before the app will launch at all.
+#
 # The .icns is generated here from the committed 1024px PNG, because iconutil
 # only exists on macOS. The Info.plist template lives next to this script.
 set -euo pipefail
@@ -21,11 +24,22 @@ sed "s/__VERSION__/$version/g" "$here/Info.plist" > "$app/Contents/Info.plist"
 
 iconset="$(mktemp -d)/fastpotify.iconset"
 mkdir -p "$iconset"
-for size in 16 32 64 128 256 512; do
+# iconutil reads only these base sizes, each with an optional @2x. It ignores
+# an icon_64x64 without saying so, so generating one is two wasted sips calls.
+for size in 16 32 128 256 512; do
     sips -z $size $size "$here/icon-1024.png" --out "$iconset/icon_${size}x${size}.png" >/dev/null
     double=$((size * 2))
     sips -z $double $double "$here/icon-1024.png" --out "$iconset/icon_${size}x${size}@2x.png" >/dev/null
 done
 iconutil -c icns "$iconset" -o "$app/Contents/Resources/fastpotify.icns"
+
+# arm64 refuses to launch an unsigned bundle, so sign one way or another.
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    codesign --force --timestamp --options runtime \
+        --sign "$CODESIGN_IDENTITY" "$app"
+else
+    codesign --force --sign - "$app"
+fi
+codesign --verify --strict "$app"
 
 echo "$app"

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,14 @@ fn native_options(fullscreen: bool) -> eframe::NativeOptions {
             .with_inner_size([1240.0, 800.0])
             .with_min_inner_size([760.0, 520.0])
             .with_fullscreen(fullscreen)
-            .with_icon(app_icon()),
+            // macOS takes the dock icon from the bundle's .icns, which is the
+            // 1024px drawing with the platform's rounding. Setting a window
+            // icon there replaces it with this flat 128px square.
+            .with_icon(if cfg!(target_os = "macos") {
+                egui::IconData::default()
+            } else {
+                app_icon()
+            }),
         // A Wayland compositor stops sending frame callbacks to a hidden
         // window; waiting for vsync there would block the event loop.
         // Repaints are event-driven, so nothing spins.


### PR DESCRIPTION
Three unrelated macOS problems in the same corner of the tree, each a few lines.

## Local network permission

macOS 15 gates mDNS behind a declared purpose. Without `NSLocalNetworkUsageDescription` and `NSBonjourServices` in `Info.plist` the system blocks the browse, so LAN speaker discovery finds nothing and there is no error for the app to surface. It just looks like there are no speakers on the network.

## Signing

arm64 refuses to launch an unsigned bundle. `bundle.sh` now signs it: ad-hoc by default so a local build runs at all, and with `CODESIGN_IDENTITY` set for a Developer ID with a hardened runtime and a timestamp. It verifies afterwards, so a broken bundle fails the script instead of failing at launch.

## Dock icon

`native_options` sets a window icon on every platform. On macOS that replaces the dock icon the system took from the bundle's `.icns`, trading a 1024px drawing with the platform's rounding for a flat 128px square. Skipped there; every other platform is unchanged.

Also drops `icon_64x64` from the iconset. iconutil ignores that size without saying so, so it was two `sips` calls producing nothing. I checked: the `.icns` is byte-identical without them.

## Verification

Ran `bundle.sh` end to end on macOS 27, arm64. The `.icns` builds, `codesign --verify --strict` passes, and `plutil -p` shows both new keys in the bundled plist. `cargo fmt --check`, `cargo clippy --all-targets` and the tests are clean.

I have no Developer ID to hand, so the `CODESIGN_IDENTITY` branch is unexercised. The ad-hoc path is the one I ran.
