### PR TITLE
feat: add sticky collection headers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2441,6 +2441,8 @@ impl App {
                 shuffle: shuffle_first.then_some(true),
                 at: Instant::now(),
             });
+        } else {
+            self.assumed_context = None;
         }
         match self.target() {
             Target::Local => {
@@ -3636,5 +3638,19 @@ mod tests {
             "{:?}",
             app.actions
         );
+    }
+
+    #[test]
+    fn a_uri_queue_replaces_the_previous_context() {
+        let mut app = headless_app();
+        app.assumed_context = Some(AssumedContext {
+            uri: "spotify:album:old".into(),
+            shuffle: None,
+            at: Instant::now(),
+        });
+
+        app.play_request(PlayRequest::tracks(vec!["spotify:track:new".into()]), false);
+
+        assert!(app.assumed_context.is_none());
     }
 }

--- a/src/ui/artist.rs
+++ b/src/ui/artist.rs
@@ -6,7 +6,7 @@ use crate::model::{Action, DiscographyFilter, Loadable, Page, RowContext};
 use crate::theme::{self, Icon};
 use crate::util;
 
-use super::collection::{Hero, hero};
+use super::collection::{self, Hero, hero};
 use super::widgets::{self, TrackRow};
 
 pub fn show(app: &mut App, ui: &mut egui::Ui, id: &str) {
@@ -98,11 +98,20 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, id: &str) {
             ui.add_space(20.0);
 
             // Popular.
+            let popular_top = ui.cursor().top();
             theme::section_title(ui, &palette, "Popular");
             ui.add_space(4.0);
             match &page.top_tracks {
                 Loadable::Loaded(tracks) if !tracks.is_empty() => {
                     let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
+                    if popular_top < ui.clip_rect().top() {
+                        collection::mark_artist_sticky(
+                            ui,
+                            Page::Artist(id.to_string()),
+                            &artist.name,
+                            uris.clone(),
+                        );
+                    }
                     let context = RowContext::Uris(uris);
                     let items: Vec<PlayableItem> =
                         tracks.iter().cloned().map(PlayableItem::Track).collect();

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -1,6 +1,6 @@
 //! Playlist, album, and Liked Songs pages: a hero, actions, and a track table.
 
-use egui::{Align, Layout, Rect, Sense, Vec2, pos2, vec2};
+use egui::{Align, Layout, Rect, Sense, UiBuilder, Vec2, pos2, vec2};
 
 use crate::api::models::{Album, PlayableItem, Playlist, pick_image};
 use crate::app::App;
@@ -260,6 +260,243 @@ pub struct Table<'a> {
     pub error: Option<&'a str>,
     pub can_load_more: bool,
     pub filter: &'a str,
+    pub sticky_title: Option<&'a str>,
+    pub sticky_play_uri: Option<&'a str>,
+}
+
+#[derive(Clone)]
+struct StickyHeader {
+    title: String,
+    play: StickyPlay,
+    page: Page,
+    show_album: bool,
+    show_cover: bool,
+    show_added: bool,
+    show_added_by: bool,
+    show_columns: bool,
+}
+
+#[derive(Clone)]
+enum StickyPlay {
+    Context(String),
+    Uris(Vec<String>),
+}
+
+#[derive(Clone, Default)]
+struct StickyState {
+    header: Option<StickyHeader>,
+    visible: bool,
+}
+
+fn sticky_id(page: &Page) -> egui::Id {
+    egui::Id::new(("collection-sticky", page.encode()))
+}
+
+const STICKY_ACTIONS_HEIGHT: f32 = 58.0;
+const STICKY_TABLE_HEIGHT: f32 = 88.0;
+
+impl StickyHeader {
+    fn height(&self) -> f32 {
+        if self.show_columns {
+            STICKY_TABLE_HEIGHT
+        } else {
+            STICKY_ACTIONS_HEIGHT
+        }
+    }
+}
+
+fn sticky_animation_id(page: &Page) -> egui::Id {
+    egui::Id::new(("collection-sticky-visible", page.encode()))
+}
+
+pub(super) fn sticky_height(ui: &egui::Ui, page: &Page) -> f32 {
+    let visible = ui
+        .data(|data| data.get_temp::<StickyState>(sticky_id(page)))
+        .is_some_and(|state| state.visible);
+    let height = ui
+        .data(|data| data.get_temp::<StickyState>(sticky_id(page)))
+        .and_then(|state| state.header)
+        .map_or(STICKY_TABLE_HEIGHT, |header| header.height());
+    height
+        * ui.ctx()
+            .animate_bool_with_time(sticky_animation_id(page), visible, 0.15)
+}
+
+pub(super) fn clear_sticky(ui: &mut egui::Ui, page: &Page) {
+    ui.data_mut(|data| {
+        let mut state = data
+            .get_temp::<StickyState>(sticky_id(page))
+            .unwrap_or_default();
+        state.visible = false;
+        data.insert_temp(sticky_id(page), state);
+    });
+}
+
+fn mark_sticky(ui: &mut egui::Ui, page: &Page, header: StickyHeader) {
+    ui.data_mut(|data| {
+        let mut state = data
+            .get_temp::<StickyState>(sticky_id(page))
+            .unwrap_or_default();
+        state.header = Some(header);
+        state.visible = true;
+        data.insert_temp(sticky_id(page), state);
+    });
+}
+
+pub(super) fn mark_artist_sticky(ui: &mut egui::Ui, page: Page, title: &str, uris: Vec<String>) {
+    mark_sticky(
+        ui,
+        &page,
+        StickyHeader {
+            title: title.to_string(),
+            play: StickyPlay::Uris(uris),
+            page: page.clone(),
+            show_album: false,
+            show_cover: true,
+            show_added: false,
+            show_added_by: false,
+            show_columns: false,
+        },
+    );
+}
+
+pub(super) fn show_sticky(
+    app: &mut App,
+    ui: &mut egui::Ui,
+    page: &Page,
+    viewport: Rect,
+    backdrop: &super::PageBackdrop,
+) {
+    let state = ui
+        .data(|data| data.get_temp::<StickyState>(sticky_id(page)))
+        .unwrap_or_default();
+    let progress = ui
+        .ctx()
+        .animate_bool_with_time(sticky_animation_id(page), state.visible, 0.15);
+    let Some(header) = state.header else {
+        return;
+    };
+    if progress <= 0.0 {
+        return;
+    }
+
+    let height = header.height();
+    let rect = Rect::from_min_size(
+        pos2(viewport.left(), viewport.top() - height * (1.0 - progress)),
+        vec2(viewport.width(), height),
+    );
+    let palette = app.palette;
+    let mut shadow_ui = ui.new_child(UiBuilder::new().max_rect(rect));
+    shadow_ui.shrink_clip_rect(viewport);
+    shadow_ui.painter().add(
+        egui::epaint::Shadow {
+            offset: [0, 4],
+            blur: 16,
+            spread: 0,
+            color: palette.shadow.gamma_multiply(progress),
+        }
+        .as_shape(rect, egui::CornerRadius::ZERO),
+    );
+    let mut backdrop_ui = ui.new_child(UiBuilder::new().max_rect(viewport));
+    backdrop_ui.shrink_clip_rect(viewport.intersect(rect));
+    backdrop.paint(&backdrop_ui);
+    let mut sticky = ui.new_child(
+        UiBuilder::new()
+            .id_salt(("sticky-table", &header.page))
+            .max_rect(rect.shrink2(vec2(widgets::PAGE_PADDING, 0.0))),
+    );
+    sticky.shrink_clip_rect(viewport);
+    sticky.set_opacity(progress);
+    sticky.add_space(4.0);
+    sticky.horizontal(|ui| {
+        let current = match &header.play {
+            StickyPlay::Context(uri) => app.playing_context_uri().as_deref() == Some(uri),
+            StickyPlay::Uris(uris) => {
+                app.playing_context_uri().is_none()
+                    && app
+                        .now_playing()
+                        .is_some_and(|now| uris.iter().any(|uri| uri == &now.uri))
+            }
+        };
+        let playing = current && app.believed_playing();
+        let pending = match &header.play {
+            StickyPlay::Context(uri) => app.play_pending(uri),
+            StickyPlay::Uris(uris) => uris.first().is_some_and(|uri| app.play_pending(uri)),
+        };
+        if pending {
+            theme::circle_spinner(ui, 40.0, palette.accent, palette.on_accent, "Starting…");
+        } else if theme::circle_button(
+            ui,
+            if playing {
+                Icon::PauseFilled
+            } else {
+                Icon::PlayFilled
+            },
+            40.0,
+            palette.accent,
+            palette.accent_hover,
+            palette.on_accent,
+            if playing { "Pause" } else { "Play" },
+        )
+        .clicked()
+        {
+            app.actions.push(if current {
+                Action::TogglePlay
+            } else {
+                match &header.play {
+                    StickyPlay::Context(uri) => Action::PlayContext {
+                        uri: uri.clone(),
+                        offset_uri: None,
+                        offset_index: None,
+                    },
+                    StickyPlay::Uris(uris) => Action::PlayUris {
+                        uris: uris.clone(),
+                        index: 0,
+                    },
+                }
+            });
+        }
+        theme::text(ui, &header.title, theme::bold(24.0), palette.text);
+    });
+    if header.show_columns {
+        let clicked = widgets::table_header(
+            &mut sticky,
+            &palette,
+            header.show_album,
+            header.show_added,
+            header.show_added_by,
+            header.show_cover,
+            app.table_sorts.get(&header.page).copied(),
+            false,
+        );
+        if let Some(column) = clicked {
+            apply_sort(app, &header.page, column);
+        }
+    }
+}
+
+fn apply_sort(app: &mut App, page: &Page, column: SortColumn) {
+    let sort = app.table_sorts.get(page).copied();
+    let next = match sort {
+        Some(sort) if sort.column == column && sort.ascending => Some(TableSort {
+            column,
+            ascending: false,
+        }),
+        Some(sort) if sort.column == column => None,
+        _ => Some(TableSort {
+            column,
+            ascending: true,
+        }),
+    };
+    match next {
+        Some(sort) => {
+            app.table_sorts.insert(page.clone(), sort);
+            app.actions.push(Action::LoadMore(page.clone()));
+        }
+        None => {
+            app.table_sorts.remove(page);
+        }
+    }
 }
 
 pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
@@ -331,8 +568,9 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
         });
     }
 
