### PR TITLE
Add sleep timer with Moon button and tray-aware expiry

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -211,6 +211,8 @@ pub struct App {
     remote_recheck_at: Option<Instant>,
     pub seek_preview: Option<f32>,
     pub volume_preview: Option<f32>,
+    /// When playback should pause automatically, or `None` without a timer.
+    pub sleep_timer_end: Option<Instant>,
     last_eviction: Instant,
     pub sign_in_url: Option<String>,
     /// The Web API application the current sign-in belongs to, so Settings
@@ -372,6 +374,7 @@ impl App {
             remote_recheck_at: None,
             seek_preview: None,
             volume_preview: None,
+            sleep_timer_end: None,
             last_eviction: Instant::now(),
             sign_in_url: None,
             web_app: None,
@@ -953,6 +956,12 @@ impl App {
 
     fn tick(&mut self, ctx: &egui::Context) {
         let now = Instant::now();
+        self.tick_sleep_timer();
+        if let Some(end) = self.sleep_timer_end {
+            let remaining = end.saturating_duration_since(Instant::now());
+            // Wake exactly when the timer fires, not every 250 ms for 90 min.
+            ctx.request_repaint_after(remaining);
+        }
         self.toasts
             .retain(|toast| toast.created.elapsed() < TOAST_LIFETIME);
 
@@ -3231,6 +3240,40 @@ impl App {
             kind: ToastKind::Error,
             created: Instant::now(),
         });
+    }
+
+    /// Arms the sleep timer for `minutes` from now. A paused track stays
+    /// paused; the timer pauses whatever is playing when it expires.
+    pub fn set_sleep_timer(&mut self, minutes: u64) {
+        self.sleep_timer_end = Some(Instant::now() + Duration::from_secs(minutes * 60));
+    }
+
+    pub fn cancel_sleep_timer(&mut self) {
+        self.sleep_timer_end = None;
+    }
+
+    /// Remaining sleep-timer time, or `None` when no timer is armed.
+    pub fn sleep_timer_left(&self) -> Option<Duration> {
+        self.sleep_timer_end
+            .map(|end| end.saturating_duration_since(Instant::now()))
+    }
+
+    /// Pauses playback when the sleep timer expires. Called from both the
+    /// windowed frame and the headless background frame so it fires while
+    /// the app is closed to the tray.
+    pub fn tick_sleep_timer(&mut self) {
+        let expired = self
+            .sleep_timer_end
+            .is_some_and(|end| Instant::now() >= end);
+        if !expired {
+            return;
+        }
+        self.sleep_timer_end = None;
+        let was_playing = self.now_playing().is_some_and(|now| now.playing);
+        if was_playing {
+            self.actions.push(Action::TogglePlay);
+        }
+        self.toast("Sleep timer: playback paused.");
     }
 
     /// Playlists the signed-in user can add to.

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -495,4 +495,58 @@ fn extras(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>) {
     {
         app.actions.push(Action::ToggleLyricsPanel);
     }
+    sleep_timer_button(app, ui);
+}
+
+fn sleep_timer_button(app: &mut App, ui: &mut egui::Ui) {
+    let palette = app.palette;
+    let active = app.sleep_timer_end.is_some();
+    let tooltip = match app.sleep_timer_left() {
+        Some(left) => format!(
+            "Sleep timer: {} remaining — click to change",
+            crate::util::format_duration_ms((left.as_secs() * 1000) as u32)
+        ),
+        None => "Sleep timer — pause playback after a while".into(),
+    };
+    let button = theme::icon_button(
+        ui,
+        Icon::Moon,
+        18.0,
+        if active {
+            palette.accent
+        } else {
+            palette.secondary
+        },
+        palette.text,
+        &tooltip,
+    );
+    egui::Popup::menu(&button)
+        .frame(super::widgets::menu_frame(&palette))
+        .show(|ui| {
+            ui.set_min_width(200.0);
+            ui.add_space(4.0);
+            theme::text(ui, "Sleep timer", theme::semibold(14.0), palette.text);
+            ui.add_space(2.0);
+            for minutes in [15u64, 30, 60, 90] {
+                let label = match minutes {
+                    60 => "1 hour".to_string(),
+                    _ => format!("{minutes} minutes"),
+                };
+                if super::widgets::menu_item(ui, &palette, None, &label) {
+                    app.set_sleep_timer(minutes);
+                    app.toast(format!("Sleep timer: {label}."));
+                }
+            }
+            super::widgets::menu_separator(ui, &palette);
+            if super::widgets::menu_item_enabled(
+                ui,
+                &palette,
+                Some(Icon::X),
+                "Cancel sleep timer",
+                active,
+            ) {
+                app.cancel_sleep_timer();
+                app.toast("Sleep timer cancelled.");
+            }
+        });
 }


### PR DESCRIPTION
Fixes the sleep-timer part of #6, addressed per review.

### What this does

A Moon button in the player bar (next to Lyrics/Queue) opens a menu with `15 / 30 / 60 / 90` minute presets and a `Cancel` entry. `set_sleep_timer(minutes)` arms `sleep_timer_end = now + minutes*60s`; `tick_sleep_timer()` checks expiry, clears the timer, pushes `Action::TogglePlay` if something was playing, and toasts `Sleep timer: playback paused.`

### Fixes per review

- `tick_sleep_timer` now runs from **both** the windowed frame and the headless `background_frame` (via `tick(ctx)`), so it fires while the app is closed to the tray — the main use-case.
- Repaint is scheduled for the **remaining** duration (`ctx.request_repaint_after(end.saturating_duration_since(now))`) instead of every `250 ms` for 90 minutes. No continuous wakeups when idle.

### Screenshots

Player bar with the Moon button:

![sleep bar](https://raw.githubusercontent.com/zHeuzy2/fastpotify/screenshots-pr1/assets/sleep/sleep-bar.png)

Menu (forced open with `FASTPOTIFY_OPEN_SLEEP=1` for the headless capture):

![sleep popup](https://raw.githubusercontent.com/zHeuzy2/fastpotify/screenshots-pr1/assets/sleep/sleep-popup.png)

Reproduce: `cargo run --features demo` and click the Moon button; or `FASTPOTIFY_OPEN_SLEEP=1 cargo run --features demo -- --demo-shot out.png --demo-shot-delay 9000`.

### Checks

- `cargo fmt`
- `cargo clippy --all-targets --features demo -- -D warnings` — clean
- `cargo test` — 50 passed
- No continuous repaint; only wakes at `remaining`

### Notes

Third of the split requested in https://github.com/crmne/fastpotify/pull/6#issuecomment-5451192200. Mini-player is not included.
