### PR TITLE
Add full top songs page

### DIFF
--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -15,6 +15,11 @@ The player bar at the bottom always shows what is playing, on this
 computer *or* on any other device. Click the title to open its album, the
 artist to open the artist, the heart to save it.
 
+## Home
+
+Home previews your most-played songs. Select **Your top songs** or **Show
+more top songs** to open the complete ranked list.
+
 ## Your Library
 
 The sidebar is your library: filter it by Playlists, Albums, Artists, or

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -874,11 +874,17 @@ impl ApiClient {
         .await
     }
 
-    pub async fn top_tracks(&self, time_range: &str, limit: u32) -> Result<Page<Track>> {
+    pub async fn top_tracks(
+        &self,
+        time_range: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Page<Track>> {
         self.get(
             "/me/top/tracks",
             &[
                 ("limit", limit.to_string()),
+                ("offset", offset.to_string()),
                 ("time_range", time_range.to_string()),
             ],
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -1025,6 +1025,7 @@ impl App {
         }
         match page {
             Page::Home => self.load_home(false),
+            Page::TopSongs => self.load_top_songs(false),
             Page::Search => {}
             Page::LikedSongs => {
                 if !self.library.liked.loaded_once {
@@ -1136,7 +1137,10 @@ impl App {
         self.home.top_tracks = Loadable::Loading;
         self.backend.api(ApiRequest::RecentlyPlayed);
         self.backend.api(ApiRequest::TopArtists);
-        self.backend.api(ApiRequest::TopTracks);
+        self.backend.api(ApiRequest::TopTracks {
+            offset: 0,
+            full: false,
+        });
         for term in DISCOVER_TERMS {
             self.home
                 .discover
@@ -1145,6 +1149,19 @@ impl App {
                 term: (*term).to_string(),
             });
         }
+    }
+
+    fn load_top_songs(&mut self, force: bool) {
+        if self.home.top_songs_loading || (!force && self.home.top_songs_complete) {
+            return;
+        }
+        self.home.top_songs = Loadable::Loading;
+        self.home.top_songs_loading = true;
+        self.home.top_songs_complete = false;
+        self.backend.api(ApiRequest::TopTracks {
+            offset: 0,
+            full: true,
+        });
     }
 
     pub fn load_more(&mut self, page: Page) {
@@ -1225,6 +1242,7 @@ impl App {
     fn reload(&mut self, page: Page) {
         match &page {
             Page::Home => self.load_home(true),
+            Page::TopSongs => self.load_top_songs(true),
             Page::LikedSongs => self.library.liked.reset(),
             Page::Albums => self.library.albums.reset(),
             Page::Artists => self.library.artists.reset(),
@@ -1445,8 +1463,41 @@ impl App {
             ApiResponse::RecentlyPlayed(result) => {
                 self.home.recently_played = Loadable::from_result(result);
             }
-            ApiResponse::TopTracks(result) => {
-                if let Ok(tracks) = &result {
+            ApiResponse::TopTracks {
+                offset,
+                full,
+                result,
+            } => {
+                if full {
+                    match result {
+                        Ok(page) => {
+                            let received = page.items.len() as u32;
+                            let tracks = page.items;
+                            let uris: Vec<String> =
+                                tracks.iter().map(|track| track.uri.clone()).collect();
+                            self.request_contains(uris);
+                            if offset == 0 {
+                                self.home.top_songs = Loadable::Loaded(tracks);
+                            } else if let Some(current) = self.home.top_songs.get_mut() {
+                                current.extend(tracks);
+                            }
+                            if page.next.is_some() && received > 0 && offset + received < 100 {
+                                self.backend.api(ApiRequest::TopTracks {
+                                    offset: offset + received,
+                                    full: true,
+                                });
+                            } else {
+                                self.home.top_songs_loading = false;
+                                self.home.top_songs_complete = true;
+                            }
+                        }
+                        Err(error) => {
+                            self.home.top_songs = Loadable::Failed(error.to_string());
+                            self.home.top_songs_loading = false;
+                        }
+                    }
+                } else if let Ok(page) = result {
+                    let tracks = page.items;
                     let seeds: Vec<String> = tracks
                         .iter()
                         .filter_map(|track| track.id.clone())
@@ -1461,8 +1512,12 @@ impl App {
                     }
                     let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
                     self.request_contains(uris);
+                    self.home.top_tracks = Loadable::Loaded(tracks);
+                } else if offset == 0
+                    && let Err(error) = result
+                {
+                    self.home.top_tracks = Loadable::Failed(error.to_string());
                 }
-                self.home.top_tracks = Loadable::from_result(result);
             }
             ApiResponse::TopArtists(result) => {
                 self.home.top_artists = Loadable::from_result(result);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -51,7 +51,10 @@ pub enum ApiRequest {
     PlaybackState,
     Queue,
     RecentlyPlayed,
-    TopTracks,
+    TopTracks {
+        offset: u32,
+        full: bool,
+    },
     TopArtists,
     Recommendations {
         seed_tracks: Vec<String>,
@@ -188,7 +191,11 @@ pub enum ApiResponse {
     PlaybackState(ApiResult<Option<PlaybackState>>),
     Queue(ApiResult<Queue>),
     RecentlyPlayed(ApiResult<Vec<PlayHistory>>),
-    TopTracks(ApiResult<Vec<Track>>),
+    TopTracks {
+        offset: u32,
+        full: bool,
+        result: ApiResult<Page<Track>>,
+    },
     TopArtists(ApiResult<Vec<Artist>>),
     Recommendations(ApiResult<Vec<Track>>),
     Discover {
@@ -1140,11 +1147,13 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
         ApiRequest::RecentlyPlayed => {
             ApiResponse::RecentlyPlayed(api.recently_played(50).await.map(|page| page.items))
         }
-        ApiRequest::TopTracks => ApiResponse::TopTracks(
-            api.top_tracks("short_term", 20)
-                .await
-                .map(|page| page.items),
-        ),
+        ApiRequest::TopTracks { offset, full } => ApiResponse::TopTracks {
+            result: api
+                .top_tracks("short_term", if full { 50 } else { 20 }, offset)
+                .await,
+            offset,
+            full,
+        },
         ApiRequest::TopArtists => ApiResponse::TopArtists(
             api.top_artists("medium_term", 20)
                 .await

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -421,6 +421,8 @@ pub fn populate(app: &mut App) {
     );
     app.home.top_artists = Loadable::Loaded((0..8).map(artist).collect());
     app.home.top_tracks = Loadable::Loaded(tracks.iter().skip(10).take(10).cloned().collect());
+    app.home.top_songs = Loadable::Loaded(tracks.iter().skip(10).cloned().collect());
+    app.home.top_songs_complete = true;
     app.home.recommendations = Loadable::Loaded(tracks.iter().skip(20).take(10).cloned().collect());
     for term in DISCOVER_TERMS {
         let matching: Vec<Playlist> = playlists
@@ -594,6 +596,7 @@ mod tests {
 
         let pages = [
             Page::Home,
+            Page::TopSongs,
             Page::Search,
             Page::LikedSongs,
             Page::Albums,

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,7 @@ use crate::api::models::*;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Page {
     Home,
+    TopSongs,
     Search,
     LikedSongs,
     Albums,
@@ -27,6 +28,7 @@ impl Page {
     pub fn encode(&self) -> String {
         match self {
             Page::Home => "home".into(),
+            Page::TopSongs => "top-songs".into(),
             Page::Search => "search".into(),
             Page::LikedSongs => "liked".into(),
             Page::Albums => "albums".into(),
@@ -45,6 +47,7 @@ impl Page {
     pub fn decode(text: &str) -> Option<Self> {
         Some(match text {
             "home" => Page::Home,
+            "top-songs" => Page::TopSongs,
             "search" => Page::Search,
             "liked" => Page::LikedSongs,
             "albums" => Page::Albums,
@@ -235,7 +238,12 @@ pub struct Library {
 pub struct HomeData {
     pub recently_played: Loadable<Vec<PlayHistory>>,
     pub top_artists: Loadable<Vec<Artist>>,
+    /// The 20-track preview shown on Home.
     pub top_tracks: Loadable<Vec<Track>>,
+    /// The separately loaded, complete ranking shown by the Top Songs page.
+    pub top_songs: Loadable<Vec<Track>>,
+    pub top_songs_loading: bool,
+    pub top_songs_complete: bool,
     pub recommendations: Loadable<Vec<Track>>,
     pub discover: HashMap<String, Loadable<Vec<Playlist>>>,
     pub requested: bool,

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -352,6 +352,56 @@ fn items_of(
         .collect()
 }
 
+/// A complete, ranked view of the listener's current top tracks.
+pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
+    let palette = app.palette;
+    ui.add_space(12.0);
+    theme::text(ui, "Your top songs", theme::bold(30.0), palette.text);
+    ui.add_space(4.0);
+    theme::text(
+        ui,
+        "Your most-listened tracks from the last four weeks.",
+        theme::regular(13.5),
+        palette.secondary,
+    );
+    ui.add_space(18.0);
+
+    let tracks = match &app.home.top_songs {
+        Loadable::Loaded(tracks) => tracks.clone(),
+        Loadable::Loading | Loadable::NotLoaded => {
+            widgets::loading_row(ui, &palette);
+            return;
+        }
+        Loadable::Failed(error) => {
+            let error = error.clone();
+            widgets::error_row(ui, app, &error, Some(Page::TopSongs));
+            return;
+        }
+    };
+    let items: Vec<(PlayableItem, Option<String>)> = tracks
+        .iter()
+        .cloned()
+        .map(|track| (PlayableItem::Track(track), None))
+        .collect();
+    let uris = tracks.into_iter().map(|track| track.uri).collect();
+    table(
+        app,
+        ui,
+        Table {
+            items: &items,
+            context: RowContext::Uris(uris),
+            show_album: true,
+            show_cover: true,
+            show_added: false,
+            page: Page::TopSongs,
+            loading: app.home.top_songs_loading,
+            error: None,
+            can_load_more: false,
+            filter: "",
+        },
+    );
+}
+
 pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let Some(mut page) = app.playlist_pages.remove(id) else {
         app.ensure_loaded(Page::Playlist(id.to_string()));

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -310,12 +310,20 @@ fn track_list(
     title: &str,
     tracks: Loadable<Vec<crate::api::models::Track>>,
     limit: usize,
+    title_page: Option<Page>,
+    more_label: Option<&str>,
 ) {
     let palette = app.palette;
     let tracks = match tracks {
         Loadable::Loaded(tracks) => tracks,
         Loadable::Loading | Loadable::NotLoaded => {
-            theme::section_title(ui, &palette, title);
+            if let Some(page) = title_page {
+                if theme::link(ui, title, theme::bold(17.0), palette.text).clicked() {
+                    app.actions.push(Action::Open(page));
+                }
+            } else {
+                theme::section_title(ui, &palette, title);
+            }
             widgets::loading_row(ui, &palette);
             ui.add_space(12.0);
             return;
@@ -325,7 +333,13 @@ fn track_list(
     if tracks.is_empty() {
         return;
     }
-    theme::section_title(ui, &palette, title);
+    if let Some(page) = title_page {
+        if theme::link(ui, title, theme::bold(17.0), palette.text).clicked() {
+            app.actions.push(Action::Open(page));
+        }
+    } else {
+        theme::section_title(ui, &palette, title);
+    }
     ui.add_space(4.0);
     let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
     let context = RowContext::Uris(uris);
@@ -346,15 +360,29 @@ fn track_list(
             },
         );
     }
+    if let Some(label) = more_label
+        && items.len() > limit
+        && theme::link(ui, label, theme::semibold(14.0), palette.secondary).clicked()
+    {
+        app.actions.push(Action::Open(Page::TopSongs));
+    }
     ui.add_space(16.0);
 }
 
 fn top_tracks(app: &mut App, ui: &mut egui::Ui) {
     let tracks = app.home.top_tracks.clone();
-    track_list(app, ui, "Your top songs", tracks, 10);
+    track_list(
+        app,
+        ui,
+        "Your top songs",
+        tracks,
+        10,
+        Some(Page::TopSongs),
+        Some("Show more top songs"),
+    );
 }
 
 fn recommendations(app: &mut App, ui: &mut egui::Ui) {
     let tracks = app.home.recommendations.clone();
-    track_list(app, ui, "Recommended for you", tracks, 20);
+    track_list(app, ui, "Recommended for you", tracks, 20, None, None);
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -129,6 +129,7 @@ fn central(app: &mut App, ui: &mut egui::Ui) {
                             ui.set_min_width(ui.available_width());
                             match page {
                                 Page::Home => home::show(app, ui),
+                                Page::TopSongs => collection::top_songs(app, ui),
                                 Page::Search => search::show(app, ui),
                                 Page::LikedSongs => collection::liked(app, ui),
                                 Page::Albums | Page::Artists | Page::Podcasts | Page::Episodes => {


### PR DESCRIPTION
## Summary
- add a dedicated page for the user’s top songs
- link the Home page title and add a “Show more top songs” action below the 10-song preview
- keep Home to one 20-item top-tracks request; load the ranked list separately on the Top Songs page in up to two 50-item pages
- document the complete top-songs view in Everyday Use

## Validation
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib