### PR TITLE
Offer a Nix development shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/_site/
 docs/.jekyll-cache/
 docs/vendor/
 docs/.bundle/
+.direnv/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ and on Debian or Ubuntu:
 sudo apt install libasound2-dev libpulse-dev libxkbcommon-dev libwayland-dev
 ```
 
+With [Nix](https://nixos.org), `nix develop` provides all of it, along with
+the exact toolchain `rust-toolchain.toml` pins; with direnv, `direnv allow`
+enters the shell on `cd`.
+
 Titles in a script the interface font does not cover -- Chinese, Japanese,
 Korean, Arabic, Hebrew, Thai, the Indic scripts and a dozen more -- are drawn
 with a face borrowed from the system rather than bundled, which would cost

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787834454,
+        "narHash": "sha256-jXSvqn04IOecJCvSvl8+g3PsbDVNP6qKs6dKUs/b16k=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dc2fd1acc537f3583744e1373597a5731ff7a6e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Spotify, native and fast";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # rust-toolchain.toml pins the compiler so local builds and CI agree.
+    # This reads that file rather than restating the version here.
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              overlays = [ (import rust-overlay) ];
+            }
+          )
+        );
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages =
+            with pkgs;
+            [
+              (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+              rust-analyzer
+              pkg-config
+            ]
+            ++ lib.optionals stdenv.hostPlatform.isDarwin [
+              apple-sdk
+            ]
+            ++ lib.optionals stdenv.hostPlatform.isLinux [
+              alsa-lib
+              libpulseaudio
+              libxkbcommon
+              wayland
+              libGL
+              xorg.libX11
+              xorg.libXcursor
+              xorg.libXi
+              xorg.libXrandr
+            ];
+          # The GUI dlopens its Wayland, X11 and GL libraries at run time.
+          LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+            pkgs.lib.makeLibraryPath (
+              with pkgs;
+              [
+                libxkbcommon
+                wayland
+                libGL
+                xorg.libX11
+                xorg.libXcursor
+                xorg.libXi
+                xorg.libXrandr
+              ]
+            )
+          );
+        };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+    };
+}


### PR DESCRIPTION
`nix develop` brings up the toolchain and the Linux GUI and audio libraries in one step, so a contributor on NixOS, or with Nix on macOS, does not hand-install the list from the README. `.envrc` enters the shell on `cd` for direnv users, and `.direnv/` is gitignored.

## The toolchain comes from the pin

The compiler is taken from `rust-toolchain.toml` via `rust-overlay`, not from whatever nixpkgs currently ships. That matters here: nixpkgs is on 1.97.1 today, so a plain `pkgs.rustc` shell would quietly disagree with the 1.98.0 the repo pins, which is the thing the pin exists to prevent.

```
$ nix develop --command cargo --version
cargo 1.98.0 (797e8a9bc 2026-08-05)
$ nix develop --command cargo clippy --version
clippy 0.1.98 (88d9e12ae1 2026-08-18)
```

## LD_LIBRARY_PATH on Linux

The GUI dlopens its Wayland, X11 and GL libraries at run time. Inside a Nix shell those are not on the default search path, so the shell exports `LD_LIBRARY_PATH` for them. On macOS the variable is empty and `apple-sdk` is pulled in instead.

## Verification

`nix develop` then `cargo build` and `cargo test` on aarch64-darwin: builds clean, 35 tests pass. `flake.lock` pins `nixpkgs` at `9fbb54b33e91` and `rust-overlay` at `dc2fd1acc537`, with rust-overlay following nixpkgs so there is one nixpkgs in the closure.

I have not run this on Linux. The Linux branch is a package list and an `LD_LIBRARY_PATH`, so it is the part most worth a second pair of eyes; happy to drop the Linux `optionals` entirely if you would rather ship a macOS-only shell first.

Four systems are declared (`aarch64-darwin`, `x86_64-darwin`, `aarch64-linux`, `x86_64-linux`). Nothing about the flake is required to build the project; `cargo install --path .` still works exactly as the README says.
