### PR TITLE
Name the media-control vocabulary for what it is

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,8 +13,9 @@ use crate::backend::{
     ApiRequest, ApiResponse, AuthStatus, Backend, Command, Event, LocalPlayback, RemoteAction,
     Waker,
 };
+use crate::media::{MediaCommand, MediaState, MediaTrack};
+use crate::media_controls::MediaService;
 use crate::model::*;
-use crate::mpris::{MprisCommand, MprisService, MprisState, MprisTrack};
 use crate::paths::AppDirs;
 use crate::player::{EngineConfig, LoadSpec, LocalState, Playback, PlayerCommand, RepeatMode};
 use crate::settings::{SessionState, Settings, ThemeChoice};
@@ -79,7 +80,7 @@ pub enum Target {
 #[derive(Clone, Copy, Debug)]
 pub struct AppOptions {
     /// Register the MPRIS media-control service (Linux).
-    pub mpris: bool,
+    pub media_controls: bool,
     /// Register the system-tray item (Linux).
     pub tray: bool,
 }
@@ -87,7 +88,7 @@ pub struct AppOptions {
 impl Default for AppOptions {
     fn default() -> Self {
         Self {
-            mpris: true,
+            media_controls: true,
             tray: true,
         }
     }
@@ -99,7 +100,7 @@ pub struct App {
     settings_dirty: bool,
     last_settings_save: Instant,
     pub backend: Backend,
-    mpris: Option<MprisService>,
+    media_controls: Option<MediaService>,
     tray: Option<TrayService>,
     pub window_hidden: bool,
     /// The window should close but the process should stay in the tray.
@@ -214,9 +215,9 @@ impl App {
             waker.clone(),
         );
         let wake = waker.clone();
-        let mpris = options
-            .mpris
-            .then(|| MprisService::spawn(move || wake.wake()));
+        let media_controls = options
+            .media_controls
+            .then(|| MediaService::spawn(move || wake.wake()));
         let wake = waker.clone();
         let tray = options
             .tray
@@ -237,7 +238,7 @@ impl App {
             settings_dirty: false,
             last_settings_save: Instant::now(),
             backend,
-            mpris,
+            media_controls,
             tray,
             window_hidden: false,
             hide_intent: false,
@@ -703,9 +704,9 @@ impl App {
             self.settings_dirty = true;
         }
         if state.seek_sequence != self.local.seek_sequence
-            && let Some(mpris) = &self.mpris
+            && let Some(controls) = &self.media_controls
         {
-            mpris.seeked(state.position_ms);
+            controls.seeked(state.position_ms);
         }
         if let Some(error) = &state.error
             && self.local.error.as_deref() != Some(error.as_str())
@@ -856,38 +857,42 @@ impl App {
         }
     }
 
-    fn handle_mpris(&mut self) {
-        let Some(commands) = self.mpris.as_ref().map(MprisService::drain_commands) else {
+    fn handle_media_commands(&mut self) {
+        let Some(commands) = self
+            .media_controls
+            .as_ref()
+            .map(MediaService::drain_commands)
+        else {
             return;
         };
         for command in commands {
             let playing = self.now_playing().is_some_and(|now| now.playing);
             let action = match command {
-                MprisCommand::Play => (!playing).then_some(Action::TogglePlay),
-                MprisCommand::Pause | MprisCommand::Stop => playing.then_some(Action::TogglePlay),
-                MprisCommand::PlayPause => Some(Action::TogglePlay),
-                MprisCommand::Next => Some(Action::Next),
-                MprisCommand::Previous => Some(Action::Previous),
-                MprisCommand::SeekBy(offset) => Some(Action::SeekBy(offset)),
-                MprisCommand::SetPosition {
+                MediaCommand::Play => (!playing).then_some(Action::TogglePlay),
+                MediaCommand::Pause | MediaCommand::Stop => playing.then_some(Action::TogglePlay),
+                MediaCommand::PlayPause => Some(Action::TogglePlay),
+                MediaCommand::Next => Some(Action::Next),
+                MediaCommand::Previous => Some(Action::Previous),
+                MediaCommand::SeekBy(offset) => Some(Action::SeekBy(offset)),
+                MediaCommand::SetPosition {
                     track_uri,
                     position_ms,
                 } => self
                     .now_playing()
                     .filter(|now| now.uri == track_uri)
                     .map(|_| Action::Seek(position_ms)),
-                MprisCommand::SetVolume(volume) => Some(Action::SetVolume(
+                MediaCommand::SetVolume(volume) => Some(Action::SetVolume(
                     (volume.clamp(0.0, 1.0) * 100.0).round() as u8,
                 )),
-                MprisCommand::SetShuffle(shuffle) => Some(Action::SetShuffle(shuffle)),
-                MprisCommand::SetRepeat(mode) => Some(Action::SetRepeat(mode)),
-                MprisCommand::OpenUri(uri) => Some(Action::PlayContext {
+                MediaCommand::SetShuffle(shuffle) => Some(Action::SetShuffle(shuffle)),
+                MediaCommand::SetRepeat(mode) => Some(Action::SetRepeat(mode)),
+                MediaCommand::OpenUri(uri) => Some(Action::PlayContext {
                     uri,
                     offset_uri: None,
                     offset_index: None,
                 }),
-                MprisCommand::Raise => Some(Action::ShowWindow),
-                MprisCommand::Quit => Some(Action::Quit),
+                MediaCommand::Raise => Some(Action::ShowWindow),
+                MediaCommand::Quit => Some(Action::Quit),
             };
             if let Some(action) = action {
                 self.actions.push(action);
@@ -895,9 +900,9 @@ impl App {
         }
     }
 
-    fn sync_mpris(&mut self) {
+    fn sync_media_controls(&mut self) {
         let state = match self.now_playing() {
-            Some(now) => MprisState {
+            Some(now) => MediaState {
                 playback: if now.playing {
                     Playback::Playing
                 } else if now.loading {
@@ -905,7 +910,7 @@ impl App {
                 } else {
                     Playback::Paused
                 },
-                track: Some(MprisTrack {
+                track: Some(MediaTrack {
                     uri: now.uri.clone(),
                     title: now.title.clone(),
                     artists: now
@@ -923,10 +928,10 @@ impl App {
                 repeat: now.repeat,
                 can_control: now.can_control,
             },
-            None => MprisState::default(),
+            None => MediaState::default(),
         };
-        if let Some(mpris) = &mut self.mpris {
-            mpris.update(state);
+        if let Some(controls) = &mut self.media_controls {
+            controls.update(state);
         }
         let playing = self.now_playing().is_some_and(|now| now.playing);
         if let Some(tray) = &mut self.tray {
@@ -2699,11 +2704,11 @@ impl App {
             self.actions.push(Action::ShowWindow);
         }
         self.handle_events();
-        self.handle_mpris();
+        self.handle_media_commands();
         self.handle_tray();
         self.tick(ctx);
         self.apply_actions(ctx);
-        self.sync_mpris();
+        self.sync_media_controls();
     }
 
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
@@ -2713,7 +2718,7 @@ impl App {
         self.lock_scroll_axis(ctx);
         crate::ui::show(self, ui);
         self.apply_actions(ctx);
-        self.sync_mpris();
+        self.sync_media_controls();
 
         let playing = self.now_playing().is_some_and(|now| now.playing);
         if playing {
@@ -2878,7 +2883,7 @@ mod tests {
             dirs,
             Settings::default(),
             AppOptions {
-                mpris: false,
+                media_controls: false,
                 tray: false,
             },
         );

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -585,7 +585,7 @@ mod tests {
             dirs,
             Settings::default(),
             AppOptions {
-                mpris: false,
+                media_controls: false,
                 tray: false,
             },
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ pub mod backend;
 #[cfg(any(test, feature = "demo"))]
 pub mod demo;
 pub mod images;
-pub mod model;
+pub mod media;
 #[cfg(target_os = "linux")]
-pub mod mpris;
+#[path = "mpris.rs"]
+pub mod media_controls;
 #[cfg(not(target_os = "linux"))]
 #[path = "media_native.rs"]
-pub mod mpris;
+pub mod media_controls;
+pub mod model;
 pub mod paths;
 pub mod player;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> eframe::Result<()> {
     #[cfg(feature = "demo")]
     if cli.demo_shot.is_some() {
         options = app::AppOptions {
-            mpris: false,
+            media_controls: false,
             tray: false,
         };
     }

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,0 +1,60 @@
+//! What the desktop's own media controls say and hear.
+//!
+//! MPRIS on Linux, the System Media Transport Controls on Windows and Now
+//! Playing on macOS answer the same questions, so the interface speaks this
+//! vocabulary and each platform module translates it.
+
+use crate::player::{Playback, RepeatMode};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum MediaCommand {
+    Play,
+    Pause,
+    PlayPause,
+    Stop,
+    Next,
+    Previous,
+    SeekBy(i64),
+    SetPosition { track_uri: String, position_ms: u32 },
+    SetVolume(f64),
+    SetShuffle(bool),
+    SetRepeat(RepeatMode),
+    OpenUri(String),
+    Raise,
+    Quit,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MediaTrack {
+    pub uri: String,
+    pub title: String,
+    pub artists: Vec<String>,
+    pub album: String,
+    pub art_url: Option<String>,
+    pub duration_ms: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MediaState {
+    pub playback: Playback,
+    pub track: Option<MediaTrack>,
+    pub position_ms: u32,
+    pub volume: f64,
+    pub shuffle: bool,
+    pub repeat: RepeatMode,
+    pub can_control: bool,
+}
+
+impl Default for MediaState {
+    fn default() -> Self {
+        Self {
+            playback: Playback::Stopped,
+            track: None,
+            position_ms: 0,
+            volume: 1.0,
+            shuffle: false,
+            repeat: RepeatMode::Off,
+            can_control: true,
+        }
+    }
+}

--- a/src/media_native.rs
+++ b/src/media_native.rs
@@ -18,97 +18,45 @@ use souvlaki::{
     SeekDirection,
 };
 
-use crate::player::{Playback, RepeatMode};
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum MprisCommand {
-    Play,
-    Pause,
-    PlayPause,
-    Stop,
-    Next,
-    Previous,
-    SeekBy(i64),
-    SetPosition { track_uri: String, position_ms: u32 },
-    SetVolume(f64),
-    SetShuffle(bool),
-    SetRepeat(RepeatMode),
-    OpenUri(String),
-    Raise,
-    Quit,
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct MprisTrack {
-    pub uri: String,
-    pub title: String,
-    pub artists: Vec<String>,
-    pub album: String,
-    pub art_url: Option<String>,
-    pub duration_ms: u32,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct MprisState {
-    pub playback: Playback,
-    pub track: Option<MprisTrack>,
-    pub position_ms: u32,
-    pub volume: f64,
-    pub shuffle: bool,
-    pub repeat: RepeatMode,
-    pub can_control: bool,
-}
-
-impl Default for MprisState {
-    fn default() -> Self {
-        Self {
-            playback: Playback::Stopped,
-            track: None,
-            position_ms: 0,
-            volume: 1.0,
-            shuffle: false,
-            repeat: RepeatMode::Off,
-            can_control: true,
-        }
-    }
-}
+use crate::media::{MediaCommand, MediaState};
+use crate::player::Playback;
 
 type Wake = Arc<dyn Fn() + Send + Sync>;
 
 /// How far a seek button without an amount moves.
 const SEEK_STEP_MS: i64 = 10_000;
 
-fn command_for(event: MediaControlEvent, track_uri: &str) -> Option<MprisCommand> {
+fn command_for(event: MediaControlEvent, track_uri: &str) -> Option<MediaCommand> {
     let step = |direction: SeekDirection, ms: i64| match direction {
-        SeekDirection::Forward => MprisCommand::SeekBy(ms),
-        SeekDirection::Backward => MprisCommand::SeekBy(-ms),
+        SeekDirection::Forward => MediaCommand::SeekBy(ms),
+        SeekDirection::Backward => MediaCommand::SeekBy(-ms),
     };
     Some(match event {
-        MediaControlEvent::Play => MprisCommand::Play,
-        MediaControlEvent::Pause => MprisCommand::Pause,
-        MediaControlEvent::Toggle => MprisCommand::PlayPause,
-        MediaControlEvent::Next => MprisCommand::Next,
-        MediaControlEvent::Previous => MprisCommand::Previous,
-        MediaControlEvent::Stop => MprisCommand::Stop,
+        MediaControlEvent::Play => MediaCommand::Play,
+        MediaControlEvent::Pause => MediaCommand::Pause,
+        MediaControlEvent::Toggle => MediaCommand::PlayPause,
+        MediaControlEvent::Next => MediaCommand::Next,
+        MediaControlEvent::Previous => MediaCommand::Previous,
+        MediaControlEvent::Stop => MediaCommand::Stop,
         MediaControlEvent::Seek(direction) => step(direction, SEEK_STEP_MS),
         MediaControlEvent::SeekBy(direction, amount) => {
             step(direction, amount.as_millis().min(i64::MAX as u128) as i64)
         }
-        MediaControlEvent::SetPosition(position) => MprisCommand::SetPosition {
+        MediaControlEvent::SetPosition(position) => MediaCommand::SetPosition {
             track_uri: track_uri.to_string(),
             position_ms: position.0.as_millis().min(u32::MAX as u128) as u32,
         },
-        MediaControlEvent::SetVolume(volume) => MprisCommand::SetVolume(volume),
-        MediaControlEvent::OpenUri(uri) => MprisCommand::OpenUri(uri),
-        MediaControlEvent::Raise => MprisCommand::Raise,
-        MediaControlEvent::Quit => MprisCommand::Quit,
+        MediaControlEvent::SetVolume(volume) => MediaCommand::SetVolume(volume),
+        MediaControlEvent::OpenUri(uri) => MediaCommand::OpenUri(uri),
+        MediaControlEvent::Raise => MediaCommand::Raise,
+        MediaControlEvent::Quit => MediaCommand::Quit,
     })
 }
 
 /// The controls, and what they were last told, so only changes are sent.
 struct Bridge {
     controls: MediaControls,
-    last: MprisState,
+    last: MediaState,
     /// The playing track, for a "set position" request to name.
     track_uri: Arc<std::sync::Mutex<String>>,
 }
@@ -116,7 +64,7 @@ struct Bridge {
 impl Bridge {
     fn new(
         hwnd: Option<*mut std::ffi::c_void>,
-        sender: Sender<MprisCommand>,
+        sender: Sender<MediaCommand>,
         wake: Wake,
     ) -> Result<Self, String> {
         let mut controls = MediaControls::new(PlatformConfig {
@@ -139,12 +87,12 @@ impl Bridge {
             .map_err(|error| error.to_string())?;
         Ok(Self {
             controls,
-            last: MprisState::default(),
+            last: MediaState::default(),
             track_uri,
         })
     }
 
-    fn apply(&mut self, state: MprisState) {
+    fn apply(&mut self, state: MediaState) {
         let track_changed = state.track != self.last.track;
         if track_changed {
             let artist = state
@@ -197,7 +145,7 @@ impl Bridge {
 
 /// What the app sends to the controls.
 enum Update {
-    State(MprisState),
+    State(MediaState),
     Seeked(u32),
 }
 
@@ -264,7 +212,7 @@ mod host {
     /// Runs the controls on their own thread. Answers with the thread's id
     /// once they exist, or with why they could not be made.
     pub fn start(
-        sender: Sender<MprisCommand>,
+        sender: Sender<MediaCommand>,
         wake: Wake,
         updates: Receiver<Update>,
     ) -> Result<u32, String> {
@@ -322,15 +270,15 @@ mod host {
 }
 
 #[cfg(windows)]
-pub struct MprisService {
-    commands: Receiver<MprisCommand>,
+pub struct MediaService {
+    commands: Receiver<MediaCommand>,
     /// Where updates go, and the thread to wake for them; `None` when the
     /// controls could not be made.
     updates: Option<(Sender<Update>, u32)>,
 }
 
 #[cfg(windows)]
-impl MprisService {
+impl MediaService {
     pub fn spawn(wake: impl Fn() + Send + Sync + 'static) -> Self {
         let (sender, commands) = std::sync::mpsc::channel();
         let (update_tx, update_rx) = std::sync::mpsc::channel();
@@ -344,11 +292,11 @@ impl MprisService {
         Self { commands, updates }
     }
 
-    pub fn drain_commands(&self) -> Vec<MprisCommand> {
+    pub fn drain_commands(&self) -> Vec<MediaCommand> {
         self.commands.try_iter().collect()
     }
 
-    pub fn update(&mut self, state: MprisState) {
+    pub fn update(&mut self, state: MediaState) {
         self.send(Update::State(state));
     }
 
@@ -366,13 +314,13 @@ impl MprisService {
 }
 
 #[cfg(target_os = "macos")]
-pub struct MprisService {
-    commands: Receiver<MprisCommand>,
+pub struct MediaService {
+    commands: Receiver<MediaCommand>,
     bridge: std::sync::Mutex<Option<Bridge>>,
 }
 
 #[cfg(target_os = "macos")]
-impl MprisService {
+impl MediaService {
     pub fn spawn(wake: impl Fn() + Send + Sync + 'static) -> Self {
         let (sender, commands) = std::sync::mpsc::channel();
         let bridge = match Bridge::new(None, sender, Arc::new(wake)) {
@@ -388,11 +336,11 @@ impl MprisService {
         }
     }
 
-    pub fn drain_commands(&self) -> Vec<MprisCommand> {
+    pub fn drain_commands(&self) -> Vec<MediaCommand> {
         self.commands.try_iter().collect()
     }
 
-    pub fn update(&mut self, state: MprisState) {
+    pub fn update(&mut self, state: MediaState) {
         self.with_bridge(|bridge| bridge.apply(state));
     }
 

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -12,77 +12,25 @@ use std::time::{Duration, Instant};
 use mpris_server::{LoopStatus, Metadata, PlaybackStatus, Player, Time, TrackId};
 use tokio::sync::mpsc as tokio_mpsc;
 
+use crate::media::{MediaCommand, MediaState, MediaTrack};
 use crate::player::{Playback, RepeatMode};
 
 const PLAYING_POSITION_INTERVAL: Duration = Duration::from_millis(1000);
 const TRACK_OBJECT_PATH_PREFIX: &str = "/me/paolino/Fastpotify/Track/";
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum MprisCommand {
-    Play,
-    Pause,
-    PlayPause,
-    Stop,
-    Next,
-    Previous,
-    SeekBy(i64),
-    SetPosition { track_uri: String, position_ms: u32 },
-    SetVolume(f64),
-    SetShuffle(bool),
-    SetRepeat(RepeatMode),
-    OpenUri(String),
-    Raise,
-    Quit,
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct MprisTrack {
-    pub uri: String,
-    pub title: String,
-    pub artists: Vec<String>,
-    pub album: String,
-    pub art_url: Option<String>,
-    pub duration_ms: u32,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct MprisState {
-    pub playback: Playback,
-    pub track: Option<MprisTrack>,
-    pub position_ms: u32,
-    pub volume: f64,
-    pub shuffle: bool,
-    pub repeat: RepeatMode,
-    pub can_control: bool,
-}
-
-impl Default for MprisState {
-    fn default() -> Self {
-        Self {
-            playback: Playback::Stopped,
-            track: None,
-            position_ms: 0,
-            volume: 1.0,
-            shuffle: false,
-            repeat: RepeatMode::Off,
-            can_control: true,
-        }
-    }
-}
-
 enum Update {
-    State(MprisState),
+    State(MediaState),
     Seeked(u32),
 }
 
-pub struct MprisService {
+pub struct MediaService {
     updates: tokio_mpsc::UnboundedSender<Update>,
-    commands: Receiver<MprisCommand>,
-    published: Option<MprisState>,
+    commands: Receiver<MediaCommand>,
+    published: Option<MediaState>,
     last_position_update: Instant,
 }
 
-impl MprisService {
+impl MediaService {
     pub fn spawn(wake: impl Fn() + Send + Sync + 'static) -> Self {
         let (updates, update_rx) = tokio_mpsc::unbounded_channel();
         let (command_tx, commands) = std::sync::mpsc::channel();
@@ -117,13 +65,13 @@ impl MprisService {
         }
     }
 
-    pub fn drain_commands(&self) -> Vec<MprisCommand> {
+    pub fn drain_commands(&self) -> Vec<MediaCommand> {
         self.commands.try_iter().collect()
     }
 
     /// Publishes structural changes immediately; the position once a second
     /// while playing, since clients interpolate between updates.
-    pub fn update(&mut self, state: MprisState) {
+    pub fn update(&mut self, state: MediaState) {
         let structural = self
             .published
             .as_ref()
@@ -148,7 +96,7 @@ impl MprisService {
     }
 }
 
-fn same_except_position(left: &MprisState, right: &MprisState) -> bool {
+fn same_except_position(left: &MediaState, right: &MediaState) -> bool {
     left.playback == right.playback
         && left.track == right.track
         && (left.volume - right.volume).abs() < 0.005
@@ -159,7 +107,7 @@ fn same_except_position(left: &MprisState, right: &MprisState) -> bool {
 
 async fn run(
     mut updates: tokio_mpsc::UnboundedReceiver<Update>,
-    commands: Sender<MprisCommand>,
+    commands: Sender<MediaCommand>,
     wake: std::sync::Arc<dyn Fn() + Send + Sync>,
 ) -> mpris_server::zbus::Result<()> {
     let player = Player::builder("fastpotify")
@@ -180,7 +128,7 @@ async fn run(
     let send = {
         let commands = commands.clone();
         let wake = wake.clone();
-        move |command: MprisCommand| {
+        move |command: MediaCommand| {
             if commands.send(command).is_ok() {
                 wake();
             }
@@ -188,37 +136,37 @@ async fn run(
     };
     {
         let send = send.clone();
-        player.connect_play(move |_| send(MprisCommand::Play));
+        player.connect_play(move |_| send(MediaCommand::Play));
     }
     {
         let send = send.clone();
-        player.connect_pause(move |_| send(MprisCommand::Pause));
+        player.connect_pause(move |_| send(MediaCommand::Pause));
     }
     {
         let send = send.clone();
-        player.connect_play_pause(move |_| send(MprisCommand::PlayPause));
+        player.connect_play_pause(move |_| send(MediaCommand::PlayPause));
     }
     {
         let send = send.clone();
-        player.connect_stop(move |_| send(MprisCommand::Stop));
+        player.connect_stop(move |_| send(MediaCommand::Stop));
     }
     {
         let send = send.clone();
-        player.connect_next(move |_| send(MprisCommand::Next));
+        player.connect_next(move |_| send(MediaCommand::Next));
     }
     {
         let send = send.clone();
-        player.connect_previous(move |_| send(MprisCommand::Previous));
+        player.connect_previous(move |_| send(MediaCommand::Previous));
     }
     {
         let send = send.clone();
-        player.connect_seek(move |_, offset| send(MprisCommand::SeekBy(offset.as_millis())));
+        player.connect_seek(move |_, offset| send(MediaCommand::SeekBy(offset.as_millis())));
     }
     {
         let send = send.clone();
         player.connect_set_position(move |_, track_id, position| {
             if let Some(uri) = uri_from_object_path(track_id.as_str()) {
-                send(MprisCommand::SetPosition {
+                send(MediaCommand::SetPosition {
                     track_uri: uri,
                     position_ms: position.as_millis().max(0) as u32,
                 });
@@ -227,16 +175,16 @@ async fn run(
     }
     {
         let send = send.clone();
-        player.connect_set_volume(move |_, volume| send(MprisCommand::SetVolume(volume)));
+        player.connect_set_volume(move |_, volume| send(MediaCommand::SetVolume(volume)));
     }
     {
         let send = send.clone();
-        player.connect_set_shuffle(move |_, shuffle| send(MprisCommand::SetShuffle(shuffle)));
+        player.connect_set_shuffle(move |_, shuffle| send(MediaCommand::SetShuffle(shuffle)));
     }
     {
         let send = send.clone();
         player.connect_set_loop_status(move |_, status| {
-            send(MprisCommand::SetRepeat(match status {
+            send(MediaCommand::SetRepeat(match status {
                 LoopStatus::None => RepeatMode::Off,
                 LoopStatus::Track => RepeatMode::Track,
                 LoopStatus::Playlist => RepeatMode::Context,
@@ -245,20 +193,20 @@ async fn run(
     }
     {
         let send = send.clone();
-        player.connect_open_uri(move |_, uri| send(MprisCommand::OpenUri(uri.to_string())));
+        player.connect_open_uri(move |_, uri| send(MediaCommand::OpenUri(uri.to_string())));
     }
     {
         let send = send.clone();
-        player.connect_raise(move |_| send(MprisCommand::Raise));
+        player.connect_raise(move |_| send(MediaCommand::Raise));
     }
     {
         let send = send.clone();
-        player.connect_quit(move |_| send(MprisCommand::Quit));
+        player.connect_quit(move |_| send(MediaCommand::Quit));
     }
 
     let server = player.run();
     let apply = async {
-        let mut published: Option<MprisState> = None;
+        let mut published: Option<MediaState> = None;
         while let Some(update) = updates.recv().await {
             match update {
                 Update::Seeked(position_ms) => {
@@ -313,7 +261,7 @@ fn loop_status(mode: RepeatMode) -> LoopStatus {
     }
 }
 
-fn metadata(track: Option<&MprisTrack>) -> Metadata {
+fn metadata(track: Option<&MediaTrack>) -> Metadata {
     let Some(track) = track else {
         return Metadata::new();
     };


### PR DESCRIPTION
Follow-up to #22, which I closed: `ecfd1da` supersedes the feature, but the duplication it left behind is still worth clearing.

`MprisCommand`, `MprisState` and `MprisTrack` are defined twice, identically, once in `mpris.rs` and once in `media_native.rs`. A change to the vocabulary has to be made in both places or the two drift apart silently, since nothing checks they agree.

The naming is also now off. `media_native.rs` talks to the System Media Transport Controls on Windows and to Now Playing on macOS, neither of which is MPRIS, and `lib.rs` routes it under the module name `mpris`.

## What changes

- The three types move to `src/media.rs`, imported by both platform modules. One definition instead of two copies.
- `lib.rs` routes `media_controls` per platform, so the module name says what it is.
- `MprisService` becomes `MediaService`, `AppOptions::mpris` becomes `media_controls`.

`MediaService` rather than the more obvious `MediaControls` because souvlaki already exports a `MediaControls` that `media_native.rs` imports; the two would collide.

`single_instance.rs` is deliberately untouched. Every MPRIS bus name there is the wire protocol and has to stay exactly as it is.

## Verification

Names only, no behaviour change. `cargo fmt --check`, `cargo clippy --all-targets --all-features` and 38 tests clean on aarch64-darwin. The two remaining clippy warnings (`tray_native.rs:298`, the unused `Update` in `media_native.rs`) are already on `main` before this change; I left them alone.

Net 97 lines removed. I built the macOS side; the Linux MPRIS service and the Windows SMTC bridge I have not run, though neither has any logic touched.
