### PR TITLE
feat: make lyrics side panel resizable and persist width

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -46,6 +46,7 @@ pub struct Settings {
     /// Last local volume, 0..=65535.
     pub volume: u16,
     pub sidebar_width: f32,
+    pub lyrics_width: f32,
     pub search_history: Vec<String>,
     pub show_shortcut_hints: bool,
     /// A personal Spotify Web API application id, if the user registered one.
@@ -78,6 +79,7 @@ impl Default for Settings {
             accent_from_art: true,
             volume: (u16::MAX as u32 * 70 / 100) as u16,
             sidebar_width: 250.0,
+            lyrics_width: 360.0,
             search_history: Vec::new(),
             show_shortcut_hints: true,
             web_client_id: None,

--- a/src/ui/lyrics.rs
+++ b/src/ui/lyrics.rs
@@ -20,45 +20,44 @@ fn blend(from: egui::Color32, to: egui::Color32, t: f32) -> egui::Color32 {
 
 pub fn side_panel(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    egui::Panel::right("lyrics-panel")
-        .exact_size(360.0)
-        .resizable(false)
+    let panel = egui::Panel::right("lyrics-panel")
+        .resizable(true)
+        .default_size(app.settings.lyrics_width)
+        .size_range(280.0..=640.0)
         .show_separator_line(false)
         .frame(
             Frame::new()
                 .fill(palette.panel)
                 .inner_margin(Margin::symmetric(12, 12)),
-        )
-        .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                ui.add_space(4.0);
-                theme::text(ui, "Lyrics", theme::bold(18.0), palette.text);
-                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                    if theme::icon_button(
-                        ui,
-                        Icon::X,
-                        18.0,
-                        palette.secondary,
-                        palette.text,
-                        "Close",
-                    )
+        );
+    let response = panel.show(ui, |ui| {
+        ui.horizontal(|ui| {
+            ui.add_space(4.0);
+            theme::text(ui, "Lyrics", theme::bold(18.0), palette.text);
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                if theme::icon_button(ui, Icon::X, 18.0, palette.secondary, palette.text, "Close")
                     .clicked()
-                    {
-                        app.actions.push(Action::ToggleLyricsPanel);
-                    }
-                    let loaded = matches!(&app.lyrics, Loadable::Loaded(Some(_)));
-                    if loaded
-                        && !app.lyrics_following
-                        && theme::pill_button(ui, &palette, "Follow", false).clicked()
-                    {
-                        app.lyrics_following = true;
-                        app.lyrics_line_shown = None;
-                    }
-                });
+                {
+                    app.actions.push(Action::ToggleLyricsPanel);
+                }
+                let loaded = matches!(&app.lyrics, Loadable::Loaded(Some(_)));
+                if loaded
+                    && !app.lyrics_following
+                    && theme::pill_button(ui, &palette, "Follow", false).clicked()
+                {
+                    app.lyrics_following = true;
+                    app.lyrics_line_shown = None;
+                }
             });
-            ui.add_space(8.0);
-            contents(app, ui);
         });
+        ui.add_space(8.0);
+        contents(app, ui);
+    });
+    let current_width = response.response.rect.width();
+    if (app.settings.lyrics_width - current_width).abs() > 1.0 {
+        app.settings.lyrics_width = current_width;
+        app.actions.push(Action::SettingsChanged);
+    }
 }
 
 fn contents(app: &mut App, ui: &mut egui::Ui) {


### PR DESCRIPTION
## Summary
Makes the Lyrics side panel resizable (range 280px to 640px) and persists its width in `Settings`.

## Motivation
The Lyrics panel had a fixed hardcoded width of 360px. On wide screens or during songs with long lyric lines/verses, lines would wrap aggressively into multiple lines. Making it resizable allows users to adjust it to their preferred reading size.

## Changes
- Added `lyrics_width: f32` to `Settings` (default `360.0`).
- Updated `side_panel` in `src/ui/lyrics.rs` to `.resizable(true)` with range `280.0..=640.0` and width change persistence.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets --features demo -- -D warnings`
- `cargo test --features demo` (all 50 tests pass)