### PR TITLE
Fold the player bar into an info popup with the streamed quality

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -84,6 +84,8 @@ pub struct NowPlaying {
     pub volume_percent: u8,
     pub can_control: bool,
     pub is_episode: bool,
+    /// Streaming quality of the local player, e.g. "320 kbps OGG".
+    pub quality: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -590,6 +592,7 @@ impl App {
                 volume_percent: volume_to_percent(self.local.volume),
                 can_control: true,
                 is_episode: track.is_episode,
+                quality: track.stream_quality.clone(),
             });
         }
         let remote = self.remote_fresh()?;
@@ -663,6 +666,7 @@ impl App {
             volume_percent: volume,
             can_control: device.is_none_or(|device| !device.is_restricted),
             is_episode,
+            quality: None,
         })
     }
 

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -565,6 +565,36 @@ pub fn apply_flags(app: &mut App, page: Option<&str>, show: Option<&str>) {
         match surface {
             "queue" => app.show_queue_panel = true,
             "devices" => app.show_devices = true,
+            // Playback handed to this computer's own player, so the
+            // playback-info popup shows the file it streams.
+            "local" => {
+                let first = track(0);
+                let album = first.album.clone().unwrap_or_default();
+                let cover = album.images.first().map(|image| image.url.clone());
+                let small = album.images.last().map(|image| image.url.clone());
+                app.local.track = Some(crate::player::LocalTrack {
+                    uri: first.uri.clone(),
+                    title: first.name.clone(),
+                    artists: first
+                        .artists
+                        .iter()
+                        .map(|artist| artist.name.clone())
+                        .collect(),
+                    album: album.name.clone(),
+                    art_url: cover,
+                    art_small_url: small,
+                    duration_ms: first.duration_ms,
+                    is_episode: false,
+                    stream_quality: Some("320 kbps OGG".into()),
+                });
+                app.local.playback = crate::player::Playback::Playing;
+                app.local.position_ms = 42_000;
+                app.local.position_at = Some(Instant::now());
+                app.local.volume = crate::app::percent_to_volume(70);
+                for device in &mut app.devices {
+                    device.is_active = device.id.as_deref() == Some("local-demo");
+                }
+            }
             "shortcuts" => app.dialog = Some(Dialog::Shortcuts),
             "create" => {
                 app.dialog = Some(Dialog::CreatePlaylist {

--- a/src/player.rs
+++ b/src/player.rs
@@ -24,7 +24,7 @@ use librespot_core::{
     session::Session,
     spotify_id::SpotifyId,
 };
-use librespot_metadata::audio::{AudioItem, UniqueFields};
+use librespot_metadata::audio::{AudioFileFormat, AudioItem, UniqueFields};
 use librespot_playback::{
     audio_backend::{self, Sink},
     config::{AudioFormat, Bitrate, NormalisationType, PlayerConfig, VolumeCtrl},
@@ -139,6 +139,12 @@ pub struct LocalTrack {
     pub art_small_url: Option<String>,
     pub duration_ms: u32,
     pub is_episode: bool,
+    /// Human-readable quality of the file the player actually streams for
+    /// this item, e.g. "320 kbps OGG". The format is the first one the
+    /// configured bitrate's preference list offers, so it can fall below the
+    /// configured bitrate (podcasts, unavailable higher formats). `None`
+    /// while unknown and for local files, whose quality is the file's own.
+    pub stream_quality: Option<String>,
 }
 
 impl LocalTrack {
@@ -276,7 +282,12 @@ impl Engine {
             sink_builder(config, Arc::clone(&state), Arc::clone(&notify), &mixer);
         let player = Player::new(player_config, session.clone(), volume, sink_builder);
         let events = player.get_player_event_channel();
-        tokio::spawn(run_events(events, Arc::clone(&state), Arc::clone(&notify)));
+        tokio::spawn(run_events(
+            events,
+            Arc::clone(&state),
+            Arc::clone(&notify),
+            config.bitrate_kbps,
+        ));
 
         let connect_config = ConnectConfig {
             name: config.device_name.clone(),
@@ -489,6 +500,7 @@ async fn run_events(
     mut events: tokio::sync::mpsc::UnboundedReceiver<PlayerEvent>,
     state: Arc<Mutex<LocalState>>,
     notify: Notify,
+    bitrate_kbps: u16,
 ) {
     let mut play_request_id = None;
     while let Some(event) = events.recv().await {
@@ -506,7 +518,7 @@ async fn run_events(
         }
         let snapshot = {
             let mut current = state.lock().unwrap_or_else(|p| p.into_inner());
-            if apply_event(&mut current, event) {
+            if apply_event(&mut current, event, bitrate_kbps) {
                 Some(current.clone())
             } else {
                 None
@@ -527,7 +539,7 @@ fn set<T: PartialEq>(target: &mut T, value: T) -> bool {
     }
 }
 
-fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
+fn apply_event(state: &mut LocalState, event: PlayerEvent, bitrate_kbps: u16) -> bool {
     match event {
         PlayerEvent::Stopped { .. } => {
             let mut changed = set(&mut state.playback, Playback::Stopped);
@@ -575,7 +587,10 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
             true
         }
         PlayerEvent::TrackChanged { audio_item } => {
-            let mut changed = set(&mut state.track, Some(local_track(&audio_item)));
+            let mut changed = set(
+                &mut state.track,
+                Some(local_track(&audio_item, bitrate_kbps)),
+            );
             changed |= set(&mut state.error, None);
             changed
         }
@@ -620,7 +635,7 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
     }
 }
 
-fn local_track(item: &AudioItem) -> LocalTrack {
+fn local_track(item: &AudioItem, bitrate_kbps: u16) -> LocalTrack {
     let (artists, album, is_episode) = match &item.unique_fields {
         UniqueFields::Track { artists, album, .. } => (
             artists.iter().map(|artist| artist.name.clone()).collect(),
@@ -645,6 +660,19 @@ fn local_track(item: &AudioItem) -> LocalTrack {
         .find(|cover| cover.width >= 64)
         .or(covers.last())
         .map(|cover| cover.url.clone());
+    // The first file librespot's own format list would pick for the
+    // configured bitrate: it walks this preference list and takes the first
+    // format the item offers. Episodes and unavailable tracks fall below
+    // the configured bitrate, so this shows the real quality, not the
+    // configured one. Local files are the file's own quality.
+    let stream_quality = if matches!(item.unique_fields, UniqueFields::Local { .. }) {
+        None
+    } else {
+        preferred_formats(bitrate_kbps)
+            .iter()
+            .find(|format| item.files.contains_key(format))
+            .map(|format| format_quality_label(*format))
+    };
     LocalTrack {
         uri: item.uri.clone(),
         title: item.name.clone(),
@@ -654,7 +682,60 @@ fn local_track(item: &AudioItem) -> LocalTrack {
         art_small_url,
         duration_ms: item.duration_ms,
         is_episode,
+        stream_quality,
     }
+}
+
+/// librespot's format preference list for a configured bitrate
+/// (`playback/src/player.rs`): the first format the item offers is the file
+/// that gets streamed.
+fn preferred_formats(bitrate_kbps: u16) -> &'static [AudioFileFormat] {
+    use AudioFileFormat::*;
+    match bitrate_kbps {
+        96 => &[
+            OGG_VORBIS_96,
+            MP3_96,
+            OGG_VORBIS_160,
+            MP3_160,
+            MP3_256,
+            OGG_VORBIS_320,
+            MP3_320,
+        ],
+        160 => &[
+            OGG_VORBIS_160,
+            MP3_160,
+            OGG_VORBIS_96,
+            MP3_96,
+            MP3_256,
+            OGG_VORBIS_320,
+            MP3_320,
+        ],
+        _ => &[
+            OGG_VORBIS_320,
+            MP3_320,
+            MP3_256,
+            OGG_VORBIS_160,
+            MP3_160,
+            OGG_VORBIS_96,
+            MP3_96,
+        ],
+    }
+}
+
+/// Human-readable quality for a streaming format, e.g. "320 kbps OGG".
+pub fn format_quality_label(format: AudioFileFormat) -> String {
+    use AudioFileFormat::*;
+    let (codec, kbps) = match format {
+        OGG_VORBIS_320 => ("OGG", 320),
+        OGG_VORBIS_160 => ("OGG", 160),
+        OGG_VORBIS_96 => ("OGG", 96),
+        MP3_320 => ("MP3", 320),
+        MP3_256 => ("MP3", 256),
+        MP3_160 => ("MP3", 160),
+        MP3_96 => ("MP3", 96),
+        _ => return format!("{format:?}"),
+    };
+    format!("{kbps} kbps {codec}")
 }
 
 #[cfg(test)]
@@ -692,6 +773,7 @@ mod tests {
                 track_id: uri(),
                 position_ms: 0,
             },
+            320,
         );
         assert_eq!(state.playback, Playback::Playing);
     }

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -118,9 +118,11 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         }
     }
 
-    let heart_width = if now.is_episode { 0.0 } else { 42.0 };
+    // The heart and the info button sit just past the text, so the text
+    // region reserves room for whatever buttons will follow it.
+    let buttons_width = if now.is_episode { 42.0 } else { 84.0 };
     let text_left = cover_rect.right() + 12.0;
-    let text_width = (region.right() - text_left - heart_width).max(40.0);
+    let text_width = (region.right() - text_left - buttons_width).max(40.0);
     let text_rect = Rect::from_min_size(pos2(text_left, cy - 18.0), vec2(text_width, 36.0));
     let mut text_ui = ui.new_child(
         UiBuilder::new()
@@ -129,27 +131,42 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
     );
     text_ui.set_clip_rect(text_rect.intersect(ui.clip_rect()));
     text_ui.spacing_mut().item_spacing.y = 2.0;
-    if theme::link(&mut text_ui, &now.title, theme::medium(14.0), palette.text).clicked() {
+
+    let title_response = theme::link(&mut text_ui, &now.title, theme::medium(14.0), palette.text);
+    if title_response.clicked() {
         if let Some(id) = &now.album_id {
             app.actions.push(Action::Open(Page::Album(id.clone())));
         } else if let Some(id) = &now.show_id {
             app.actions.push(Action::Open(Page::Show(id.clone())));
         }
     }
-    if theme::link(
+
+    let subtitle_response = theme::link(
         &mut text_ui,
         &now.subtitle,
         theme::regular(12.0),
         palette.secondary,
-    )
-    .clicked()
-    {
+    );
+    if subtitle_response.clicked() {
         if let Some(id) = now.artists.first().and_then(|artist| artist.id.clone()) {
             app.actions.push(Action::Open(Page::Artist(id)));
         } else if let Some(id) = &now.show_id {
             app.actions.push(Action::Open(Page::Show(id.clone())));
         }
     }
+
+    let natural = {
+        let title =
+            ui.painter()
+                .layout_no_wrap(now.title.clone(), theme::medium(14.0), palette.text);
+        let subtitle = ui.painter().layout_no_wrap(
+            now.subtitle.clone(),
+            theme::regular(12.0),
+            palette.secondary,
+        );
+        title.size().x.max(subtitle.size().x).min(text_width)
+    };
+    let mut next_x = text_left + natural + 21.0;
 
     if !now.is_episode {
         let saved = app.is_saved(&now.uri).unwrap_or(false);
@@ -158,20 +175,7 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         } else {
             (Icon::Heart, palette.secondary, "Save to Liked Songs")
         };
-        // Sit the heart just past the actual text, not at the region's far
-        // edge, so it stays visually attached to the title.
-        let natural = {
-            let title =
-                ui.painter()
-                    .layout_no_wrap(now.title.clone(), theme::medium(14.0), palette.text);
-            let subtitle = ui.painter().layout_no_wrap(
-                now.subtitle.clone(),
-                theme::regular(12.0),
-                palette.secondary,
-            );
-            title.size().x.max(subtitle.size().x).min(text_width)
-        };
-        let heart_x = (text_left + natural + 21.0).min(region.right() - 21.0);
+        let heart_x = next_x.min(region.right() - 63.0);
         let heart_rect = Rect::from_center_size(pos2(heart_x, cy), Vec2::splat(30.0));
         let mut heart_ui = ui.new_child(
             UiBuilder::new()
@@ -181,7 +185,121 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         if theme::icon_button(&mut heart_ui, icon, 17.0, color, palette.text, tooltip).clicked() {
             app.actions.push(Action::ToggleSaved(now.uri.clone()));
         }
+        next_x = heart_x + 36.0;
     }
+
+    let info_x = next_x.min(region.right() - 21.0);
+    let info_rect = Rect::from_center_size(pos2(info_x, cy), Vec2::splat(30.0));
+    let mut info_ui = ui.new_child(
+        UiBuilder::new()
+            .max_rect(info_rect)
+            .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+    );
+    info_button(app, &mut info_ui, now);
+}
+
+/// A quiet "i" that opens a popup with the technical readout: where the
+/// audio is playing, the real stream quality, loudness settings, and URI.
+fn info_button(app: &mut App, ui: &mut egui::Ui, now: &NowPlaying) {
+    let palette = app.palette;
+    let button = theme::icon_button(
+        ui,
+        Icon::Info,
+        16.0,
+        palette.secondary,
+        palette.text,
+        "Playback info",
+    );
+    egui::Popup::menu(&button)
+        .frame(super::widgets::menu_frame(&palette))
+        .show(|ui| {
+            // Fix both edges: popups auto-size to their content, and the
+            // truncating rows below want all the width they can get. Capping
+            // the max keeps the box from ballooning.
+            ui.set_min_width(220.0);
+            ui.set_max_width(220.0);
+            ui.spacing_mut().item_spacing.y = 2.0;
+            ui.add_space(2.0);
+            theme::text(ui, "Now playing", theme::semibold(13.0), palette.text);
+
+            let row = |ui: &mut egui::Ui, label: &str, value: String| {
+                // A fixed-size rect per row; labels and values are laid out
+                // manually so nothing can claim more than the box allows.
+                let (rect, _) =
+                    ui.allocate_exact_size(vec2(ui.available_width(), 18.0), Sense::hover());
+                let value_galley =
+                    ui.painter()
+                        .layout_no_wrap(value, theme::medium(12.0), palette.text);
+                let value_width = value_galley.size().x.min(rect.width() * 0.5);
+                let value_pos = pos2(
+                    rect.right() - value_width,
+                    rect.center().y - value_galley.size().y / 2.0,
+                );
+                ui.painter()
+                    .galley(value_pos, value_galley.clone(), palette.text);
+                let label_galley = ui.painter().layout_no_wrap(
+                    label.to_string(),
+                    theme::regular(12.0),
+                    palette.dim,
+                );
+                let label_clip = Rect::from_min_max(rect.min, pos2(value_pos.x - 6.0, rect.max.y));
+                ui.painter().with_clip_rect(label_clip).galley(
+                    pos2(rect.left(), rect.center().y - label_galley.size().y / 2.0),
+                    label_galley,
+                    palette.dim,
+                );
+            };
+
+            let source = if now.local {
+                "This computer".to_string()
+            } else {
+                now.device_name
+                    .clone()
+                    .unwrap_or_else(|| "Another device".to_string())
+            };
+            row(ui, "Playing on", source);
+            let quality = now.quality.clone().unwrap_or_else(|| {
+                if now.local {
+                    if now.uri.starts_with("spotify:local") {
+                        "Local file".to_string()
+                    } else {
+                        "Unknown".to_string()
+                    }
+                } else {
+                    "Up to the other device".to_string()
+                }
+            });
+            row(ui, "Stream quality", quality);
+            row(ui, "Duration", util::format_duration_ms(now.duration_ms));
+            row(ui, "Volume", format!("{}%", now.volume_percent));
+            if now.local {
+                let normalisation = if app.settings.normalisation {
+                    "On".to_string()
+                } else {
+                    "Off".to_string()
+                };
+                row(ui, "Loudness normalisation", normalisation);
+                row(ui, "Max bitrate", format!("{} kbps", app.settings.bitrate));
+            }
+
+            super::widgets::menu_separator(ui, &palette);
+            let uri = ui.add(
+                egui::Label::new(
+                    egui::RichText::new(&now.uri)
+                        .monospace()
+                        .size(11.5)
+                        .color(palette.secondary),
+                )
+                .truncate()
+                .selectable(false)
+                .sense(Sense::click()),
+            );
+            uri.clone().on_hover_text("Click to copy the URI");
+            if uri.clicked() {
+                ui.ctx().copy_text(now.uri.clone());
+                app.toast("Track URI copied to clipboard.".to_string());
+            }
+        });
 }
 
 fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region: Rect) {


### PR DESCRIPTION
Fixes the stream-quality part of #6, addressed per review.

### What this does

The player bar no longer shows a `320 kbps OGG` badge next to the title. The same information is now behind a quiet info button (`Info`) next to the heart — a small popup with:

- **Playing on** — `This computer` when `NowPlaying.local`, otherwise the remote device name
- **Stream quality** — the file librespot actually streams for the configured bitrate. It walks the same per-bitrate preference list as `librespot-playback` (`playback/src/player.rs:1011`, e.g. `320 → OGG_320, MP3_320, MP3_256, OGG_160, …` and takes the first the item offers). Podcasts/fallback tracks therefore show their real, lower rate.
- Duration, volume, loudness normalisation, max bitrate, and the track URI (click the row to copy)

Local files (`spotify:local`) show `Local file` and remote playback shows `Up to the other device` — no invented `Buffering…` or `900 kbps`, no FLAC.

### Screenshots

Player bar — info button sits just past the text, next to the heart:

![info bar](https://raw.githubusercontent.com/zHeuzy2/fastpotify/screenshots-pr1/assets/pr6/info-bar.png)

Popup (demo with `--demo-show local`, i.e. the sample track playing through the local player so `stream_quality = 320 kbps OGG`):

![info popup](https://raw.githubusercontent.com/zHeuzy2/fastpotify/screenshots-pr1/assets/pr6/info-popup.png)

Reproduce: `cargo run --features demo -- --demo-show local` (or `--demo-show local --demo-shot out.png --demo-shot-delay 9000` for a headless capture).

### How quality is derived

`src/player.rs:preferred_formats` mirrors the `match self.config.bitrate { Bitrate96, Bitrate160, Bitrate320 }` table in librespot. `local_track()` finds the first of those formats present in `AudioItem.files` and stores `format_quality_label()` (`"320 kbps OGG"`, `"256 kbps MP3"` including `MP3_256` etc.) in `LocalTrack.stream_quality`. `App::now_playing()` surfaces it as `NowPlaying.quality`. No new dependency, no continuous repaint.

### Checks

- `cargo fmt`
- `cargo clippy --all-targets --features demo -- -D warnings` — clean
- `cargo test` — 50 passed
- App stays idle when nothing animates (popup only repaints on open/hover)

### Notes

- This PR is the first of the split requested in https://github.com/crmne/fastpotify/pull/6#issuecomment-5451192200. It only touches the info-popup/quality lane; normalisation preamp, tint/page fades and `dev.ps1` are intentionally left out.
- `main` currently does not build on Windows (`tokio::fs` without the `fs` feature, only unified in on Linux via `mpris-server`). Not addressed here to keep the diff focused.
