### PR TITLE
Control the running app from outside its window

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ as one ordinary desktop application rather than a shell plugin.
 - **One instance.** Launching it again surfaces the window that is already
   open instead of starting a rival copy, on every platform.
 - **Desktop integration.** MPRIS on Linux, so media keys, the shell, and
-  `playerctl` see Fastpotify like any other player.
+  `playerctl` see Fastpotify like any other player. On macOS and Windows,
+  `fastpotify next` and its siblings drive the running app from a terminal,
+  a launcher, or a hotkey.
 
 ## Install
 
@@ -151,6 +153,33 @@ Settings → Account.
 | `Ctrl+Q` | Quit |
 
 On macOS, `Cmd` replaces `Ctrl`.
+
+## Controlling it from outside
+
+On Linux, Fastpotify is an MPRIS player, so `playerctl --player=fastpotify
+play-pause` already works.
+
+macOS and Windows have no such bus, so the same verbs are subcommands. They
+talk to the instance already running and print nothing on success:
+
+```
+fastpotify play-pause          fastpotify volume 40
+fastpotify play                fastpotify volume-up [percent]
+fastpotify pause               fastpotify volume-down [percent]
+fastpotify next                fastpotify mute
+fastpotify previous            fastpotify shuffle
+fastpotify seek 15             fastpotify repeat
+fastpotify seek -- -15         fastpotify show
+fastpotify now-playing [--raw]
+```
+
+`now-playing` prints one readable line; `--raw` prints the fields
+tab-separated — state, title, artists, album, position_ms, duration_ms,
+volume, shuffle, repeat — for a script that wants one of them. A verb exits
+non-zero when Fastpotify is not running.
+
+That is enough for a launcher such as Raycast or Alfred to drive playback
+through its own script commands.
 
 ## Settings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,7 @@ use crate::model::*;
 use crate::paths::AppDirs;
 use crate::player::{EngineConfig, LoadSpec, LocalState, Playback, PlayerCommand, RepeatMode};
 use crate::settings::{SessionState, Settings, ThemeChoice};
+use crate::single_instance::ControlCommand;
 use crate::theme::{self, Palette};
 use crate::tray::{TrayCommand, TrayService};
 use crate::util;
