### PR TITLE
Give macOS a real application menu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ souvlaki = { version = "0.8", default-features = false }
 # Serving AppKit while no window exists (the status item lives on the main
 # thread), and leaving the Dock while hidden.
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSEvent", "NSResponder", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSEvent", "NSMenu", "NSMenuItem", "NSResponder", "NSRunningApplication"] }
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSDate", "NSObjCRuntime", "NSRunLoop", "NSString"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod backend;
 #[cfg(any(test, feature = "demo"))]
 pub mod demo;
 pub mod images;
+#[cfg(target_os = "macos")]
+pub mod mac_menu;
 pub mod model;
 #[cfg(target_os = "linux")]
 pub mod mpris;

--- a/src/mac_menu.rs
+++ b/src/mac_menu.rs
@@ -1,0 +1,524 @@
+//! Native macOS application menu bar (File, Edit, View, Playback, Window, Help).
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MenuCommand {
+    PlayPause,
+    Next,
+    Previous,
+    SeekForward,
+    SeekBackward,
+    ToggleShuffle,
+    CycleRepeat,
+    VolumeUp,
+    VolumeDown,
+    ToggleMute,
+    Home,
+    Search,
+    LikedSongs,
+    Queue,
+    Settings,
+    Shortcuts,
+    Back,
+    Forward,
+    OpenRepo,
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn init() {}
+
+#[cfg(not(target_os = "macos"))]
+pub fn set_waker(_wake: impl Fn() + Send + Sync + 'static) {}
+
+#[cfg(not(target_os = "macos"))]
+pub fn drain_commands() -> Vec<MenuCommand> {
+    Vec::new()
+}
+
+#[cfg(target_os = "macos")]
+pub use mac_impl::*;
+
+#[cfg(target_os = "macos")]
+mod mac_impl {
+    use objc2::rc::Retained;
+    use objc2::runtime::Sel;
+    use objc2::{MainThreadOnly, define_class, sel};
+    use objc2_app_kit::{NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
+    use objc2_foundation::{MainThreadMarker, NSObject, NSString, ns_string};
+    use std::sync::Mutex;
+
+    use super::MenuCommand;
+
+    static COMMANDS: Mutex<Vec<MenuCommand>> = Mutex::new(Vec::new());
+    static WAKER: Mutex<Option<Box<dyn Fn() + Send + Sync>>> = Mutex::new(None);
+
+    pub fn set_waker(wake: impl Fn() + Send + Sync + 'static) {
+        if let Ok(mut w) = WAKER.lock() {
+            *w = Some(Box::new(wake));
+        }
+    }
+
+    fn push_command(cmd: MenuCommand) {
+        if let Ok(mut list) = COMMANDS.lock() {
+            list.push(cmd);
+        }
+        if let Ok(w) = WAKER.lock()
+            && let Some(wake) = w.as_ref()
+        {
+            wake();
+        }
+    }
+
+    pub fn drain_commands() -> Vec<MenuCommand> {
+        if let Ok(mut list) = COMMANDS.lock() {
+            std::mem::take(&mut *list)
+        } else {
+            Vec::new()
+        }
+    }
+
+    define_class!(
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[name = "FastpotifyMenuHandler"]
+        pub struct FastpotifyMenuHandler;
+
+        impl FastpotifyMenuHandler {
+            #[unsafe(method(openSettings:))]
+            fn open_settings(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Settings);
+            }
+
+            #[unsafe(method(playPause:))]
+            fn play_pause(&self, _sender: &NSObject) {
+                push_command(MenuCommand::PlayPause);
+            }
+
+            #[unsafe(method(nextTrack:))]
+            fn next_track(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Next);
+            }
+
+            #[unsafe(method(previousTrack:))]
+            fn previous_track(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Previous);
+            }
+
+            #[unsafe(method(seekForward:))]
+            fn seek_forward(&self, _sender: &NSObject) {
+                push_command(MenuCommand::SeekForward);
+            }
+
+            #[unsafe(method(seekBackward:))]
+            fn seek_backward(&self, _sender: &NSObject) {
+                push_command(MenuCommand::SeekBackward);
+            }
+
+            #[unsafe(method(toggleShuffle:))]
+            fn toggle_shuffle(&self, _sender: &NSObject) {
+                push_command(MenuCommand::ToggleShuffle);
+            }
+
+            #[unsafe(method(cycleRepeat:))]
+            fn cycle_repeat(&self, _sender: &NSObject) {
+                push_command(MenuCommand::CycleRepeat);
+            }
+
+            #[unsafe(method(volumeUp:))]
+            fn volume_up(&self, _sender: &NSObject) {
+                push_command(MenuCommand::VolumeUp);
+            }
+
+            #[unsafe(method(volumeDown:))]
+            fn volume_down(&self, _sender: &NSObject) {
+                push_command(MenuCommand::VolumeDown);
+            }
+
+            #[unsafe(method(toggleMute:))]
+            fn toggle_mute(&self, _sender: &NSObject) {
+                push_command(MenuCommand::ToggleMute);
+            }
+
+            #[unsafe(method(openHome:))]
+            fn open_home(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Home);
+            }
+
+            #[unsafe(method(focusSearch:))]
+            fn focus_search(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Search);
+            }
+
+            #[unsafe(method(openLikedSongs:))]
+            fn open_liked_songs(&self, _sender: &NSObject) {
+                push_command(MenuCommand::LikedSongs);
+            }
+
+            #[unsafe(method(toggleQueue:))]
+            fn toggle_queue(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Queue);
+            }
+
+            #[unsafe(method(goBack:))]
+            fn go_back(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Back);
+            }
+
+            #[unsafe(method(goForward:))]
+            fn go_forward(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Forward);
+            }
+
+            #[unsafe(method(showShortcuts:))]
+            fn show_shortcuts(&self, _sender: &NSObject) {
+                push_command(MenuCommand::Shortcuts);
+            }
+
+            #[unsafe(method(openRepo:))]
+            fn open_repo(&self, _sender: &NSObject) {
+                push_command(MenuCommand::OpenRepo);
+            }
+        }
+    );
+
+    fn create_item(
+        mtm: MainThreadMarker,
+        title: &NSString,
+        action: Option<Sel>,
+        key: &NSString,
+        masks: Option<NSEventModifierFlags>,
+        target: Option<&NSObject>,
+    ) -> Retained<NSMenuItem> {
+        let item = unsafe {
+            NSMenuItem::initWithTitle_action_keyEquivalent(mtm.alloc(), title, action, key)
+        };
+        if let Some(masks) = masks {
+            item.setKeyEquivalentModifierMask(masks);
+        }
+        if let Some(target) = target {
+            unsafe { item.setTarget(Some(target)) };
+        }
+        item
+    }
+
+    fn create_menu(
+        mtm: MainThreadMarker,
+        title: &NSString,
+    ) -> (Retained<NSMenuItem>, Retained<NSMenu>) {
+        let container_item = unsafe {
+            NSMenuItem::initWithTitle_action_keyEquivalent(mtm.alloc(), title, None, ns_string!(""))
+        };
+        let menu = NSMenu::initWithTitle(mtm.alloc(), title);
+        menu.setAutoenablesItems(false);
+        container_item.setSubmenu(Some(&menu));
+        (container_item, menu)
+    }
+
+    pub fn init() {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return;
+        };
+        let app = NSApplication::sharedApplication(mtm);
+        let Some(menubar) = app.mainMenu() else {
+            return;
+        };
+
+        static INITIALIZED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        if INITIALIZED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+
+        let handler: Retained<FastpotifyMenuHandler> =
+            unsafe { objc2::msg_send![mtm.alloc::<FastpotifyMenuHandler>(), init] };
+        let target: &NSObject = &handler;
+
+        // 1. Settings item in app menu (first menu)
+        if let Some(app_menu_item) = menubar.itemAtIndex(0)
+            && let Some(app_menu) = app_menu_item.submenu()
+        {
+            let settings_item = create_item(
+                mtm,
+                ns_string!("Settings…"),
+                Some(sel!(openSettings:)),
+                ns_string!(","),
+                None,
+                Some(target),
+            );
+            let sep = NSMenuItem::separatorItem(mtm);
+            app_menu.insertItem_atIndex(&settings_item, 1);
+            app_menu.insertItem_atIndex(&sep, 2);
+        }
+
+        // 2. File menu
+        let (file_item, file_menu) = create_menu(mtm, ns_string!("File"));
+        file_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Close Window"),
+            Some(sel!(performClose:)),
+            ns_string!("w"),
+            None,
+            None,
+        ));
+        menubar.addItem(&file_item);
+
+        // 3. Edit menu
+        let (edit_item, edit_menu) = create_menu(mtm, ns_string!("Edit"));
+        edit_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Undo"),
+            Some(sel!(undo:)),
+            ns_string!("z"),
+            None,
+            None,
+        ));
+        edit_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Redo"),
+            Some(sel!(redo:)),
+            ns_string!("Z"),
+            Some(NSEventModifierFlags::Command | NSEventModifierFlags::Shift),
+            None,
+        ));
+        edit_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        edit_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Cut"),
+            Some(sel!(cut:)),
+            ns_string!("x"),
+            None,
+            None,
+        ));
+        edit_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Copy"),
+            Some(sel!(copy:)),
+            ns_string!("c"),
+            None,
+            None,
+        ));
+        edit_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Paste"),
+            Some(sel!(paste:)),
+            ns_string!("v"),
+            None,
+            None,
+        ));
+        edit_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Select All"),
+            Some(sel!(selectAll:)),
+            ns_string!("a"),
+            None,
+            None,
+        ));
+        menubar.addItem(&edit_item);
+
+        // 4. Playback menu
+        let (playback_item, playback_menu) = create_menu(mtm, ns_string!("Playback"));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Play / Pause"),
+            Some(sel!(playPause:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Next Track"),
+            Some(sel!(nextTrack:)),
+            &NSString::from_str("\u{F703}"), // Right arrow
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Previous Track"),
+            Some(sel!(previousTrack:)),
+            &NSString::from_str("\u{F702}"), // Left arrow
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        playback_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        // Shift+arrow has no key equivalent here on purpose: a menu key
+        // equivalent fires ahead of the focused view, so binding it would
+        // take shift-arrow selection away from every text field. The window
+        // handles the same chord itself, and only when nothing has focus.
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Seek Forward (10s)"),
+            Some(sel!(seekForward:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Seek Backward (10s)"),
+            Some(sel!(seekBackward:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        playback_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Shuffle"),
+            Some(sel!(toggleShuffle:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Repeat"),
+            Some(sel!(cycleRepeat:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        playback_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Increase Volume"),
+            Some(sel!(volumeUp:)),
+            &NSString::from_str("\u{F700}"), // Up arrow
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Decrease Volume"),
+            Some(sel!(volumeDown:)),
+            &NSString::from_str("\u{F701}"), // Down arrow
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        playback_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Mute"),
+            Some(sel!(toggleMute:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        menubar.addItem(&playback_item);
+
+        // 5. View menu
+        let (view_item, view_menu) = create_menu(mtm, ns_string!("View"));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Back"),
+            Some(sel!(goBack:)),
+            ns_string!("["),
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Forward"),
+            Some(sel!(goForward:)),
+            ns_string!("]"),
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        view_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Home"),
+            Some(sel!(openHome:)),
+            ns_string!("H"),
+            Some(NSEventModifierFlags::Command | NSEventModifierFlags::Shift),
+            Some(target),
+        ));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Search"),
+            Some(sel!(focusSearch:)),
+            ns_string!("f"),
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Liked Songs"),
+            Some(sel!(openLikedSongs:)),
+            ns_string!("l"),
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Queue"),
+            Some(sel!(toggleQueue:)),
+            ns_string!("u"),
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        view_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        view_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Toggle Full Screen"),
+            Some(sel!(toggleFullScreen:)),
+            ns_string!("f"),
+            Some(NSEventModifierFlags::Control | NSEventModifierFlags::Command),
+            None,
+        ));
+        menubar.addItem(&view_item);
+
+        // 6. Window menu
+        let (window_item, window_menu) = create_menu(mtm, ns_string!("Window"));
+        window_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Minimize"),
+            Some(sel!(performMiniaturize:)),
+            ns_string!("m"),
+            Some(NSEventModifierFlags::Command),
+            None,
+        ));
+        window_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Zoom"),
+            Some(sel!(performZoom:)),
+            ns_string!(""),
+            None,
+            None,
+        ));
+        window_menu.addItem(&NSMenuItem::separatorItem(mtm));
+        window_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Bring All to Front"),
+            Some(sel!(arrangeInFront:)),
+            ns_string!(""),
+            None,
+            None,
+        ));
+        menubar.addItem(&window_item);
+
+        // 7. Help menu
+        let (help_item, help_menu) = create_menu(mtm, ns_string!("Help"));
+        help_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Keyboard Shortcuts"),
+            Some(sel!(showShortcuts:)),
+            ns_string!("/"),
+            Some(NSEventModifierFlags::Command),
+            Some(target),
+        ));
+        help_menu.addItem(&create_item(
+            mtm,
+            ns_string!("Fastpotify on GitHub"),
+            Some(sel!(openRepo:)),
+            ns_string!(""),
+            None,
+            Some(target),
+        ));
+        menubar.addItem(&help_item);
+
+        // NSMenuItem does not retain its target, and this one has to answer
+        // for as long as the menu bar exists. It is a single process-wide
+        // object, so leaking it is the whole lifetime story.
+        std::mem::forget(handler);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,15 @@ fn main() -> eframe::Result<()> {
                     .unwrap_or_else(|p| p.into_inner())
                     .take()
                     .expect("application state present");
+                // Built once per window, before the first frame; the handler
+                // wakes the loop so a menu pick is not held until the next
+                // repaint.
+                #[cfg(target_os = "macos")]
+                {
+                    fastpotify::mac_menu::init();
+                    let ctx = cc.egui_ctx.clone();
+                    fastpotify::mac_menu::set_waker(move || ctx.request_repaint());
+                }
                 app.attach(&cc.egui_ctx);
                 Ok(Box::new(Shell {
                     app: Some(app),
@@ -348,6 +357,38 @@ impl Shell {
 impl eframe::App for Shell {
     fn logic(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         if let Some(app) = self.app.as_mut() {
+            #[cfg(target_os = "macos")]
+            for command in fastpotify::mac_menu::drain_commands() {
+                use fastpotify::mac_menu::MenuCommand;
+                use fastpotify::model::{Action, Dialog, Page};
+                let action = match command {
+                    MenuCommand::PlayPause => Action::TogglePlay,
+                    MenuCommand::Next => Action::Next,
+                    MenuCommand::Previous => Action::Previous,
+                    MenuCommand::SeekForward => Action::SeekBy(10_000),
+                    MenuCommand::SeekBackward => Action::SeekBy(-10_000),
+                    MenuCommand::ToggleShuffle => Action::ToggleShuffle,
+                    MenuCommand::CycleRepeat => Action::CycleRepeat,
+                    MenuCommand::VolumeUp => Action::VolumeBy(5),
+                    MenuCommand::VolumeDown => Action::VolumeBy(-5),
+                    MenuCommand::ToggleMute => Action::ToggleMute,
+                    MenuCommand::Home => Action::Open(Page::Home),
+                    MenuCommand::Search => Action::FocusSearch,
+                    MenuCommand::LikedSongs => Action::Open(Page::LikedSongs),
+                    MenuCommand::Queue => Action::ToggleQueuePanel,
+                    MenuCommand::Settings => Action::Open(Page::Settings),
+                    MenuCommand::Shortcuts => Action::ShowDialog(Dialog::Shortcuts),
+                    MenuCommand::Back => Action::Back,
+                    MenuCommand::Forward => Action::Forward,
+                    MenuCommand::OpenRepo => {
+                        ctx.open_url(egui::OpenUrl::new_tab(
+                            "https://github.com/crmne/fastpotify",
+                        ));
+                        continue;
+                    }
+                };
+                app.actions.push(action);
+            }
             app.background_frame(ctx);
         }
         #[cfg(feature = "demo")]


### PR DESCRIPTION
On macOS the app has no menu bar to speak of. winit installs a skeleton one with an app menu and nothing else, so there is no File, Edit, Playback, Go or Window menu, and every command is reachable only by chord or by pointer.

The missing Edit menu is the part that bites hardest: without it the standard `cut:`, `copy:`, `paste:` and `selectAll:` selectors are unbound, so Cmd+C in the search field does nothing.

## Shape

`src/mac_menu.rs` builds the menu against AppKit directly, since winit offers no way to extend the one it installs.

Playback, Go and View items post into a queue that the frame loop drains into the same `Action`s the keyboard already produces. One path per command, so the menu cannot drift away from the shortcuts. Edit items go to the responder chain selectors instead, which is what makes the text-field editing keys work.

Two deliberate choices worth review:

- The menu is built once per window, in the eframe creator, not per frame.
- The handler object is leaked on purpose. It has to outlive every menu item that targets it, and the alternative is a `static mut`. There is one per process, created once.

The waker closure requests a repaint, so a menu pick is acted on immediately rather than at whatever frame the app draws next; without it a pick on an idle window sits until something else wakes the loop.

## Cost

None in dependencies. Rebased onto "Close to the tray and answer media keys on Windows and macOS", this builds against the `objc2` 0.6 and `objc2-app-kit` 0.3 that commit already brought in, adding only the `NSMenu` and `NSMenuItem` features to the existing entry. `Cargo.lock` is untouched. Everything is behind `#[cfg(target_os = "macos")]`.

## Verification

`cargo clippy --all-targets` clean with no new warnings, 38 tests pass on aarch64-darwin. The module has been running in my fork, though against objc2 0.5; the port to 0.6 here (`define_class!`, `#[unsafe(method(...))]`, the `NSEventModifierFlags` constants) is compiled and tested but I have not re-run the menu interactively since the port. Worth a click through Playback and Edit before merging.
