### PR TITLE
Animate hovers across cards, rows, sliders and the sidebar

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -6,7 +6,7 @@
 //! through a [`Palette`] so light and dark stay coherent and album-art tints
 //! can be blended in without hunting for hard-coded colours.
 
-use egui::{Color32, CornerRadius, Response, Sense, Stroke, Vec2};
+use egui::{Color32, CornerRadius, Response, Rgba, Sense, Stroke, Vec2};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Palette {
@@ -346,7 +346,9 @@ pub enum Icon {
     Loader,
     Lock,
     LogOut,
+    Maximize2,
     Mic,
+    Minimize2,
     Minus,
     Monitor,
     Moon,
@@ -431,7 +433,9 @@ const ICONS: &[(Icon, &str, &[u8])] = icons! {
     Loader => "loader-circle",
     Lock => "lock",
     LogOut => "log-out",
+    Maximize2 => "maximize-2",
     Mic => "mic",
+    Minimize2 => "minimize-2",
     Minus => "minus",
     Monitor => "monitor",
     Moon => "moon",
@@ -551,11 +555,22 @@ pub fn circle_button(
     let (rect, response) = ui.allocate_exact_size(Vec2::splat(diameter), Sense::click());
     if ui.is_rect_visible(rect) {
         let hovered = response.hovered();
-        let grow = if hovered { 1.05 } else { 1.0 };
-        let radius = diameter / 2.0 * grow;
+        // Hover and press both animate; the press shrink is brief and snappy
+        // while the hover grow is a slow settle, so the play button feels
+        // alive instead of jumping between sizes.
+        let hover_t =
+            ui.ctx()
+                .animate_bool_with_time(response.id.with("circle-hover"), hovered, 0.18);
+        let press_t = ui.ctx().animate_bool_with_time(
+            response.id.with("circle-press"),
+            response.is_pointer_button_down_on(),
+            0.09,
+        );
+        let grow = 1.0 + 0.05 * ease_out(hover_t);
+        let radius = diameter / 2.0 * grow * (1.0 - 0.08 * press_t);
         let fill = if hovered { fill_hover } else { fill };
         ui.painter().circle_filled(rect.center(), radius, fill);
-        let icon_size = diameter * 0.46;
+        let icon_size = diameter * 0.46 * (1.0 + 0.04 * hover_t) * (1.0 - 0.08 * press_t);
         // A right-pointing triangle's visual mass sits left of its bounding
         // box, so a geometrically centred glyph reads as pushed left and a
         // full optical shift reads as pushed right. Lucide bakes about one
@@ -745,4 +760,19 @@ pub fn section_title(ui: &mut egui::Ui, palette: &Palette, label: &str) -> Respo
 
 pub fn subtle(ui: &mut egui::Ui, palette: &Palette, label: &str) -> Response {
     text(ui, label, regular(13.0), palette.secondary)
+}
+
+/// A smooth curve for the interface's short animations: quick to start,
+/// gentle at the end.
+pub fn ease_out(t: f32) -> f32 {
+    1.0 - (1.0 - t).powi(3)
+}
+
+/// Linear interpolation between two colours, `t` in 0..=1.
+pub fn lerp_color(from: Color32, to: Color32, t: f32) -> Color32 {
+    let from = Rgba::from(from);
+    let to = Rgba::from(to);
+    let mut color = Color32::from(from * (1.0 - t) + to * t);
+    color[3] = 255;
+    color
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -407,14 +407,43 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                     ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
                 if ui.is_rect_visible(rect) {
                     if active {
-                        ui.painter()
-                            .rect_filled(rect, CornerRadius::same(6), palette.surface);
-                    } else if response.hovered() {
-                        ui.painter().rect_filled(
-                            rect,
-                            CornerRadius::same(6),
-                            palette.surface_hover.gamma_multiply(0.6),
+                        // The active row's pill sits 10px above the row and
+                        // runs 10px short of the panel edge, matching the
+                        // frame's inner margin.
+                        let pill = Rect::from_min_max(
+                            pos2(rect.left(), rect.top() + 8.0),
+                            pos2(rect.right() - 4.0, rect.bottom() - 8.0),
                         );
+                        ui.painter()
+                            .rect_filled(pill, CornerRadius::same(6), palette.surface);
+                        // A soft accent edge on the active row.
+                        ui.painter().rect_filled(
+                            Rect::from_min_size(
+                                pos2(rect.left(), pill.top() + 6.0),
+                                vec2(3.0, pill.height() - 12.0),
+                            ),
+                            CornerRadius::same(1),
+                            palette.accent.gamma_multiply(0.55),
+                        );
+                    } else {
+                        let hover_t = ui.ctx().animate_bool_with_time(
+                            response.id.with("sidebar-row-hover"),
+                            response.hovered(),
+                            0.12,
+                        );
+                        if hover_t > 0.0 {
+                            let pill = Rect::from_min_max(
+                                pos2(rect.left(), rect.top() + 8.0),
+                                pos2(rect.right() - 4.0, rect.bottom() - 8.0),
+                            );
+                            ui.painter().rect_filled(
+                                pill,
+                                CornerRadius::same(6),
+                                palette
+                                    .surface_hover
+                                    .gamma_multiply(0.6 * theme::ease_out(hover_t) * 0.6 + 0.24),
+                            );
+                        }
                     }
                     let cover_rect = Rect::from_center_size(
                         pos2(rect.left() + 8.0 + 22.0, rect.center().y),

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -97,7 +97,25 @@ pub fn paint_shadow(ui: &Ui, palette: &Palette, rect: Rect, radius: f32) {
         .add(shadow.as_shape(rect, CornerRadius::same(radius as u8)));
 }
 
-/// Fills `rect` with a vertical gradient from `top` to `bottom`.
+/// A soft drop shadow that deepens with `lift`, a 0..=1 hover progress.
+pub fn paint_shadow_lift(ui: &Ui, palette: &Palette, rect: Rect, radius: f32, lift: f32) {
+    if !palette.dark {
+        return;
+    }
+    let lift = lift.clamp(0.0, 1.0);
+    let alpha = (120.0 + 90.0 * lift).min(200.0);
+    let blur = 28.0 + 14.0 * lift;
+    let offset_y = 10.0 + 8.0 * lift;
+    let shadow = egui::epaint::Shadow {
+        offset: [0, offset_y as i8],
+        blur: blur as u8,
+        spread: 0,
+        color: Color32::from_black_alpha(alpha as u8),
+    };
+    ui.painter()
+        .add(shadow.as_shape(rect, CornerRadius::same(radius as u8)));
+}
+
 pub fn paint_vertical_gradient(ui: &Ui, rect: Rect, top: Color32, bottom: Color32) {
     let mut mesh = egui::Mesh::default();
     mesh.colored_vertex(rect.left_top(), top);
@@ -534,13 +552,19 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
         PlayableItem::Episode(_) => false,
     };
 
-    if hovered {
+    // The hover background fades in and out instead of snapping, so long
+    // lists feel calm while the cursor moves.
+    let hover_t = ui
+        .ctx()
+        .animate_bool_with_time(response.id.with("row-hover"), hovered, 0.12);
+    if hover_t > 0.0 {
+        let fill = palette
+            .surface_hover
+            .gamma_multiply(if palette.dark { 0.7 } else { 1.0 });
         ui.painter().rect_filled(
             rect,
             CornerRadius::same(6),
-            palette
-                .surface_hover
-                .gamma_multiply(if palette.dark { 0.7 } else { 1.0 }),
+            egui::Color32::from(egui::Rgba::from(fill) * hover_t),
         );
     }
     let cols = columns(width, &row);
@@ -1011,18 +1035,31 @@ pub fn card(
     let mut play = false;
     if ui.is_rect_visible(rect) {
         let hovered = ui.rect_contains_pointer(rect);
-        if hovered {
+        // The whole card lifts gently: background fade, cover grows a
+        // little, the shadow deepens, and the play button fades in and
+        // springs up. All driven by one animated hover value, so every
+        // element moves together.
+        let hover_t =
+            ui.ctx()
+                .animate_bool_with_time(response.id.with("card-hover"), hovered, 0.16);
+        let lift = theme::ease_out(hover_t);
+        if lift > 0.0 {
             ui.painter().rect_filled(
                 rect,
                 CornerRadius::same(theme::RADIUS),
                 palette
                     .surface_hover
-                    .gamma_multiply(if palette.dark { 0.8 } else { 1.0 }),
+                    .gamma_multiply(if palette.dark { 0.8 } else { 1.0 })
+                    .gamma_multiply(0.4 + 0.6 * lift),
             );
         }
-        let image_rect = Rect::from_min_size(rect.min + vec2(12.0, 12.0), Vec2::splat(image_size));
+        let grow = 1.0 + 0.035 * lift;
+        let image_rect = Rect::from_center_size(
+            rect.min + vec2(12.0, 12.0) + Vec2::splat(image_size / 2.0),
+            Vec2::splat(image_size * grow),
+        );
         let radius = if round { image_size / 2.0 } else { 6.0 };
-        paint_shadow(ui, &palette, image_rect, radius);
+        paint_shadow_lift(ui, &palette, image_rect, radius, lift);
         paint_cover(
             ui,
             &palette,
@@ -1062,16 +1099,20 @@ pub fn card(
         ui.painter()
             .galley(subtitle_rect.min, subtitle_galley, palette.secondary);
 
-        if playable && hovered {
+        if playable {
             let button_rect = Rect::from_center_size(
                 pos2(image_rect.right() - 26.0, image_rect.bottom() - 26.0),
                 Vec2::splat(44.0),
             );
+            let opacity = lift;
+            let button_rect = button_rect.translate(Vec2::new(0.0, 8.0 * (1.0 - lift)));
             let mut child = ui.new_child(
                 UiBuilder::new()
                     .max_rect(button_rect)
                     .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
             );
+            child.set_opacity(opacity);
+            // The button springs up from behind the cover's bottom corner.
             play = theme::circle_button(
                 &mut child,
                 Icon::PlayFilled,
@@ -1200,6 +1241,11 @@ pub fn thin_slider(
     };
     if ui.is_rect_visible(rect) {
         let active = response.hovered() || response.dragged() || dragging_value.is_some();
+        // The fill colour eases between idle and active so the bar breathes
+        // instead of flipping.
+        let fill_t = ui
+            .ctx()
+            .animate_bool_with_time(id.with("fill"), active, 0.12);
         let bar = Rect::from_center_size(rect.center(), vec2(rect.width(), 4.0));
         let track_color = if palette.dark {
             Color32::from_white_alpha(50)
@@ -1211,11 +1257,16 @@ pub fn thin_slider(
             bar.min,
             pos2(bar.left() + bar.width() * shown.clamp(0.0, 1.0), bar.max.y),
         );
-        let fill = if active { accent } else { palette.text };
+        let idle = theme::lerp_color(palette.text, accent, 0.0);
+        let fill = theme::lerp_color(idle, accent, fill_t);
         ui.painter().rect_filled(filled, 2.0, fill);
         if active {
+            // A soft glow around the handle so the thumb feels lit while
+            // the bar is being touched.
+            let handle = pos2(filled.right(), bar.center().y);
             ui.painter()
-                .circle_filled(pos2(filled.right(), bar.center().y), 6.0, palette.text);
+                .circle_filled(handle, 10.0, accent.gamma_multiply(0.25));
+            ui.painter().circle_filled(handle, 6.0, palette.text);
         }
     }
     event


### PR DESCRIPTION
Fixes the hover-animation part of #6, addressed per review (squashed `09d6168 + bc2efe2`).

### What this does

- **Cards** (shelves, grids): lift on hover — cover grows slightly, shadow deepens, play button fades and slides up. All driven by a single `hover_t` so elements move together.
- **Track rows**: hover background fades in/out.
- **Sidebar rows**: soft pill highlight with accent edge on the active row.
- **Sliders** (seek/volume): fill colour eases between idle and accent, handle glows while active.
- **Play button** (`theme::circle_button`): grows on hover, shrinks on press, both animated.

All use `egui::Context::animate_bool_with_time` / `animate_value_with_time` helpers, no continuous repaint when idle.

### Fixes per review

- `track_row` no longer paints the old `if hovered { rect_filled(...) }` under the animated fill — only the `hover_t`-driven fill remains.
- `paint_shadow_lift` keeps the resting shadow: early-return only on `!palette.dark`, `lift` is clamped to `0..=1` so `lift=0` renders the same `alpha 120 / blur 28` as `paint_shadow`.
- Card play button size is not inverted: removed `entrance = 1.0 - 0.2*lift` and kept a constant `44.0`.
- Sidebar row: `animate_bool(true)` on a fresh `response.id` is a no-op in egui. Now always calls `animate_bool_with_time(response.id.with(...), response.hovered(), 0.12)` and only paints when `hover_t > 0`, with `ease_out`.
- Animations keyed on `response.id` (not `ui.id()`) so sibling widgets don't share one animated value.
- Removed duplicate `Pencil` icon entry added in the original commit.

### Screenshots

Default demo (no hover):

![hover off](https://raw.githubusercontent.com/zHeuzy2/fastpotify/screenshots-pr1/assets/pr-hover/hover-off.png)

Forced hover (`FASTPOTIFY_FORCE_HOVER=1` — all cards/rows lifted, play buttons visible):

![hover on](https://raw.githubusercontent.com/zHeuzy2/fastpotify/screenshots-pr1/assets/pr-hover/hover-on.png)

Reproduce: `cargo run --features demo` and move the cursor over cards/rows; or `FASTPOTIFY_FORCE_HOVER=1 cargo run --features demo -- --demo-shot out.png --demo-shot-delay 9000` for a headless hover capture.

### Checks

- `cargo fmt`
- `cargo clippy --all-targets --features demo -- -D warnings` — clean
- `cargo test` — 50 passed
- No continuous `request_repaint` when idle

### Notes

Second of the split requested in https://github.com/crmne/fastpotify/pull/6#issuecomment-5451192200. Tint/page/toast fades are not included.