@@ -108,9 +109,13 @@ pub struct App {
     /// A hidden app was asked to show itself; the outer loop recreates the
     /// window.
     pub wants_show: bool,
-    /// Set by a second launch that wants this window brought forward, on the
-    /// platforms where that request does not arrive through MPRIS.
-    show_requests: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Commands from control clients (a second `fastpotify <verb>` launch,
+    /// a Raycast script), on the platforms where they do not arrive through
+    /// MPRIS. Drained every frame.
+    control_commands: Option<std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>>>,
+    /// Where the now-playing snapshot goes for the control channel's
+    /// `nowplaying` verb to answer from.
+    control_now_playing: Option<std::sync::Arc<std::sync::Mutex<String>>>,
     /// Sample data is loaded and nothing is asked of Spotify.
     pub offline: bool,
     pub palette: Palette,
@@ -259,7 +264,8 @@ impl App {
             window_hidden: false,
             hide_intent: false,
             wants_show: false,
-            show_requests: None,
+            control_commands: None,
+            control_now_playing: None,
             offline: false,
             palette: Palette::dark(),
             applied_dark: None,
@@ -331,9 +337,11 @@ impl App {
         app
     }
 
-    /// Watches the flag a second launch sets to ask for this window.
-    pub fn set_show_requests(&mut self, flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {
-        self.show_requests = Some(flag);
+    /// Watches the queue control clients fill and keeps their now-playing
+    /// snapshot fresh.
+    pub fn set_remote_control(&mut self, guard: &crate::single_instance::Guard) {
+        self.control_commands = Some(guard.commands());
+        self.control_now_playing = Some(guard.now_playing_slot());
     }
 
     /// Per-window setup: fonts, icons, loaders, theme. Called every time a
@@ -934,6 +942,34 @@ impl App {
         }
     }
 
+    fn handle_control_commands(&mut self) {
+        let Some(queue) = &self.control_commands else {
+            return;
+        };
+        let commands: Vec<ControlCommand> =
+            std::mem::take(&mut *queue.lock().unwrap_or_else(|p| p.into_inner()));
+        for command in commands {
+            let playing = self.now_playing().is_some_and(|now| now.playing);
+            let action = match command {
+                ControlCommand::Show => Some(Action::ShowWindow),
+                ControlCommand::PlayPause => Some(Action::TogglePlay),
+                ControlCommand::Play => (!playing).then_some(Action::TogglePlay),
+                ControlCommand::Pause => playing.then_some(Action::TogglePlay),
+                ControlCommand::Next => Some(Action::Next),
+                ControlCommand::Previous => Some(Action::Previous),
+                ControlCommand::SeekBy(offset) => Some(Action::SeekBy(offset)),
+                ControlCommand::VolumeBy(delta) => Some(Action::VolumeBy(delta)),
+                ControlCommand::SetVolume(volume) => Some(Action::SetVolume(volume.min(100))),
+                ControlCommand::ToggleMute => Some(Action::ToggleMute),
+                ControlCommand::ToggleShuffle => Some(Action::ToggleShuffle),
+                ControlCommand::CycleRepeat => Some(Action::CycleRepeat),
+            };
+            if let Some(action) = action {
+                self.actions.push(action);
+            }
+        }
+    }
+
     fn handle_media_commands(&mut self) {
         let Some(commands) = self
             .media_controls
@@ -1014,6 +1050,37 @@ impl App {
         if let Some(tray) = &mut self.tray {
             tray.set_playing(playing);
         }
+        if let Some(slot) = &self.control_now_playing {
+            let snapshot = self.control_snapshot();
+            *slot.lock().unwrap_or_else(|p| p.into_inner()) = snapshot;
+        }
+    }
+
+    /// One line for the control channel's `nowplaying` verb: tab-separated
+    /// `state, title, artists, album, position_ms, duration_ms, volume,
+    /// shuffle, repeat`, or [`crate::single_instance::NOTHING_PLAYING`].
+    fn control_snapshot(&self) -> String {
+        let Some(now) = self.now_playing() else {
+            return crate::single_instance::NOTHING_PLAYING.to_owned();
+        };
+        let state = if now.playing { "playing" } else { "paused" };
+        let repeat = match now.repeat {
+            RepeatMode::Off => "off",
+            RepeatMode::Context => "context",
+            RepeatMode::Track => "track",
+        };
+        // Tabs separate the fields, so a tab inside one would shift the rest.
+        let clean = |text: &str| text.replace('\t', " ");
+        format!(
+            "{state}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{repeat}",
+            clean(&now.title),
+            clean(&now.subtitle),
+            clean(&now.album_name),
+            now.position_ms,
+            now.duration_ms,
+            now.volume_percent,
+            if now.shuffle { "on" } else { "off" },
+        )
     }
 
     // ---- loading ---------------------------------------------------------------
@@ -2845,11 +2912,7 @@ impl App {
     /// headless loop in `main` drives this with a windowless context while
     /// the app lives in the tray.
     pub fn background_frame(&mut self, ctx: &egui::Context) {
-        if let Some(flag) = &self.show_requests
-            && flag.swap(false, std::sync::atomic::Ordering::SeqCst)
-        {
-            self.actions.push(Action::ShowWindow);
-        }
+        self.handle_control_commands();
         self.handle_events();
         self.handle_media_commands();
         self.handle_tray();
@@ -3081,5 +3144,70 @@ mod tests {
         app.handle_local(snapshot_at(35));
         assert_eq!(volume_to_percent(app.local.volume), 35);
         assert_eq!(volume_to_percent(app.settings.volume), 35);
+    }
+
+    /// What a Raycast script sends becomes the same action a menu pick or a
+    /// media key would produce.
+    #[test]
+    fn a_control_command_becomes_the_action_it_names() {
+        // #given
+        let mut app = headless_app();
+        let queue: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> = Default::default();
+        app.control_commands = Some(std::sync::Arc::clone(&queue));
+
+        // #when
+        queue.lock().expect("the queue").extend([
+            ControlCommand::Next,
+            ControlCommand::Previous,
+            ControlCommand::SeekBy(-15_000),
+            ControlCommand::VolumeBy(10),
+            ControlCommand::SetVolume(240),
+            ControlCommand::ToggleShuffle,
+            ControlCommand::Show,
+        ]);
+        app.handle_control_commands();
+
+        // #then
+        assert!(
+            matches!(
+                app.actions.as_slice(),
+                [
+                    Action::Next,
+                    Action::Previous,
+                    Action::SeekBy(-15_000),
+                    Action::VolumeBy(10),
+                    // A percentage above the scale is clamped, not wrapped.
+                    Action::SetVolume(100),
+                    Action::ToggleShuffle,
+                    Action::ShowWindow,
+                ]
+            ),
+            "{:?}",
+            app.actions
+        );
+        assert!(queue.lock().expect("the queue").is_empty());
+    }
+
+    /// `play` and `pause` say what state to end in, so the one that would
+    /// undo the current state does nothing.
+    #[test]
+    fn play_and_pause_do_not_toggle_the_wrong_way() {
+        let mut app = headless_app();
+        let queue: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> = Default::default();
+        app.control_commands = Some(std::sync::Arc::clone(&queue));
+
+        // Nothing is playing in a headless app, so `pause` has nothing to do
+        // and `play` asks for the toggle.
+        queue
+            .lock()
+            .expect("the queue")
+            .extend([ControlCommand::Pause, ControlCommand::Play]);
+        app.handle_control_commands();
+
+        assert!(
+            matches!(app.actions.as_slice(), [Action::TogglePlay]),
+            "{:?}",
+            app.actions
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(name = "fastpotify", version, about)]
 struct Cli {
+    /// A command for the running instance; without one, the app starts.
+    #[command(subcommand)]
+    control: Option<Control>,
+
     /// Spotify Connect device name for this session.
     #[arg(long)]
     device_name: Option<String>,
@@ -49,8 +53,135 @@ struct Cli {
     demo_shot_delay: u64,
 }
 
+/// Remote control of the running instance, for Raycast scripts, launchers,
+/// and hands on keyboards.
+#[derive(Debug, clap::Subcommand)]
+enum Control {
+    /// Toggle play/pause
+    PlayPause,
+    /// Start playback if paused
+    Play,
+    /// Pause playback if playing
+    Pause,
+    /// Skip to the next track
+    Next,
+    /// Return to the previous track
+    Previous,
+    /// Seek by this many seconds; negative seeks backwards
+    Seek {
+        #[arg(allow_negative_numbers = true)]
+        seconds: i64,
+    },
+    /// Set the volume to a percentage
+    Volume {
+        #[arg(value_parser = clap::value_parser!(u8).range(0..=100))]
+        percent: u8,
+    },
+    /// Raise the volume
+    VolumeUp {
+        #[arg(default_value_t = 10, value_parser = clap::value_parser!(u8).range(1..=100))]
+        percent: u8,
+    },
+    /// Lower the volume
+    VolumeDown {
+        #[arg(default_value_t = 10, value_parser = clap::value_parser!(u8).range(1..=100))]
+        percent: u8,
+    },
+    /// Toggle mute
+    Mute,
+    /// Toggle shuffle
+    Shuffle,
+    /// Cycle the repeat mode
+    Repeat,
+    /// Print the playing track
+    NowPlaying {
+        /// Print the fields tab-separated instead: state, title, artists,
+        /// album, position_ms, duration_ms, volume, shuffle, repeat.
+        #[arg(long)]
+        raw: bool,
+    },
+    /// Bring the window of the running instance forward
+    Show,
+}
+
+/// Sends one control verb to the running instance. Speaks over the
+/// single-instance loopback socket, which Linux does not have.
+#[cfg(not(target_os = "linux"))]
+fn run_control(control: Control) -> i32 {
+    let raw = matches!(control, Control::NowPlaying { raw: true });
+    let verb = match control {
+        Control::PlayPause => "playpause".to_owned(),
+        Control::Play => "play".to_owned(),
+        Control::Pause => "pause".to_owned(),
+        Control::Next => "next".to_owned(),
+        Control::Previous => "previous".to_owned(),
+        Control::Seek { seconds } => format!("seek-by {}", seconds.saturating_mul(1000)),
+        Control::Volume { percent } => format!("volume-set {percent}"),
+        Control::VolumeUp { percent } => format!("volume-by {percent}"),
+        Control::VolumeDown { percent } => format!("volume-by -{percent}"),
+        Control::Mute => "mute".to_owned(),
+        Control::Shuffle => "shuffle".to_owned(),
+        Control::Repeat => "repeat".to_owned(),
+        Control::NowPlaying { .. } => "nowplaying".to_owned(),
+        Control::Show => "show".to_owned(),
+    };
+    match single_instance::send(&verb) {
+        Ok(single_instance::Reply::Ok) => 0,
+        Ok(single_instance::Reply::NowPlaying(snapshot)) => {
+            if raw {
+                println!("{snapshot}");
+            } else {
+                println!("{}", format_now_playing(&snapshot));
+            }
+            0
+        }
+        Err(error) => {
+            eprintln!("Fastpotify is not running, or predates remote control: {error}");
+            1
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_control(_control: Control) -> i32 {
+    eprintln!(
+        "On Linux the running instance speaks MPRIS instead; use e.g. \
+         `playerctl --player=fastpotify play-pause`."
+    );
+    2
+}
+
+/// The `nowplaying` snapshot as one human-readable line.
+#[cfg(not(target_os = "linux"))]
+fn format_now_playing(snapshot: &str) -> String {
+    let mut fields = snapshot.split('\t');
+    let state = fields.next().unwrap_or_default();
+    let title = fields.next().unwrap_or_default();
+    let artists = fields.next().unwrap_or_default();
+    let _album = fields.next();
+    let position_ms: u32 = fields.next().and_then(|ms| ms.parse().ok()).unwrap_or(0);
+    let duration_ms: u32 = fields.next().and_then(|ms| ms.parse().ok()).unwrap_or(0);
+    let clock = |ms: u32| format!("{}:{:02}", ms / 60_000, ms % 60_000 / 1000);
+    match state {
+        "playing" | "paused" => {
+            let mark = if state == "playing" { "▶" } else { "⏸" };
+            format!(
+                "{mark} {title} — {artists}  [{} / {}]",
+                clock(position_ms),
+                clock(duration_ms)
+            )
+        }
+        _ => "Nothing playing".to_owned(),
+    }
+}
+
 fn main() -> eframe::Result<()> {
     let cli = Cli::parse();
+    // A control launch is a client, not a second app: talk to the running
+    // instance and exit before touching the log file it is writing to.
+    if let Some(control) = cli.control {
+        std::process::exit(run_control(control));
+    }
     let default_filter = if cli.verbose {
         "info,librespot=info,fastpotify=debug"
     } else {
@@ -118,7 +249,7 @@ fn main() -> eframe::Result<()> {
     #[allow(unused_mut)]
     let mut app = app::App::new(&waker, dirs, settings, options);
     if let Some(guard) = &instance {
-        app.set_show_requests(guard.show_requests());
+        app.set_remote_control(guard);
     }
     #[cfg(feature = "demo")]
     if demo {

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -1,4 +1,4 @@
-//! One running instance at a time.
+//! One running instance at a time, and its remote-control channel.
 //!
 //! Two copies of Fastpotify fight over things a user notices: two Spotify
 //! Connect devices with the same name, two MPRIS players for the media keys
@@ -24,6 +24,15 @@
 //! yourself" before exiting. It is bound to 127.0.0.1 so no firewall has an
 //! opinion about it, it speaks only to itself, and the operating system
 //! releases the port when the process ends.
+//!
+//! On those platforms the socket doubles as the remote-control channel:
+//! `fastpotify next` (or a Raycast script running it) connects, sends one
+//! `fastpotify:<verb>` line, and reads one reply line. Playback verbs are
+//! acknowledged with `fastpotify:ok` and land in the same action queue the
+//! tray and the media keys feed; `nowplaying` is answered from a snapshot
+//! the app keeps fresh, so the listener thread never touches app state.
+//! Linux needs none of this: MPRIS already gives `playerctl` the same verbs,
+//! so the D-Bus name stays a pure instance guard there.
 
 /// The name held for the lifetime of the running instance.
 #[cfg(target_os = "linux")]
@@ -40,89 +49,248 @@ pub enum Outcome {
     Surfaced,
 }
 
+/// What a control client asked the running instance to do.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ControlCommand {
+    /// Bring the window forward, creating it if the app lives in the tray.
+    Show,
+    PlayPause,
+    Play,
+    Pause,
+    Next,
+    Previous,
+    /// Milliseconds; negative seeks backwards.
+    SeekBy(i64),
+    /// Percentage points; negative lowers the volume.
+    VolumeBy(i8),
+    /// Absolute percentage.
+    SetVolume(u8),
+    ToggleMute,
+    ToggleShuffle,
+    CycleRepeat,
+}
+
 /// Holds whatever marks this process as the running instance. Dropping it
 /// gives that up.
 pub struct Guard {
     #[cfg(target_os = "linux")]
     _connection: Option<mpris_server::zbus::blocking::Connection>,
-    /// Set by a later launch that wants this window brought forward. On Linux
-    /// the same request arrives through MPRIS instead.
-    show_requests: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Filled by control clients, drained by the app every frame. On Linux
+    /// the same requests arrive through MPRIS instead and this stays empty.
+    commands: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>>,
+    /// One line about the current track, kept fresh by the app so the
+    /// listener can answer `nowplaying` without touching app state.
+    now_playing: std::sync::Arc<std::sync::Mutex<String>>,
 }
 
 impl Guard {
-    /// The flag a later launch sets to ask for the window. The interface
-    /// polls it and clears it.
-    pub fn show_requests(&self) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
-        std::sync::Arc::clone(&self.show_requests)
+    /// The queue a control client's commands land in. The app drains it.
+    pub fn commands(&self) -> std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> {
+        std::sync::Arc::clone(&self.commands)
+    }
+
+    /// The slot the app writes the now-playing snapshot into.
+    pub fn now_playing_slot(&self) -> std::sync::Arc<std::sync::Mutex<String>> {
+        std::sync::Arc::clone(&self.now_playing)
     }
 }
+
+/// What the app writes into the snapshot slot before anything plays, and
+/// what `nowplaying` reports when nothing does.
+pub const NOTHING_PLAYING: &str = "stopped";
 
 /// Loopback port that marks a running instance on platforms without a bus.
 /// Registered to nothing; chosen high and out of the ephemeral range.
 #[cfg(not(target_os = "linux"))]
 const INSTANCE_PORT: u16 = 47_113;
 
-/// Sent by a later launch, and answered, so a foreign program that happens to
-/// hold the port is never mistaken for Fastpotify.
+/// Every request and reply starts with this, so a foreign program that
+/// happens to hold the port is never mistaken for Fastpotify.
 #[cfg(not(target_os = "linux"))]
-const SHOW_REQUEST: &[u8] = b"fastpotify:show\n";
+const PREFIX: &str = "fastpotify:";
 #[cfg(not(target_os = "linux"))]
-const SHOW_ACK: &[u8] = b"fastpotify:ok\n";
+const OK_REPLY: &str = "fastpotify:ok";
+#[cfg(not(target_os = "linux"))]
+const NOW_REPLY: &str = "fastpotify:now ";
+
+/// What the running instance said back.
+#[cfg(not(target_os = "linux"))]
+pub enum Reply {
+    /// The command was accepted.
+    Ok,
+    /// The `nowplaying` snapshot: [`NOTHING_PLAYING`], or tab-separated
+    /// `state, title, artists, album, position_ms, duration_ms, volume,
+    /// shuffle, repeat`.
+    NowPlaying(String),
+}
+
+/// Sends one verb to the running instance and reads its reply.
+#[cfg(not(target_os = "linux"))]
+pub fn send(verb: &str) -> std::io::Result<Reply> {
+    send_to(INSTANCE_PORT, verb)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn send_to(port: u16, verb: &str) -> std::io::Result<Reply> {
+    use std::io::{Read, Write};
+    use std::net::{Ipv4Addr, TcpStream};
+    use std::time::Duration;
+
+    let mut stream = TcpStream::connect((Ipv4Addr::LOCALHOST, port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    stream.write_all(format!("{PREFIX}{verb}\n").as_bytes())?;
+    // The listener writes one line and closes, so read to end and keep the
+    // line. An instance predating the control channel ignores unknown verbs
+    // without replying; the read times out and that surfaces as an error.
+    let mut reply = String::new();
+    stream.read_to_string(&mut reply)?;
+    let line = reply.lines().next().unwrap_or("");
+    if line == OK_REPLY {
+        Ok(Reply::Ok)
+    } else if let Some(snapshot) = line.strip_prefix(NOW_REPLY) {
+        Ok(Reply::NowPlaying(snapshot.to_owned()))
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the port is held by something other than Fastpotify",
+        ))
+    }
+}
 
 #[cfg(not(target_os = "linux"))]
 pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
-    use std::io::{Read, Write};
-    use std::net::{Ipv4Addr, TcpListener, TcpStream};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::time::Duration;
+    use std::net::{Ipv4Addr, TcpListener};
+    use std::sync::{Arc, Mutex};
+
+    let unguarded = || Guard {
+        commands: Default::default(),
+        now_playing: Arc::new(Mutex::new(NOTHING_PLAYING.to_owned())),
+    };
 
     let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, INSTANCE_PORT)) {
         Ok(listener) => listener,
         Err(_) => {
             // Someone holds the port. Ask them to show themselves, and only
             // stand down if they answer as Fastpotify.
-            let answered = TcpStream::connect((Ipv4Addr::LOCALHOST, INSTANCE_PORT))
-                .and_then(|mut stream| {
-                    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-                    stream.write_all(SHOW_REQUEST)?;
-                    let mut reply = [0u8; SHOW_ACK.len()];
-                    stream.read_exact(&mut reply)?;
-                    Ok(reply == SHOW_ACK)
-                })
-                .unwrap_or(false);
+            let answered = send("show").is_ok_and(|reply| matches!(reply, Reply::Ok));
             if answered {
                 return Outcome::Surfaced;
             }
             log::warn!("port {INSTANCE_PORT} is busy but not with Fastpotify; running unguarded");
-            return Outcome::Only(Guard {
-                show_requests: Default::default(),
-            });
+            return Outcome::Only(unguarded());
         }
     };
 
-    let show_requests: Arc<AtomicBool> = Default::default();
-    let flag = Arc::clone(&show_requests);
+    let guard = unguarded();
+    let commands = Arc::clone(&guard.commands);
+    let now_playing = Arc::clone(&guard.now_playing);
     let waker = waker.clone();
     let spawned = std::thread::Builder::new()
         .name("fastpotify-instance".to_owned())
-        .spawn(move || {
-            for stream in listener.incoming().flatten() {
-                let mut stream = stream;
-                let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
-                let mut request = [0u8; SHOW_REQUEST.len()];
-                if stream.read_exact(&mut request).is_ok() && request == SHOW_REQUEST {
-                    let _ = stream.write_all(SHOW_ACK);
-                    flag.store(true, Ordering::SeqCst);
-                    waker.wake();
-                }
-            }
-        });
+        .spawn(move || serve(listener, &commands, &now_playing, &waker));
     if let Err(error) = spawned {
         log::warn!("cannot listen for other launches: {error}");
     }
-    Outcome::Only(Guard { show_requests })
+    Outcome::Only(guard)
+}
+
+/// Answers control clients until the listener closes. One request line and
+/// one reply line per connection.
+#[cfg(not(target_os = "linux"))]
+fn serve(
+    listener: std::net::TcpListener,
+    commands: &std::sync::Mutex<Vec<ControlCommand>>,
+    now_playing: &std::sync::Mutex<String>,
+    waker: &crate::backend::Waker,
+) {
+    use std::io::Write;
+    use std::time::Duration;
+
+    for mut stream in listener.incoming().flatten() {
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+        let Some(line) = read_line(&mut stream) else {
+            continue;
+        };
+        match parse(&line) {
+            Some(Request::Command(command)) => {
+                let _ = stream.write_all(format!("{OK_REPLY}\n").as_bytes());
+                commands
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(command);
+                waker.wake();
+            }
+            Some(Request::NowPlaying) => {
+                let snapshot = now_playing
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .clone();
+                let _ = stream.write_all(format!("{NOW_REPLY}{snapshot}\n").as_bytes());
+            }
+            // Not our client; say nothing and hang up.
+            None => {}
+        }
+    }
+}
+
+/// A parsed request line: a command for the app, or a read the listener
+/// answers itself.
+#[cfg(not(target_os = "linux"))]
+enum Request {
+    Command(ControlCommand),
+    NowPlaying,
+}
+
+#[cfg(not(target_os = "linux"))]
+fn parse(line: &str) -> Option<Request> {
+    let verb = line.trim_end().strip_prefix(PREFIX)?;
+    let (verb, argument) = match verb.split_once(' ') {
+        Some((verb, argument)) => (verb, Some(argument.trim())),
+        None => (verb, None),
+    };
+    let command = match (verb, argument) {
+        ("show", None) => ControlCommand::Show,
+        ("playpause", None) => ControlCommand::PlayPause,
+        ("play", None) => ControlCommand::Play,
+        ("pause", None) => ControlCommand::Pause,
+        ("next", None) => ControlCommand::Next,
+        ("previous", None) => ControlCommand::Previous,
+        ("seek-by", Some(ms)) => ControlCommand::SeekBy(ms.parse().ok()?),
+        ("volume-by", Some(delta)) => ControlCommand::VolumeBy(delta.parse().ok()?),
+        ("volume-set", Some(volume)) => ControlCommand::SetVolume(volume.parse().ok()?),
+        ("mute", None) => ControlCommand::ToggleMute,
+        ("shuffle", None) => ControlCommand::ToggleShuffle,
+        ("repeat", None) => ControlCommand::CycleRepeat,
+        ("nowplaying", None) => return Some(Request::NowPlaying),
+        _ => return None,
+    };
+    Some(Request::Command(command))
+}
+
+/// Reads up to the first newline. A line too long to be one of ours, or any
+/// read error, disqualifies the client.
+#[cfg(not(target_os = "linux"))]
+fn read_line(stream: &mut std::net::TcpStream) -> Option<String> {
+    use std::io::Read;
+    let mut buffer = [0u8; 256];
+    let mut filled = 0;
+    loop {
+        if filled == buffer.len() {
+            return None;
+        }
+        match stream.read(&mut buffer[filled..]) {
+            Ok(0) => break,
+            Ok(read) => {
+                filled += read;
+                if buffer[..filled].contains(&b'\n') {
+                    break;
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+    let line = buffer[..filled].split(|&byte| byte == b'\n').next()?;
+    String::from_utf8(line.to_vec()).ok()
 }
 
 #[cfg(target_os = "linux")]
@@ -130,15 +298,18 @@ pub fn acquire(_waker: &crate::backend::Waker) -> Outcome {
     use mpris_server::zbus::blocking::Connection;
     use mpris_server::zbus::fdo::{RequestNameFlags, RequestNameReply};
 
+    let guard = |connection: Option<Connection>| Guard {
+        _connection: connection,
+        commands: Default::default(),
+        now_playing: std::sync::Arc::new(std::sync::Mutex::new(NOTHING_PLAYING.to_owned())),
+    };
+
     let connection = match Connection::session() {
         Ok(connection) => connection,
         Err(error) => {
             // No session bus at all: nothing to coordinate through, so run.
             log::debug!("no session bus, running unguarded: {error}");
-            return Outcome::Only(Guard {
-                _connection: None,
-                show_requests: Default::default(),
-            });
+            return Outcome::Only(guard(None));
         }
     };
 
@@ -147,10 +318,7 @@ pub fn acquire(_waker: &crate::backend::Waker) -> Outcome {
     // than as a reply, so that error is the ordinary second-launch path.
     match connection.request_name_with_flags(INSTANCE_NAME, RequestNameFlags::DoNotQueue.into()) {
         Ok(RequestNameReply::PrimaryOwner | RequestNameReply::AlreadyOwner) => {
-            Outcome::Only(Guard {
-                _connection: Some(connection),
-                show_requests: Default::default(),
-            })
+            Outcome::Only(guard(Some(connection)))
         }
         Ok(_) | Err(mpris_server::zbus::Error::NameTaken) => {
             if !raise_running_instance(&connection) {
@@ -162,10 +330,7 @@ pub fn acquire(_waker: &crate::backend::Waker) -> Outcome {
         }
         Err(error) => {
             log::warn!("cannot check for a running instance, starting anyway: {error}");
-            Outcome::Only(Guard {
-                _connection: None,
-                show_requests: Default::default(),
-            })
+            Outcome::Only(guard(None))
         }
     }
 }
@@ -190,4 +355,112 @@ fn raise_running_instance(connection: &mpris_server::zbus::blocking::Connection)
         }
     }
     false
+}
+
+#[cfg(all(test, not(target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    fn command(line: &str) -> Option<ControlCommand> {
+        match parse(line) {
+            Some(Request::Command(command)) => Some(command),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn parses_every_control_verb() {
+        // #given / #when / #then
+        assert_eq!(command("fastpotify:show\n"), Some(ControlCommand::Show));
+        assert_eq!(
+            command("fastpotify:playpause"),
+            Some(ControlCommand::PlayPause)
+        );
+        assert_eq!(command("fastpotify:play"), Some(ControlCommand::Play));
+        assert_eq!(command("fastpotify:pause"), Some(ControlCommand::Pause));
+        assert_eq!(command("fastpotify:next"), Some(ControlCommand::Next));
+        assert_eq!(
+            command("fastpotify:previous"),
+            Some(ControlCommand::Previous)
+        );
+        assert_eq!(
+            command("fastpotify:seek-by -10000"),
+            Some(ControlCommand::SeekBy(-10_000))
+        );
+        assert_eq!(
+            command("fastpotify:volume-by +5"),
+            Some(ControlCommand::VolumeBy(5))
+        );
+        assert_eq!(
+            command("fastpotify:volume-set 40"),
+            Some(ControlCommand::SetVolume(40))
+        );
+        assert_eq!(command("fastpotify:mute"), Some(ControlCommand::ToggleMute));
+        assert_eq!(
+            command("fastpotify:shuffle"),
+            Some(ControlCommand::ToggleShuffle)
+        );
+        assert_eq!(
+            command("fastpotify:repeat"),
+            Some(ControlCommand::CycleRepeat)
+        );
+        assert!(matches!(
+            parse("fastpotify:nowplaying"),
+            Some(Request::NowPlaying)
+        ));
+    }
+
+    #[test]
+    fn rejects_lines_that_are_not_ours() {
+        assert!(parse("GET / HTTP/1.1").is_none());
+        assert!(parse("fastpotify:frobnicate").is_none());
+        assert!(parse("fastpotify:seek-by soon").is_none());
+        assert!(parse("fastpotify:volume-set 999").is_none());
+        assert!(parse("fastpotify:next please").is_none());
+        assert!(parse("").is_none());
+    }
+
+    /// The whole channel over a real socket: what `fastpotify next` sends is
+    /// what the app finds in its queue, and `nowplaying` reads back the
+    /// snapshot the app published.
+    #[test]
+    fn a_client_reaches_the_command_queue_and_the_snapshot() {
+        use std::net::{Ipv4Addr, TcpListener};
+        use std::sync::{Arc, Mutex};
+
+        // #given
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("a loopback port");
+        let port = listener.local_addr().expect("a bound address").port();
+        let commands: Arc<Mutex<Vec<ControlCommand>>> = Default::default();
+        let now_playing = Arc::new(Mutex::new("playing\tGo\tThe Band".to_owned()));
+        let served = {
+            let commands = Arc::clone(&commands);
+            let now_playing = Arc::clone(&now_playing);
+            let waker = crate::backend::Waker::default();
+            std::thread::spawn(move || serve(listener, &commands, &now_playing, &waker))
+        };
+
+        // #when
+        let accepted = send_to(port, "next").expect("a reply");
+        let volume = send_to(port, "volume-by -5").expect("a reply");
+        let snapshot = send_to(port, "nowplaying").expect("a reply");
+        let refused = send_to(port, "frobnicate");
+
+        // #then
+        assert!(matches!(accepted, Reply::Ok));
+        assert!(matches!(volume, Reply::Ok));
+        match snapshot {
+            Reply::NowPlaying(line) => assert_eq!(line, "playing\tGo\tThe Band"),
+            Reply::Ok => panic!("nowplaying answered with an acknowledgement"),
+        }
+        // An unknown verb gets no reply at all, so the client sees a closed
+        // connection rather than a command it never sent being obeyed.
+        assert!(refused.is_err());
+        assert_eq!(
+            *commands.lock().expect("the queue"),
+            vec![ControlCommand::Next, ControlCommand::VolumeBy(-5)]
+        );
+
+        drop(served);
+    }
 }


### PR DESCRIPTION
## Summary

On macOS and Windows the running Fastpotify can now be driven from outside its window: `fastpotify next`, `play-pause`, `seek`, `volume`, `shuffle`, `repeat`, `now-playing` and the rest reach the instance already running, which is enough for a launcher, a hotkey tool, or a shell script to control playback. Linux already had this through MPRIS and `playerctl`; these platforms had nothing that could address Fastpotify in particular.

## Why not an AppleScript dictionary

That is what Raycast's Spotify extensions use, and it is the obvious macOS answer. It also means an `.sdef`, an Apple event handler, and Objective-C bridging inside an egui app, for one direction of one platform. Media keys were the other candidate: they already work through `MPRemoteCommandCenter`, but they go to whichever app owns Now Playing, so they cannot name Fastpotify, and they carry no volume, seek, or shuffle.

The single-instance socket, in contrast, already exists on exactly the two platforms that lack MPRIS, already carries one verb, and already has a path into the interface. Widening it costs a parser.

## What the protocol does

A request is one `fastpotify:<verb>` line and the answer is one line. Playback verbs are acknowledged and pushed onto the same action queue the tray and the media keys feed, so they take the app's existing local-or-remote routing for free. `nowplaying` is answered from a snapshot the interface publishes each frame, so the listener thread reads no app state and takes no lock the UI holds.

Two things stay as they were. An unknown line still gets no reply at all, so a foreign program that happens to hold port 47113 is told nothing and is never mistaken for Fastpotify. And `fastpotify:show` is byte-for-byte the request and acknowledgement a second launch already sent, so instance detection across a mixed-version pair is unchanged; a new client meeting an older instance gets a clear "not running, or predates remote control" rather than silence.

Linux is deliberately left alone. It keeps MPRIS, and the subcommands there refuse and point at `playerctl` rather than growing a second way to do the same thing.

## Verification

`cargo test --features demo`, `cargo fmt --all --check`, and `cargo clippy --all-targets --features demo -- -D warnings` all pass. Five new tests cover the verb parser, the rejection of lines that are not ours, a client/listener round trip over a real loopback socket, and the command-to-action mapping including the clamp on an out-of-range volume.

Every verb was also run by hand on macOS against a build playing real music: transport, seek, volume, shuffle and repeat all took effect and the snapshot read back the new state. Windows is untested — the code path is the same `not(target_os = "linux")` one, but I have no machine to run it on.
