### PR TITLE
Give macOS the two shortcuts the system takes away

### DIFF
--- a/src/ui/keys.rs
+++ b/src/ui/keys.rs
@@ -17,7 +17,17 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
         key(Modifiers::COMMAND, Key::F, Action::FocusSearch);
         key(Modifiers::COMMAND, Key::Comma, Action::Open(Page::Settings));
         key(Modifiers::COMMAND, Key::Q, Action::Quit);
-        key(Modifiers::COMMAND, Key::H, Action::Open(Page::Home));
+        // winit installs its own macOS app menu, whose Hide item owns Cmd+H
+        // before the window is offered the key.
+        if cfg!(target_os = "macos") {
+            key(
+                Modifiers::COMMAND | Modifiers::SHIFT,
+                Key::H,
+                Action::Open(Page::Home),
+            );
+        } else {
+            key(Modifiers::COMMAND, Key::H, Action::Open(Page::Home));
+        }
         key(Modifiers::COMMAND, Key::L, Action::Open(Page::LikedSongs));
         key(
             Modifiers::COMMAND,
@@ -40,11 +50,16 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
             Key::B,
             Action::OpenUri("album".into()),
         );
-        key(
-            Modifiers::COMMAND | Modifiers::SHIFT,
-            Key::Q,
-            Action::ToggleQueuePanel,
-        );
+        // Cmd+Shift+Q is Log Out, taken by the window server.
+        if cfg!(target_os = "macos") {
+            key(Modifiers::COMMAND, Key::U, Action::ToggleQueuePanel);
+        } else {
+            key(
+                Modifiers::COMMAND | Modifiers::SHIFT,
+                Key::Q,
+                Action::ToggleQueuePanel,
+            );
+        }
         if !typing {
             key(Modifiers::SHIFT, Key::ArrowLeft, Action::SeekBy(-10_000));
             key(Modifiers::SHIFT, Key::ArrowRight, Action::SeekBy(10_000));
@@ -99,7 +114,14 @@ pub const SHORTCUTS: &[(&str, &str)] = &[
     ("Q", "Show the queue"),
     ("Ctrl+F  or  /", "Search"),
     ("Alt+←  /  Alt+→", "Back or forward"),
-    ("Ctrl+H", "Home"),
+    (
+        if cfg!(target_os = "macos") {
+            "Ctrl+Shift+H"
+        } else {
+            "Ctrl+H"
+        },
+        "Home",
+    ),
     ("Ctrl+L", "Liked Songs"),
     ("Ctrl+Shift+A", "Go to the playing artist"),
     ("Ctrl+Shift+B", "Go to the playing album"),


### PR DESCRIPTION
`Cmd+H` and `Cmd+Shift+Q` never reach the window on macOS, so Home and the queue panel have no working chord there.

`Cmd+H` is the one that matters. winit installs its own application menu before the app runs (`menu::initialize` from `platform_impl/macos/app_state.rs`), and its Hide item claims `h` as a key equivalent. A menu key equivalent is dispatched ahead of the key window, so `consume_key` is never offered the press. `Cmd+Shift+Q` is Log Out, held by the window server.

Home moves to `Cmd+Shift+H` and the queue panel to `Cmd+U`, on macOS only; every other platform keeps what it has. The queue was the milder of the two, since plain `Q` already opened it and still does.

`SHORTCUTS` reads the same `cfg`, so the dialog shows what actually works.

One thing I left alone: the table still writes the modifier as "Ctrl" on macOS, where egui renders `COMMAND` as the command symbol. That is a separate change across every row. Happy to fold it in here if you would rather have it in one go.

`cargo fmt --check`, `cargo clippy --all-targets` and 34 tests clean.