-    if !table.items.is_empty()
-        && let Some(column) = widgets::table_header(
+    let table_top = ui.cursor().top();
+    let clicked = if !table.items.is_empty() {
+        widgets::table_header(
             ui,
             &palette,
             table.show_album,
@@ -340,31 +578,11 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
             table.show_added_by,
             table.show_cover,
             sort,
+            true,
         )
-    {
-        // Ascending, descending, back to the list's own order.
-        let next = match sort {
-            Some(sort) if sort.column == column && sort.ascending => Some(TableSort {
-                column,
-                ascending: false,
-            }),
-            Some(sort) if sort.column == column => None,
-            _ => Some(TableSort {
-                column,
-                ascending: true,
-            }),
-        };
-        match next {
-            Some(sort) => {
-                app.table_sorts.insert(table.page.clone(), sort);
-                // A sort covers the whole list, so the rest must load.
-                app.actions.push(Action::LoadMore(table.page.clone()));
-            }
-            None => {
-                app.table_sorts.remove(&table.page);
-            }
-        }
-    }
+    } else {
+        None
+    };
     // What is displayed is what plays: a sorted view plays in its own
     // order, as a plain list of tracks, and its rows cannot edit server
     // positions that no longer match the screen.
@@ -399,6 +617,27 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
             },
         );
     });
