### PR TITLE
Put playback on the macOS media keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "aes",
  "anyhow",
  "base64",
+ "block2 0.5.1",
  "clap",
  "cpal",
  "ctr",
@@ -1465,6 +1466,10 @@ dependencies = [
  "mdns-sd",
  "memmap2",
  "mpris-server",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-media-player",
  "open",
  "pbkdf2",
  "percent-encoding",
@@ -3437,6 +3442,19 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-media-player"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeee7e398f352d50d8016c73969878942efb422030884a744180a2d2b8b341de"
+dependencies = [
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,23 @@ pbkdf2 = "0.12"
 aes = "0.8"
 ctr = "0.9"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.5.2"
+objc2-foundation = { version = "0.2.2", features = ["NSString", "NSDictionary", "NSData", "NSValue", "NSGeometry"] }
+objc2-app-kit = { version = "0.2.2", features = ["NSImage"] }
+# Now Playing and the remote command centre: media keys, Control Centre and
+# the lock screen. block2 carries the command handlers, NSImage the cover art.
+objc2-media-player = { version = "0.2.2", features = [
+    "MPNowPlayingInfoCenter",
+    "MPRemoteCommandCenter",
+    "MPRemoteCommand",
+    "MPRemoteCommandEvent",
+    "MPMediaItem",
+    "block2",
+    "objc2-app-kit",
+] }
+block2 = "0.5"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 ksni = { version = "0.3", features = ["blocking"] }
 librespot-playback = { version = "0.8", default-features = false, features = ["rodio-backend", "pulseaudio-backend", "rustls-tls-native-roots"] }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ On macOS, with [Homebrew](https://brew.sh):
 brew install --cask crmne/tap/fastpotify
 ```
 
+The media keys, Control Centre and the lock screen drive playback there. macOS
+routes them to bundled applications only, so they work from `Fastpotify.app`
+and not from `cargo run`; `packaging/macos/bundle.sh` builds the bundle.
+
 Everywhere else it is a single binary. Build it with a stable Rust toolchain
 (1.95 or newer):
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,8 +13,9 @@ use crate::backend::{
     ApiRequest, ApiResponse, AuthStatus, Backend, Command, Event, LocalPlayback, RemoteAction,
     Waker,
 };
+use crate::media::{MediaCommand, MediaState, MediaTrack};
+use crate::media_controls::MediaControls;
 use crate::model::*;
-use crate::mpris::{MprisCommand, MprisService, MprisState, MprisTrack};
 use crate::paths::AppDirs;
 use crate::player::{EngineConfig, LoadSpec, LocalState, Playback, PlayerCommand, RepeatMode};
 use crate::settings::{SessionState, Settings, ThemeChoice};
@@ -79,7 +80,7 @@ pub enum Target {
 #[derive(Clone, Copy, Debug)]
 pub struct AppOptions {
     /// Register the MPRIS media-control service (Linux).
-    pub mpris: bool,
+    pub media_controls: bool,
     /// Register the system-tray item (Linux).
     pub tray: bool,
 }
@@ -87,7 +88,7 @@ pub struct AppOptions {
 impl Default for AppOptions {
     fn default() -> Self {
         Self {
-            mpris: true,
+            media_controls: true,
             tray: true,
         }
     }
@@ -99,7 +100,7 @@ pub struct App {
     settings_dirty: bool,
     last_settings_save: Instant,
     pub backend: Backend,
-    mpris: Option<MprisService>,
+    media_controls: Option<MediaControls>,
     tray: Option<TrayService>,
     pub window_hidden: bool,
     /// The window should close but the process should stay in the tray.
@@ -210,9 +211,9 @@ impl App {
             waker.clone(),
         );
         let wake = waker.clone();
-        let mpris = options
-            .mpris
-            .then(|| MprisService::spawn(move || wake.wake()));
+        let media_controls = options
+            .media_controls
+            .then(|| MediaControls::spawn(move || wake.wake()));
         let wake = waker.clone();
         let tray = options
             .tray
@@ -233,7 +234,7 @@ impl App {
             settings_dirty: false,
             last_settings_save: Instant::now(),
             backend,
-            mpris,
+            media_controls,
             tray,
             window_hidden: false,
             hide_intent: false,
@@ -683,9 +684,9 @@ impl App {
             self.settings_dirty = true;
         }
         if state.seek_sequence != self.local.seek_sequence
-            && let Some(mpris) = &self.mpris
+            && let Some(controls) = &self.media_controls
         {
-            mpris.seeked(state.position_ms);
+            controls.seeked(state.position_ms);
         }
         if let Some(error) = &state.error
             && self.local.error.as_deref() != Some(error.as_str())
@@ -833,38 +834,42 @@ impl App {
         }
     }
 
-    fn handle_mpris(&mut self) {
-        let Some(commands) = self.mpris.as_ref().map(MprisService::drain_commands) else {
+    fn handle_media_commands(&mut self) {
+        let Some(commands) = self
+            .media_controls
+            .as_ref()
+            .map(MediaControls::drain_commands)
+        else {
             return;
         };
         for command in commands {
             let playing = self.now_playing().is_some_and(|now| now.playing);
             let action = match command {
-                MprisCommand::Play => (!playing).then_some(Action::TogglePlay),
-                MprisCommand::Pause | MprisCommand::Stop => playing.then_some(Action::TogglePlay),
-                MprisCommand::PlayPause => Some(Action::TogglePlay),
-                MprisCommand::Next => Some(Action::Next),
-                MprisCommand::Previous => Some(Action::Previous),
-                MprisCommand::SeekBy(offset) => Some(Action::SeekBy(offset)),
-                MprisCommand::SetPosition {
+                MediaCommand::Play => (!playing).then_some(Action::TogglePlay),
+                MediaCommand::Pause | MediaCommand::Stop => playing.then_some(Action::TogglePlay),
+                MediaCommand::PlayPause => Some(Action::TogglePlay),
+                MediaCommand::Next => Some(Action::Next),
+                MediaCommand::Previous => Some(Action::Previous),
+                MediaCommand::SeekBy(offset) => Some(Action::SeekBy(offset)),
+                MediaCommand::SetPosition {
                     track_uri,
                     position_ms,
                 } => self
                     .now_playing()
                     .filter(|now| now.uri == track_uri)
                     .map(|_| Action::Seek(position_ms)),
-                MprisCommand::SetVolume(volume) => Some(Action::SetVolume(
+                MediaCommand::SetVolume(volume) => Some(Action::SetVolume(
                     (volume.clamp(0.0, 1.0) * 100.0).round() as u8,
                 )),
-                MprisCommand::SetShuffle(shuffle) => Some(Action::SetShuffle(shuffle)),
-                MprisCommand::SetRepeat(mode) => Some(Action::SetRepeat(mode)),
-                MprisCommand::OpenUri(uri) => Some(Action::PlayContext {
+                MediaCommand::SetShuffle(shuffle) => Some(Action::SetShuffle(shuffle)),
+                MediaCommand::SetRepeat(mode) => Some(Action::SetRepeat(mode)),
+                MediaCommand::OpenUri(uri) => Some(Action::PlayContext {
                     uri,
                     offset_uri: None,
                     offset_index: None,
                 }),
-                MprisCommand::Raise => Some(Action::ShowWindow),
-                MprisCommand::Quit => Some(Action::Quit),
+                MediaCommand::Raise => Some(Action::ShowWindow),
+                MediaCommand::Quit => Some(Action::Quit),
             };
             if let Some(action) = action {
                 self.actions.push(action);
@@ -872,9 +877,9 @@ impl App {
         }
     }
 
-    fn sync_mpris(&mut self) {
+    fn sync_media_controls(&mut self) {
         let state = match self.now_playing() {
-            Some(now) => MprisState {
+            Some(now) => MediaState {
                 playback: if now.playing {
                     Playback::Playing
                 } else if now.loading {
@@ -882,7 +887,7 @@ impl App {
                 } else {
                     Playback::Paused
                 },
-                track: Some(MprisTrack {
+                track: Some(MediaTrack {
                     uri: now.uri.clone(),
                     title: now.title.clone(),
                     artists: now
@@ -900,10 +905,10 @@ impl App {
                 repeat: now.repeat,
                 can_control: now.can_control,
             },
-            None => MprisState::default(),
+            None => MediaState::default(),
         };
-        if let Some(mpris) = &mut self.mpris {
-            mpris.update(state);
+        if let Some(controls) = &mut self.media_controls {
+            controls.update(state);
         }
         let playing = self.now_playing().is_some_and(|now| now.playing);
         if let Some(tray) = &mut self.tray {
@@ -2654,11 +2659,11 @@ impl App {
             self.actions.push(Action::ShowWindow);
         }
         self.handle_events();
-        self.handle_mpris();
+        self.handle_media_commands();
         self.handle_tray();
         self.tick(ctx);
         self.apply_actions(ctx);
-        self.sync_mpris();
+        self.sync_media_controls();
     }
 
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
@@ -2668,7 +2673,7 @@ impl App {
         self.lock_scroll_axis(ctx);
         crate::ui::show(self, ui);
         self.apply_actions(ctx);
-        self.sync_mpris();
+        self.sync_media_controls();
 
         let playing = self.now_playing().is_some_and(|now| now.playing);
         if playing {

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -585,7 +585,7 @@ mod tests {
             dirs,
             Settings::default(),
             AppOptions {
-                mpris: false,
+                media_controls: false,
                 tray: false,
             },
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ pub mod media;
 #[cfg(target_os = "linux")]
 #[path = "mpris.rs"]
 pub mod media_controls;
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+#[path = "now_playing.rs"]
+pub mod media_controls;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 #[path = "media_stub.rs"]
 pub mod media_controls;
 pub mod model;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ pub mod backend;
 #[cfg(any(test, feature = "demo"))]
 pub mod demo;
 pub mod images;
-pub mod model;
+pub mod media;
 #[cfg(target_os = "linux")]
-pub mod mpris;
+#[path = "mpris.rs"]
+pub mod media_controls;
 #[cfg(not(target_os = "linux"))]
-#[path = "mpris_stub.rs"]
-pub mod mpris;
+#[path = "media_stub.rs"]
+pub mod media_controls;
+pub mod model;
 pub mod paths;
 pub mod player;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> eframe::Result<()> {
     #[cfg(feature = "demo")]
     if cli.demo_shot.is_some() {
         options = app::AppOptions {
-            mpris: false,
+            media_controls: false,
             tray: false,
         };
     }

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,9 +1,12 @@
-//! No-op desktop media controls for platforms without MPRIS.
+//! What the desktop's own media controls say and hear.
+//!
+//! MPRIS on Linux and Now Playing on macOS answer the same questions, so the
+//! interface speaks this vocabulary and each platform module translates it.
 
 use crate::player::{Playback, RepeatMode};
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum MprisCommand {
+pub enum MediaCommand {
     Play,
     Pause,
     PlayPause,
@@ -21,7 +24,7 @@ pub enum MprisCommand {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MprisTrack {
+pub struct MediaTrack {
     pub uri: String,
     pub title: String,
     pub artists: Vec<String>,
@@ -31,9 +34,9 @@ pub struct MprisTrack {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct MprisState {
+pub struct MediaState {
     pub playback: Playback,
-    pub track: Option<MprisTrack>,
+    pub track: Option<MediaTrack>,
     pub position_ms: u32,
     pub volume: f64,
     pub shuffle: bool,
@@ -41,7 +44,7 @@ pub struct MprisState {
     pub can_control: bool,
 }
 
-impl Default for MprisState {
+impl Default for MediaState {
     fn default() -> Self {
         Self {
             playback: Playback::Stopped,
@@ -53,20 +56,4 @@ impl Default for MprisState {
             can_control: true,
         }
     }
-}
-
-pub struct MprisService;
-
-impl MprisService {
-    pub fn spawn(_wake: impl Fn() + Send + Sync + 'static) -> Self {
-        Self
-    }
-
-    pub fn drain_commands(&self) -> Vec<MprisCommand> {
-        Vec::new()
-    }
-
-    pub fn update(&mut self, _state: MprisState) {}
-
-    pub fn seeked(&self, _position_ms: u32) {}
 }

--- a/src/media_stub.rs
+++ b/src/media_stub.rs
@@ -1,0 +1,19 @@
+//! No-op desktop media controls for platforms with none of their own.
+
+use crate::media::{MediaCommand, MediaState};
+
+pub struct MediaControls;
+
+impl MediaControls {
+    pub fn spawn(_wake: impl Fn() + Send + Sync + 'static) -> Self {
+        Self
+    }
+
+    pub fn drain_commands(&self) -> Vec<MediaCommand> {
+        Vec::new()
+    }
+
+    pub fn update(&mut self, _state: MediaState) {}
+
+    pub fn seeked(&self, _position_ms: u32) {}
+}

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -12,77 +12,20 @@ use std::time::{Duration, Instant};
 use mpris_server::{LoopStatus, Metadata, PlaybackStatus, Player, Time, TrackId};
 use tokio::sync::mpsc as tokio_mpsc;
 
+use crate::media::{MediaCommand, MediaState, MediaTrack};
 use crate::player::{Playback, RepeatMode};
 
 const PLAYING_POSITION_INTERVAL: Duration = Duration::from_millis(1000);
 const TRACK_OBJECT_PATH_PREFIX: &str = "/me/paolino/Fastpotify/Track/";
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum MprisCommand {
-    Play,
-    Pause,
-    PlayPause,
-    Stop,
-    Next,
-    Previous,
-    SeekBy(i64),
-    SetPosition { track_uri: String, position_ms: u32 },
-    SetVolume(f64),
-    SetShuffle(bool),
-    SetRepeat(RepeatMode),
-    OpenUri(String),
-    Raise,
-    Quit,
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct MprisTrack {
-    pub uri: String,
-    pub title: String,
-    pub artists: Vec<String>,
-    pub album: String,
-    pub art_url: Option<String>,
-    pub duration_ms: u32,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct MprisState {
-    pub playback: Playback,
-    pub track: Option<MprisTrack>,
-    pub position_ms: u32,
-    pub volume: f64,
-    pub shuffle: bool,
-    pub repeat: RepeatMode,
-    pub can_control: bool,
-}
-
-impl Default for MprisState {
-    fn default() -> Self {
-        Self {
-            playback: Playback::Stopped,
-            track: None,
-            position_ms: 0,
-            volume: 1.0,
-            shuffle: false,
-            repeat: RepeatMode::Off,
-            can_control: true,
-        }
-    }
-}
-
-enum Update {
-    State(MprisState),
-    Seeked(u32),
-}
-
-pub struct MprisService {
+pub struct MediaControls {
     updates: tokio_mpsc::UnboundedSender<Update>,
-    commands: Receiver<MprisCommand>,
-    published: Option<MprisState>,
+    commands: Receiver<MediaCommand>,
+    published: Option<MediaState>,
     last_position_update: Instant,
 }
 
-impl MprisService {
+impl MediaControls {
     pub fn spawn(wake: impl Fn() + Send + Sync + 'static) -> Self {
         let (updates, update_rx) = tokio_mpsc::unbounded_channel();
         let (command_tx, commands) = std::sync::mpsc::channel();
@@ -117,13 +60,13 @@ impl MprisService {
         }
     }
 
-    pub fn drain_commands(&self) -> Vec<MprisCommand> {
+    pub fn drain_commands(&self) -> Vec<MediaCommand> {
         self.commands.try_iter().collect()
     }
 
     /// Publishes structural changes immediately; the position once a second
     /// while playing, since clients interpolate between updates.
-    pub fn update(&mut self, state: MprisState) {
+    pub fn update(&mut self, state: MediaState) {
         let structural = self
             .published
             .as_ref()
@@ -148,7 +91,7 @@ impl MprisService {
     }
 }
 
-fn same_except_position(left: &MprisState, right: &MprisState) -> bool {
+fn same_except_position(left: &MediaState, right: &MediaState) -> bool {
     left.playback == right.playback
         && left.track == right.track
         && (left.volume - right.volume).abs() < 0.005
@@ -159,7 +102,7 @@ fn same_except_position(left: &MprisState, right: &MprisState) -> bool {
 
 async fn run(
     mut updates: tokio_mpsc::UnboundedReceiver<Update>,
-    commands: Sender<MprisCommand>,
+    commands: Sender<MediaCommand>,
     wake: std::sync::Arc<dyn Fn() + Send + Sync>,
 ) -> mpris_server::zbus::Result<()> {
     let player = Player::builder("fastpotify")
@@ -180,7 +123,7 @@ async fn run(
     let send = {
         let commands = commands.clone();
         let wake = wake.clone();
-        move |command: MprisCommand| {
+        move |command: MediaCommand| {
             if commands.send(command).is_ok() {
                 wake();
             }
@@ -188,37 +131,37 @@ async fn run(
     };
     {
         let send = send.clone();
-        player.connect_play(move |_| send(MprisCommand::Play));
+        player.connect_play(move |_| send(MediaCommand::Play));
     }
     {
         let send = send.clone();
-        player.connect_pause(move |_| send(MprisCommand::Pause));
+        player.connect_pause(move |_| send(MediaCommand::Pause));
     }
     {
         let send = send.clone();
-        player.connect_play_pause(move |_| send(MprisCommand::PlayPause));
+        player.connect_play_pause(move |_| send(MediaCommand::PlayPause));
     }
     {
         let send = send.clone();
-        player.connect_stop(move |_| send(MprisCommand::Stop));
+        player.connect_stop(move |_| send(MediaCommand::Stop));
     }
     {
         let send = send.clone();
-        player.connect_next(move |_| send(MprisCommand::Next));
+        player.connect_next(move |_| send(MediaCommand::Next));
     }
     {
         let send = send.clone();
-        player.connect_previous(move |_| send(MprisCommand::Previous));
+        player.connect_previous(move |_| send(MediaCommand::Previous));
     }
     {
         let send = send.clone();
-        player.connect_seek(move |_, offset| send(MprisCommand::SeekBy(offset.as_millis())));
+        player.connect_seek(move |_, offset| send(MediaCommand::SeekBy(offset.as_millis())));
     }
     {
         let send = send.clone();
         player.connect_set_position(move |_, track_id, position| {
             if let Some(uri) = uri_from_object_path(track_id.as_str()) {
-                send(MprisCommand::SetPosition {
+                send(MediaCommand::SetPosition {
                     track_uri: uri,
                     position_ms: position.as_millis().max(0) as u32,
                 });
@@ -227,16 +170,16 @@ async fn run(
     }
     {
         let send = send.clone();
-        player.connect_set_volume(move |_, volume| send(MprisCommand::SetVolume(volume)));
+        player.connect_set_volume(move |_, volume| send(MediaCommand::SetVolume(volume)));
     }
     {
         let send = send.clone();
-        player.connect_set_shuffle(move |_, shuffle| send(MprisCommand::SetShuffle(shuffle)));
+        player.connect_set_shuffle(move |_, shuffle| send(MediaCommand::SetShuffle(shuffle)));
     }
     {
         let send = send.clone();
         player.connect_set_loop_status(move |_, status| {
-            send(MprisCommand::SetRepeat(match status {
+            send(MediaCommand::SetRepeat(match status {
                 LoopStatus::None => RepeatMode::Off,
                 LoopStatus::Track => RepeatMode::Track,
                 LoopStatus::Playlist => RepeatMode::Context,
@@ -245,20 +188,20 @@ async fn run(
     }
     {
         let send = send.clone();
-        player.connect_open_uri(move |_, uri| send(MprisCommand::OpenUri(uri.to_string())));
+        player.connect_open_uri(move |_, uri| send(MediaCommand::OpenUri(uri.to_string())));
     }
     {
         let send = send.clone();
-        player.connect_raise(move |_| send(MprisCommand::Raise));
+        player.connect_raise(move |_| send(MediaCommand::Raise));
     }
     {
         let send = send.clone();
-        player.connect_quit(move |_| send(MprisCommand::Quit));
+        player.connect_quit(move |_| send(MediaCommand::Quit));
     }
 
     let server = player.run();
     let apply = async {
-        let mut published: Option<MprisState> = None;
+        let mut published: Option<MediaState> = None;
         while let Some(update) = updates.recv().await {
             match update {
                 Update::Seeked(position_ms) => {
@@ -313,7 +256,7 @@ fn loop_status(mode: RepeatMode) -> LoopStatus {
     }
 }
 
-fn metadata(track: Option<&MprisTrack>) -> Metadata {
+fn metadata(track: Option<&MediaTrack>) -> Metadata {
     let Some(track) = track else {
         return Metadata::new();
     };

--- a/src/now_playing.rs
+++ b/src/now_playing.rs
@@ -1,0 +1,410 @@
+//! macOS media controls: Now Playing and the remote command centre.
+//!
+//! This is what puts Fastpotify on the media keys, in Control Centre, on the lock
+//! screen, and behind the AirPods pinch. The command centre keeps its handler
+//! blocks for the life of the process, so they post into a shared queue that
+//! the interface drains on its own thread.
+//!
+//! Cover art arrives over the network. The fetch runs on a worker thread and
+//! leaves bytes behind; the `NSImage` is built on the next update, which is
+//! always the main thread.
+
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use block2::RcBlock;
+use objc2::ClassType;
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2_app_kit::NSImage;
+use objc2_foundation::{CGSize, NSData, NSDictionary, NSNumber, NSString};
+use objc2_media_player::{
+    MPChangePlaybackPositionCommandEvent, MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle,
+    MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork, MPMediaItemPropertyPlaybackDuration,
+    MPMediaItemPropertyTitle, MPNowPlayingInfoCenter, MPNowPlayingInfoPropertyElapsedPlaybackTime,
+    MPNowPlayingInfoPropertyPlaybackRate, MPNowPlayingPlaybackState, MPRemoteCommandCenter,
+    MPRemoteCommandEvent, MPRemoteCommandHandlerStatus,
+};
+
+use crate::media::{MediaCommand, MediaState};
+use crate::player::Playback;
+
+/// How often the elapsed time is restated. macOS extrapolates between
+/// updates from the playback rate, so this only has to correct drift.
+const POSITION_REFRESH: Duration = Duration::from_secs(5);
+const SKIP_INTERVAL_SECONDS: f64 = 10.0;
+/// The square the artwork is published at. Control Centre and the lock
+/// screen both scale down from it.
+const ARTWORK_SIZE: f64 = 600.0;
+
+static COMMANDS: Mutex<Vec<MediaCommand>> = Mutex::new(Vec::new());
+static CURRENT_URI: Mutex<Option<String>> = Mutex::new(None);
+#[allow(clippy::type_complexity)]
+static WAKER: Mutex<Option<Arc<dyn Fn() + Send + Sync>>> = Mutex::new(None);
+
+fn push(command: MediaCommand) {
+    if let Ok(mut queue) = COMMANDS.lock() {
+        queue.push(command);
+    }
+    let wake = WAKER.lock().ok().and_then(|waker| waker.clone());
+    if let Some(wake) = wake {
+        wake();
+    }
+}
+
+/// Wraps `command` around the position the event carries, when there is a
+/// track for it to apply to.
+fn seek_command(position_seconds: f64) -> Option<MediaCommand> {
+    let track_uri = CURRENT_URI.lock().ok()?.clone()?;
+    Some(MediaCommand::SetPosition {
+        track_uri,
+        position_ms: (position_seconds.max(0.0) * 1000.0) as u32,
+    })
+}
+
+/// The bytes of one cover, and the cover they were asked for.
+#[derive(Default)]
+struct Artwork {
+    /// The cover `bytes` belong to, once a download has succeeded.
+    url: Option<String>,
+    bytes: Option<Vec<u8>>,
+    /// The cover a download has been started for, whether it is still
+    /// running, succeeded, or failed. One attempt per cover: a cover that
+    /// will not download must not be retried on every frame.
+    attempted: Option<String>,
+}
+
+pub struct MediaControls {
+    published: Option<MediaState>,
+    published_art: Option<String>,
+    last_position_update: Instant,
+    artwork: Arc<Mutex<Artwork>>,
+}
+
+impl MediaControls {
+    pub fn spawn(wake: impl Fn() + Send + Sync + 'static) -> Self {
+        if let Ok(mut slot) = WAKER.lock() {
+            *slot = Some(Arc::new(wake));
+        }
+        register_commands();
+        Self {
+            published: None,
+            published_art: None,
+            last_position_update: Instant::now() - POSITION_REFRESH,
+            artwork: Arc::new(Mutex::new(Artwork::default())),
+        }
+    }
+
+    pub fn drain_commands(&self) -> Vec<MediaCommand> {
+        COMMANDS
+            .lock()
+            .map(|mut queue| std::mem::take(&mut *queue))
+            .unwrap_or_default()
+    }
+
+    pub fn update(&mut self, state: MediaState) {
+        let art_url = state.track.as_ref().and_then(|track| track.art_url.clone());
+        self.request_artwork(art_url.as_deref());
+
+        let art_ready = self.ready_artwork_url();
+        let position_due = self.last_position_update.elapsed() >= POSITION_REFRESH;
+        let changed = match &self.published {
+            Some(published) => !same_except_position(published, &state),
+            None => true,
+        };
+        if !changed && !position_due && art_ready == self.published_art {
+            return;
+        }
+
+        if let Ok(mut slot) = CURRENT_URI.lock() {
+            *slot = state.track.as_ref().map(|track| track.uri.clone());
+        }
+        self.apply(&state, art_ready.is_some());
+        self.published_art = art_ready;
+        self.published = Some(state);
+        self.last_position_update = Instant::now();
+    }
+
+    pub fn seeked(&self, _position_ms: u32) {
+        // The next update carries the position; forcing one here would race
+        // the state the interface has not applied yet.
+    }
+
+    fn apply(&self, state: &MediaState, with_artwork: bool) {
+        let center = unsafe { MPNowPlayingInfoCenter::defaultCenter() };
+        let Some(track) = state.track.as_ref() else {
+            unsafe {
+                center.setNowPlayingInfo(None);
+                center.setPlaybackState(MPNowPlayingPlaybackState::Stopped);
+            }
+            return;
+        };
+
+        let rate = if state.playback == Playback::Playing {
+            1.0
+        } else {
+            0.0
+        };
+        let mut keys: Vec<&NSString> = vec![
+            unsafe { MPMediaItemPropertyTitle },
+            unsafe { MPMediaItemPropertyArtist },
+            unsafe { MPMediaItemPropertyAlbumTitle },
+            unsafe { MPMediaItemPropertyPlaybackDuration },
+            unsafe { MPNowPlayingInfoPropertyElapsedPlaybackTime },
+            unsafe { MPNowPlayingInfoPropertyPlaybackRate },
+        ];
+        let mut values: Vec<Retained<AnyObject>> = vec![
+            into_object(NSString::from_str(&track.title)),
+            into_object(NSString::from_str(&track.artists.join(", "))),
+            into_object(NSString::from_str(&track.album)),
+            into_object(NSNumber::new_f64(f64::from(track.duration_ms) / 1000.0)),
+            into_object(NSNumber::new_f64(f64::from(state.position_ms) / 1000.0)),
+            into_object(NSNumber::new_f64(rate)),
+        ];
+        if with_artwork && let Some(artwork) = self.build_artwork() {
+            keys.push(unsafe { MPMediaItemPropertyArtwork });
+            values.push(into_object(artwork));
+        }
+
+        let info = NSDictionary::from_vec(&keys, values);
+        unsafe {
+            center.setNowPlayingInfo(Some(&info));
+            center.setPlaybackState(match state.playback {
+                Playback::Playing | Playback::Loading => MPNowPlayingPlaybackState::Playing,
+                Playback::Paused => MPNowPlayingPlaybackState::Paused,
+                Playback::Stopped => MPNowPlayingPlaybackState::Stopped,
+            });
+        }
+    }
+
+    /// The URL whose bytes are downloaded and ready to publish.
+    fn ready_artwork_url(&self) -> Option<String> {
+        let artwork = self.artwork.lock().ok()?;
+        artwork.bytes.as_ref()?;
+        artwork.url.clone()
+    }
+
+    fn build_artwork(&self) -> Option<Retained<MPMediaItemArtwork>> {
+        let bytes = self.artwork.lock().ok()?.bytes.clone()?;
+        let data = NSData::with_bytes(&bytes);
+        let image = NSImage::initWithData(NSImage::alloc(), &data)?;
+        let size = CGSize::new(ARTWORK_SIZE, ARTWORK_SIZE);
+        // The handler is called back for whatever size the system wants; one
+        // image answers every request.
+        let handler = RcBlock::new(move |_: CGSize| NonNull::from(&*image));
+        Some(unsafe {
+            MPMediaItemArtwork::initWithBoundsSize_requestHandler(
+                MPMediaItemArtwork::alloc(),
+                size,
+                &handler,
+            )
+        })
+    }
+
+    /// Starts a download when the cover changed, and forgets the old bytes.
+    fn request_artwork(&self, url: Option<&str>) {
+        let Ok(mut artwork) = self.artwork.lock() else {
+            return;
+        };
+        let wanted = url.filter(|url| url.starts_with("http"));
+        if artwork.attempted.as_deref() == wanted {
+            return;
+        }
+        let Some(wanted) = wanted else {
+            *artwork = Artwork::default();
+            return;
+        };
+        artwork.bytes = None;
+        artwork.url = None;
+        artwork.attempted = Some(wanted.to_string());
+        drop(artwork);
+
+        let slot = Arc::clone(&self.artwork);
+        let url = wanted.to_string();
+        let spawned = std::thread::Builder::new()
+            .name("fastpotify-now-playing-art".to_string())
+            .spawn(move || {
+                let bytes = reqwest::blocking::get(&url)
+                    .and_then(|response| response.error_for_status())
+                    .and_then(|response| response.bytes());
+                let Ok(mut artwork) = slot.lock() else {
+                    return;
+                };
+                if artwork.attempted.as_deref() != Some(url.as_str()) {
+                    return;
+                }
+                match bytes {
+                    Ok(bytes) => {
+                        artwork.bytes = Some(bytes.to_vec());
+                        artwork.url = Some(url);
+                    }
+                    Err(error) => log::debug!("no Now Playing artwork for {url}: {error}"),
+                }
+                drop(artwork);
+                let wake = WAKER.lock().ok().and_then(|waker| waker.clone());
+                if let Some(wake) = wake {
+                    wake();
+                }
+            });
+        if let Err(error) = spawned {
+            log::warn!("unable to fetch Now Playing artwork: {error}");
+        }
+    }
+}
+
+fn into_object<T: objc2::Message>(value: Retained<T>) -> Retained<AnyObject> {
+    unsafe { Retained::cast(value) }
+}
+
+fn same_except_position(left: &MediaState, right: &MediaState) -> bool {
+    left.playback == right.playback
+        && left.track == right.track
+        && left.can_control == right.can_control
+}
+
+fn register_commands() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static REGISTERED: AtomicBool = AtomicBool::new(false);
+    if REGISTERED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    let center = unsafe { MPRemoteCommandCenter::sharedCommandCenter() };
+    let simple: [(Retained<objc2_media_player::MPRemoteCommand>, MediaCommand); 6] = unsafe {
+        [
+            (center.playCommand(), MediaCommand::Play),
+            (center.pauseCommand(), MediaCommand::Pause),
+            (center.togglePlayPauseCommand(), MediaCommand::PlayPause),
+            (center.stopCommand(), MediaCommand::Stop),
+            (center.nextTrackCommand(), MediaCommand::Next),
+            (center.previousTrackCommand(), MediaCommand::Previous),
+        ]
+    };
+    for (command, message) in simple {
+        let handler = RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
+            push(message.clone());
+            MPRemoteCommandHandlerStatus::Success
+        });
+        unsafe {
+            command.setEnabled(true);
+            command.addTargetWithHandler(&handler);
+        }
+    }
+
+    let skip_ms = (SKIP_INTERVAL_SECONDS * 1000.0) as i64;
+    let intervals =
+        objc2_foundation::NSArray::from_vec(vec![NSNumber::new_f64(SKIP_INTERVAL_SECONDS)]);
+    for (command, offset) in unsafe {
+        [
+            (center.skipForwardCommand(), skip_ms),
+            (center.skipBackwardCommand(), -skip_ms),
+        ]
+    } {
+        let handler = RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
+            push(MediaCommand::SeekBy(offset));
+            MPRemoteCommandHandlerStatus::Success
+        });
+        unsafe {
+            command.setPreferredIntervals(&intervals);
+            command.setEnabled(true);
+            command.addTargetWithHandler(&handler);
+        }
+    }
+
+    let scrub = unsafe { center.changePlaybackPositionCommand() };
+    let handler = RcBlock::new(move |event: NonNull<MPRemoteCommandEvent>| {
+        let seconds = unsafe {
+            let event: &MPChangePlaybackPositionCommandEvent = event.cast().as_ref();
+            event.positionTime()
+        };
+        match seek_command(seconds) {
+            Some(command) => {
+                push(command);
+                MPRemoteCommandHandlerStatus::Success
+            }
+            None => MPRemoteCommandHandlerStatus::NoActionableNowPlayingItem,
+        }
+    });
+    unsafe {
+        scrub.setEnabled(true);
+        scrub.addTargetWithHandler(&handler);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::MediaTrack;
+
+    fn controls() -> MediaControls {
+        MediaControls {
+            published: None,
+            published_art: None,
+            last_position_update: Instant::now(),
+            artwork: Arc::new(Mutex::new(Artwork::default())),
+        }
+    }
+
+    #[test]
+    fn a_track_reaches_the_now_playing_centre_and_stopping_clears_it() {
+        let state = MediaState {
+            playback: Playback::Playing,
+            track: Some(MediaTrack {
+                uri: "spotify:track:abc".into(),
+                title: "Blue Monday".into(),
+                artists: vec!["New Order".into()],
+                album: "Power, Corruption & Lies".into(),
+                art_url: None,
+                duration_ms: 448_000,
+            }),
+            position_ms: 12_000,
+            ..MediaState::default()
+        };
+        controls().apply(&state, false);
+
+        let center = unsafe { MPNowPlayingInfoCenter::defaultCenter() };
+        let info = unsafe { center.nowPlayingInfo() }.expect("the centre took the info");
+        assert_eq!(
+            text(&info, unsafe { MPMediaItemPropertyTitle }),
+            Some("Blue Monday".to_string())
+        );
+        assert_eq!(
+            text(&info, unsafe { MPMediaItemPropertyArtist }),
+            Some("New Order".to_string())
+        );
+        assert_eq!(
+            number(&info, unsafe { MPMediaItemPropertyPlaybackDuration }),
+            Some(448.0)
+        );
+        assert_eq!(
+            number(&info, unsafe { MPNowPlayingInfoPropertyPlaybackRate }),
+            Some(1.0)
+        );
+        assert_eq!(
+            unsafe { center.playbackState() },
+            MPNowPlayingPlaybackState::Playing
+        );
+
+        // Same test: the centre is process-wide, so clearing it cannot be a
+        // second one running alongside this.
+        controls().apply(&MediaState::default(), false);
+        assert!(unsafe { center.nowPlayingInfo() }.is_none());
+        assert_eq!(
+            unsafe { center.playbackState() },
+            MPNowPlayingPlaybackState::Stopped
+        );
+    }
+
+    fn text(info: &NSDictionary<NSString, AnyObject>, key: &NSString) -> Option<String> {
+        let value = info.get(key)?;
+        let value: &NSString = unsafe { &*(value as *const AnyObject).cast() };
+        Some(value.to_string())
+    }
+
+    fn number(info: &NSDictionary<NSString, AnyObject>, key: &NSString) -> Option<f64> {
+        let value = info.get(key)?;
+        let value: &NSNumber = unsafe { &*(value as *const AnyObject).cast() };
+        Some(value.as_f64())
+    }
+}


### PR DESCRIPTION
macOS has no desktop media controls today. The F7-F9 keys, Control Centre, the lock screen and the AirPods pinch all reach whatever else is playing, and Linux gets MPRIS while macOS gets the no-op stub.

Two commits, and the first is worth reading on its own.

## 1. Name the media-control vocabulary for what it is

`MprisCommand`, `MprisState` and `MprisTrack` were defined twice, once in `mpris.rs` and once in `mpris_stub.rs`, and every platform that is not Linux imported MPRIS-named types to say it had none.

They move to `src/media.rs`, imported by both platform modules, so there is one definition instead of two copies to keep in step. `lib.rs` routes `media_controls` per platform, `MprisService` becomes `MediaControls`, `AppOptions::mpris` becomes `media_controls`. Names only, no behaviour change, and `single_instance.rs` keeps every MPRIS D-Bus name exactly as it is because those are the wire protocol.

## 2. Put playback on the macOS media keys

`now_playing.rs` registers with `MPNowPlayingInfoCenter` and `MPRemoteCommandCenter` behind the same `MediaControls` interface `mpris.rs` implements, so `app.rs` drives both through one path and neither platform is a special case.

Title, artist, album, duration and elapsed time are published; cover art is fetched off the main thread and handed over as an `NSImage`; play, pause, next, previous, seek and scrub come back as `MediaCommand`s.

Position is published rather than pushed on a timer. The system interpolates from the elapsed time and the playback rate, so a paused track does not creep and there is no repaint budget spent on keeping the lock screen honest.

## Cost

macOS-only: `objc2`, `objc2-foundation`, `objc2-app-kit`, `objc2-media-player`, `block2`. Behind `cfg(target_os = "macos")`, so no other platform compiles or links any of it.

## The bundling catch

macOS routes the media keys to bundled applications only. This is live from `Fastpotify.app` and does nothing from `cargo run`, which is worth knowing before testing it. I added a line to the README saying so.

## Verification

`cargo clippy --all-targets --all-features` and 36 tests clean on aarch64-darwin, including a round trip through the published Now Playing info. Exercised by hand from a signed bundle: media keys, Control Centre, the lock screen, scrubbing from the system UI, and cover art all drive playback.

I cannot test the Linux side of commit 1 here. It is a rename, and `cargo clippy` passes for the tree, but the MPRIS service itself is the thing I have not run.

## Overlap

Independent of #17, #18 and #21, though #21 also adds `objc2` dependencies; whichever lands second will want its `Cargo.toml` block merged rather than added twice.
