### PR TITLE
fix: enable tokio fs feature in Cargo.toml for cross-platform builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ librespot-protocol = { version = "0.8", default-features = false }
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
 cpal = "0.16"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "gzip", "http2", "blocking"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "fs"] }
 sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"


### PR DESCRIPTION
## Summary
Enables the `fs` feature flag for `tokio` in `Cargo.toml`.

## Motivation
Commit `fabf009` introduced `tokio::fs` calls in `src/backend.rs` for playlist caching. On targets like Windows and macOS where `tokio/fs` is not pulled transitively via platform-specific crates, this breaks compilation with `E0433: cannot find fs in tokio`.

## Verification
- `cargo check --features demo`
- `cargo clippy --all-targets --features demo -- -D warnings`
- `cargo fmt --all --check`
- `cargo test --features demo` (all 50 tests pass)