+    if table_top < ui.clip_rect().top()
+        && let (Some(title), Some(uri)) = (table.sticky_title, table.sticky_play_uri)
+    {
+        mark_sticky(
+            ui,
+            &table.page,
+            StickyHeader {
+                title: title.to_string(),
+                play: StickyPlay::Context(uri.to_string()),
+                page: table.page.clone(),
+                show_album: table.show_album,
+                show_cover: table.show_cover,
+                show_added: table.show_added,
+                show_added_by: table.show_added_by,
+                show_columns: true,
+            },
+        );
+    }
+    if let Some(column) = clicked {
+        apply_sort(app, &table.page, column);
+    }
     if table.loading {
         ui.add_space(8.0);
         widgets::loading_row(ui, &palette);
@@ -511,6 +750,8 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
             error: None,
             can_load_more: false,
             filter: "",
+            sticky_title: None,
+            sticky_play_uri: None,
         },
     );
 }
@@ -625,6 +866,8 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                     error: page.items.error.as_deref(),
                     can_load_more: page.items.can_load_more(),
                     filter: &page.filter,
+                    sticky_title: Some(&playlist.name),
+                    sticky_play_uri: Some(&playlist.uri),
                 },
             );
         }
@@ -700,6 +943,8 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                     error: page.tracks.error.as_deref(),
                     can_load_more: page.tracks.can_load_more(),
                     filter: "",
+                    sticky_title: Some(&album.name),
+                    sticky_play_uri: Some(&album.uri),
                 },
             );
             ui.add_space(24.0);
@@ -848,9 +1093,9 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         .iter()
         .map(|(item, _, _)| item.uri().to_string())
         .collect();
-    let context = match collection_uri {
+    let context = match collection_uri.as_ref() {
         Some(uri) if app.library.liked.is_complete() => RowContext::Context {
-            uri,
+            uri: uri.clone(),
             editable_playlist: None,
         },
         _ => RowContext::Uris(uris),
@@ -874,6 +1119,8 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
             error: error.as_deref(),
             can_load_more,
             filter: &filter,
+            sticky_title: Some("Liked Songs"),
+            sticky_play_uri: collection_uri.as_deref(),
         },
     );
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -52,7 +52,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     toasts(app, ctx, theme::PLAYER_BAR_HEIGHT + 16.0);
 }
 
-fn page_tint(app: &mut App) -> Option<Color32> {
+pub(super) fn page_tint(app: &mut App) -> Option<Color32> {
     let page = app.page().clone();
     let image = match &page {
         Page::Playlist(id) => app
@@ -91,6 +91,37 @@ fn page_tint(app: &mut App) -> Option<Color32> {
     }
 }
 
+/// The single background treatment shared by a page and its sticky controls.
+pub(super) struct PageBackdrop {
+    rect: Rect,
+    top: Color32,
+    bottom: Color32,
+}
+
+impl PageBackdrop {
+    fn new(app: &App, rect: Rect, tint: Option<Color32>) -> Self {
+        let strength = if matches!(
+            app.page(),
+            Page::Home | Page::Search | Page::Settings | Page::Queue
+        ) {
+            0.45
+        } else {
+            0.85
+        };
+        Self {
+            rect,
+            top: tint.map_or(app.palette.window, |tint| {
+                blend(app.palette.window, tint, strength)
+            }),
+            bottom: app.palette.window,
+        }
+    }
+
+    pub(super) fn paint(&self, ui: &egui::Ui) {
+        widgets::paint_vertical_gradient(ui, self.rect, self.top, self.bottom);
+    }
+}
+
 fn central(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
     let tint = page_tint(app);
@@ -98,25 +129,23 @@ fn central(app: &mut App, ui: &mut egui::Ui) {
         .frame(Frame::new().fill(palette.window))
         .show(ui, |ui| {
             let rect = ui.max_rect();
-            if let Some(tint) = tint {
-                let strength = if matches!(
-                    app.page(),
-                    Page::Home | Page::Search | Page::Settings | Page::Queue
-                ) {
-                    0.45
-                } else {
-                    0.85
-                };
-                let top = blend(palette.window, tint, strength);
-                let header = Rect::from_min_size(rect.min, vec2(rect.width(), 340.0));
-                widgets::paint_vertical_gradient(ui, header, top, palette.window);
-            }
+            let backdrop = PageBackdrop::new(
+                app,
+                Rect::from_min_size(rect.min, vec2(rect.width(), 340.0)),
+                tint,
+            );
+            backdrop.paint(ui);
             ui.spacing_mut().item_spacing = vec2(8.0, 6.0);
             topbar::show(app, ui);
             let page = app.page().clone();
-            egui::ScrollArea::vertical()
+            let mut scroll_bar_rect = ui.available_rect_before_wrap();
+            scroll_bar_rect.min.y += collection::sticky_height(ui, &page);
+            collection::clear_sticky(ui, &page);
+            let content_page = page.clone();
+            let scroll = egui::ScrollArea::vertical()
                 .id_salt(("page", page.encode()))
                 .auto_shrink([false, false])
+                .scroll_bar_rect(scroll_bar_rect)
                 .show(ui, |ui| {
                     Frame::new()
                         .inner_margin(Margin {
@@ -127,13 +156,13 @@ fn central(app: &mut App, ui: &mut egui::Ui) {
                         })
                         .show(ui, |ui| {
                             ui.set_min_width(ui.available_width());
-                            match page {
+                            match content_page {
                                 Page::Home => home::show(app, ui),
                                 Page::TopSongs => collection::top_songs(app, ui),
                                 Page::Search => search::show(app, ui),
                                 Page::LikedSongs => collection::liked(app, ui),
                                 Page::Albums | Page::Artists | Page::Podcasts | Page::Episodes => {
-                                    library::show(app, ui, page)
+                                    library::show(app, ui, page.clone())
                                 }
                                 Page::Playlist(id) => collection::playlist(app, ui, &id),
                                 Page::Album(id) => collection::album(app, ui, &id),
@@ -144,6 +173,7 @@ fn central(app: &mut App, ui: &mut egui::Ui) {
                             }
                         });
                 });
+            collection::show_sticky(app, ui, &page, scroll.inner_rect, &backdrop);
         });
 }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -838,7 +838,7 @@ pub fn explicit_badge(ui: &mut Ui, palette: &Palette) {
 /// The header row above a track table.
 /// The column headings above a track table. Answers with the heading that
 /// was clicked, so the table can sort by it.
-#[expect(clippy::fn_params_excessive_bools)]
+#[expect(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub fn table_header(
     ui: &mut Ui,
     palette: &Palette,
@@ -847,6 +847,7 @@ pub fn table_header(
     show_added_by: bool,
     show_cover: bool,
     sort: Option<crate::model::TableSort>,
+    separator: bool,
 ) -> Option<crate::model::SortColumn> {
     use crate::model::SortColumn;
     let width = ui.available_width();
@@ -964,11 +965,13 @@ pub fn table_header(
     {
         clicked = Some(SortColumn::Duration);
     }
-    ui.painter().hline(
-        rect.x_range().shrink(8.0),
-        rect.bottom() - 0.5,
-        Stroke::new(1.0, palette.outline),
-    );
+    if separator {
+        ui.painter().hline(
+            rect.x_range().shrink(8.0),
+            rect.bottom() - 0.5,
+            Stroke::new(1.0, palette.outline),
+        );
+    }
     ui.add_space(6.0);
     clicked
 }


### PR DESCRIPTION
<img width="1166" height="320" alt="image" src="https://github.com/user-attachments/assets/21e0b0d5-b9ef-4cd6-bc8c-647f352054cc" />

## Summary

Adds Spotify-style sticky collection headers that keep playback controls available while scrolling.

- Adds animated sticky headers for Liked Songs, playlists, albums, and artist pages.
- Uses the page’s original background gradient mesh, keeping the sticky header visually continuous with the top bar.
- Adds compact Artist sticky headers that play the artist’s Top Songs as a queue.
- Keeps Play/Pause behavior consistent with the main player: pausing and resuming preserves the current position.
- Keeps the floating scrollbar below the visible sticky header.
- Preserves existing table sorting and header behavior for collection pages.

## Validation

- `cargo check`
- `cargo test` (51 tests)
- `cargo clippy --lib -- -D warnings`