### PR TITLE
Use shared and personal Spotify Web API apps together

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ librespot-protocol = { version = "0.8", default-features = false }
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
 cpal = "0.16"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "gzip", "http2", "blocking"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "fs"] }
 sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ here, set up once") or Settings; it needs Spotify Premium, and librespot
 stores a reusable credential so it also never asks again. Browsing and
 remote control work on any account without this step.
 
-By default the Web API uses the shared public application also used by
-spotify-player, ncspot, and Omarchy Spotify. If you hit rate limits you can
-register your own (free) Spotify application and paste its Client ID in
-Settings → Account.
+The Web API always keeps shared catalog coverage. You can also register a
+personal Spotify Development Mode app and paste its Client ID in Settings →
+Account; supported requests use its separate quota while complete playlist
+views, playlist-bearing search, external playlists, and unavailable operations
+continue through the shared app.
 
 ## Keyboard shortcuts
 
@@ -197,9 +198,10 @@ any time without signing you out.
 - `src/player.rs`: the librespot session, player, mixer, and Spirc (Spotify
   Connect) wrapped into one engine that folds player events into a state
   snapshot for the interface.
-- `src/api/`: a small Web API client with bounded concurrency,
-  `Retry-After` handling, and automatic fallback between the 2026 endpoint
-  shapes (`/me/library`, `/playlists/{id}/items`) and the classic ones.
+- `src/api/`: one routing gateway over independent shared and personal Web API
+  sessions, each with bounded concurrency and coordinated `Retry-After`
+  handling. Capability profiles select current endpoint contracts before a
+  request is dispatched.
 - `src/backend.rs`: a tokio runtime on its own thread; the interface talks to
   it through channels and is woken with `request_repaint`, so the app is idle
   when nothing happens.
@@ -210,8 +212,8 @@ any time without signing you out.
 - `src/mpris.rs`: Linux media controls on a dedicated thread.
 
 Fastpotify pins its Rust toolchain in `rust-toolchain.toml`; `cargo test`
-covers the API models, the endpoint fallbacks, PKCE, the player state
-machine, and a headless render of every page, panel, and dialog.
+covers the API models, dual-session routing, PKCE, the player state machine,
+and a headless render of every page, panel, and dialog.
 
 To look at the interface without a Spotify account, build with the `demo`
 feature and start it with sample data:

--- a/docs/_guide/make-it-even-faster.md
+++ b/docs/_guide/make-it-even-faster.md
@@ -1,6 +1,6 @@
 ---
 title: Make It Even Faster
-description: "Fastpotify is quick; Spotify's API rate limits are not. A Spotify app of your own lifts them in five minutes."
+description: "Use a personal Spotify app for a separate quota while shared coverage stays active."
 nav_order: 4
 ---
 
@@ -13,19 +13,19 @@ open-source players, so at busy times its requests queue behind everyone
 else's. That is the spinner in the top bar, and pages that take a while
 to fill.
 
-An app of your own has that limit to itself. Fastpotify cannot ship one
-for everyone (Spotify allows a new app only a handful of users), but
-making yours is free and takes five minutes.
+An app of your own gives supported requests a separate Development Mode
+quota. Fastpotify cannot ship one for everyone, but making yours is free and
+takes a few minutes.
 
-## What a personal app cannot do
+## Shared coverage stays active
 
-Spotify keeps a personal app in Development Mode, and since February 2026
-that mode reads only the playlists you own or collaborate on. Anyone
-else's public playlist, and Spotify's own editorial ones, show their name
-and cover but not their songs; artist top tracks and browsing are gone
-too. The shared app has none of these limits, so this is reach traded for
-speed. Switching back is one click: clear the field and press **Switch
-now**.
+Spotify keeps a personal app in Development Mode, and since February 2026 that
+mode omits Spotify-owned playlists and reads playlist items only for playlists
+you own or collaborate on. Artist top tracks, related artists,
+recommendations, and some catalog fields are unavailable too. Fastpotify uses
+the shared app for the complete playlist library, playlist-bearing search,
+external playlist metadata and items, and those unavailable operations. Your
+app accelerates supported work without replacing shared coverage.
 
 ## Make a Spotify app
 
@@ -49,9 +49,9 @@ now**.
 
 1. Open **Settings**, find **Make it even faster**, and paste the
    Client ID.
-2. Click **Switch now**. Your browser opens Spotify's sign-in for your
-   app; approve it and you are back in Fastpotify, which now says
-   **Your app is in use**.
+2. Click **Authorize**. Your browser opens Spotify's sign-in for your app.
+   Fastpotify verifies that it belongs to the same Spotify account, then shows
+   **Personal acceleration is ready**.
 
-That is all. Playing music on this computer is unaffected. To go back to
-the shared app, clear the field and click **Switch now** again.
+That is all. Playing music on this computer is unaffected. Select **Remove**
+to delete only the personal grant; the shared session stays signed in.

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -1,38 +1,38 @@
 ---
 title: How It Connects
-description: The two Spotify grants, why they are separate, what is stored, and what the client does when Spotify pushes back.
+description: Fastpotify's independent Spotify grants, what is stored, and how API traffic is routed.
 nav_order: 1
 ---
 
-## Two grants, once each
+## Independent grants, once each
 
-Fastpotify talks to Spotify in two distinct ways, and Spotify issues
-credentials for them separately:
+Fastpotify uses independent credentials for Web API coverage, optional
+personal acceleration, and local playback:
 
-1. **The Web API** covers your library, search, playlists, and devices. Fastpotify
-   uses the standard Authorization Code + PKCE flow in your browser, as a
-   registered Spotify application. The refresh token is stored locally and
-   renewed automatically; your password never touches the app.
-2. **Streaming** is actually playing audio on this computer, through
+1. **The shared Web API app** provides broad catalog and playlist coverage.
+2. **Your optional personal Web API app** handles supported playback, library,
+   catalog, playlist creation, and owned or collaborative playlist requests
+   without using the shared app's quota. Complete playlist-library views and
+   playlist-bearing search stay on the shared app so Spotify-owned results are
+   not filtered out. Both Web API grants must verify as the same Spotify
+   account.
+3. **Streaming** is actually playing audio on this computer, through
    [librespot](https://github.com/librespot-org/librespot). This runs the
    same browser flow once against Spotify's streaming client identity, after
    which librespot stores its own reusable credential. Premium is required,
    because that is what Spotify's streaming protocol requires.
 
-Why not one grant? Because Spotify throttles Web API calls made with
-streaming-identity tokens. Measured during development, every endpoint
-answers `429` within the first request. Two narrow grants are what actually
-works, and each one happens exactly once per machine.
+Local playback authorization stays separate from both Web API grants.
 
 By default the Web API uses the shared public application also used by
 spotify-player, ncspot, and Omarchy Spotify, whose allowance Spotify
-divides among everyone running any of them. An application of your own
-gets one to itself; [Make It Even Faster](/make-it-even-faster/) shows
-how, in five minutes.
+divides among everyone running any of them. An application of your own adds a
+separate Development Mode quota; [Make It Even Faster](/make-it-even-faster/)
+shows how to add one.
 
 ## What the client stores
 
-- The Web API refresh token and librespot's reusable credential, owner-only,
+- The shared and personal Web API refresh tokens and librespot's reusable credential, owner-only,
   in the state directory ([where](/settings-and-files/)).
 - Downloaded audio and artwork, in the cache directory, within the budget
   you set.
@@ -47,11 +47,10 @@ how, in five minutes.
 
 ## When Spotify pushes back
 
-The Web API rate-limits bursts. Fastpotify bounds its concurrency, honours
-`Retry-After`, retries quietly, and shows a small spinner in the top bar
-when a conversation with Spotify takes longer than a moment. Spotify also
-reshapes endpoints over time; the client detects several of these shapes at
-runtime and falls back to the older form where one still exists.
+Each Web API session has its own concurrency and cooldown. Fastpotify honours
+`Retry-After` without pausing the other session and treats Development Mode
+quota exhaustion separately from an ordinary burst limit. A logical request
+is routed once before dispatch and is never retried through the other app.
 
 ## Receivers on the local network
 

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -11,19 +11,21 @@ Fastpotify follows each platform's conventions. On Linux:
 | What | Where | Safe to delete? |
 | --- | --- | --- |
 | Settings | `~/.config/fastpotify/settings.json` | Yes, you lose preferences |
-| Web API sign-in | `~/.local/state/fastpotify/web_api_token.json` | Yes, you sign in again |
+| Shared Web API sign-in | `~/.local/state/fastpotify/shared_web_api_token.json` | Yes, you sign in again |
+| Personal Web API sign-in | `~/.local/state/fastpotify/personal_web_api_token.json` | Yes, personal acceleration is removed |
 | Playback credential | `~/.local/state/fastpotify/credentials/` | Yes, you approve playback again |
 | Last session | `~/.local/state/fastpotify/session.json` | Yes |
 | Audio cache | `~/.cache/fastpotify/audio/` | Always |
 | Artwork cache | `~/.cache/fastpotify/art/` | Always |
 | Lyrics cache | `~/.cache/fastpotify/lyrics/` | Always |
+| Account-scoped playlist cache | `~/.cache/fastpotify/playlists/<account-id>/` | Always |
 | Last run's log | `~/.local/state/fastpotify/fastpotify.log` | Always |
 | Crash log | `~/.local/state/fastpotify/panic.log` | Always |
 
 Clearing caches never signs you out; credentials live in *state*, not
-*cache*, precisely so cleanup tools cannot log you out. Both credential
-files are written with owner-only permissions. Signing out from Settings
-deletes both.
+*cache*. Web API token files are written with owner-only permissions.
+Signing out from Settings deletes both Web API grants and the separate
+playback credential.
 
 On macOS, settings, state, and the logs are in
 `~/Library/Application Support/me.paolino.fastpotify` and the caches in
@@ -49,7 +51,7 @@ One readable JSON file, written atomically. The interesting fields:
 | `accent_from_art` | `true` | Tint pages with album art |
 | `keep_playing_in_background` | `true` | Close to tray |
 | `check_for_updates` | `true` | Ask GitHub once a day for a newer release |
-| `web_client_id` | none | Your own Spotify app id, if you set one |
+| `web_client_id` | none | Optional personal Spotify app id used alongside shared coverage |
 
 ## Command line
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -21,6 +21,7 @@ use super::models::*;
 const BASE_URL: &str = "https://api.spotify.com/v1";
 const MAX_IN_FLIGHT: usize = 6;
 const RATE_LIMIT_RETRIES: u32 = 3;
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, Error)]
 pub enum ApiError {
@@ -136,10 +137,16 @@ impl WebTokens {
                         log::warn!("token refresh returned an unusable response: {error}")
                     }
                 },
-                Err(_) => {
+                Err(crate::auth::TokenEndpointError::Rejected { .. }) => {
                     return Err(ApiError::SignInExpired {
                         api_source: self.source,
                     });
+                }
+                Err(crate::auth::TokenEndpointError::Unreachable(detail)) => {
+                    if force || guard.expired() {
+                        return Err(ApiError::Network(detail));
+                    }
+                    log::warn!("token refresh failed, using the current token: {detail}");
                 }
             }
         }
@@ -366,7 +373,8 @@ impl ApiClient {
                     .get(reqwest::header::RETRY_AFTER)
                     .and_then(|value| value.to_str().ok())
                     .and_then(|value| value.parse::<u64>().ok())
-                    .map_or(Duration::from_secs(1), Duration::from_secs);
+                    .map_or(Duration::from_secs(1), Duration::from_secs)
+                    .min(MAX_RETRY_AFTER);
                 let text = response.text().await.unwrap_or_default();
                 if is_quota_exhausted(&text) {
                     return Err(ApiError::QuotaExhausted);

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -3,12 +3,9 @@
 //! The client is deliberately small: a handful of typed calls over one
 //! `request` helper that injects the bearer token, bounds concurrency,
 //! honours `Retry-After`, and maps error bodies to messages a person can
-//! read. Spotify reshaped several endpoints in 2026 (`/me/library`,
-//! `/playlists/{id}/items`, search limits); the client tries the current
-//! shape first and falls back to the classic one when Spotify answers that
-//! an endpoint is gone, remembering the answer for the rest of the session.
+//! read. The gateway supplies capability differences before dispatch.
 
-use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -18,25 +15,25 @@ use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::sync::Semaphore;
 
+use super::ApiSource;
 use super::models::*;
 
 const BASE_URL: &str = "https://api.spotify.com/v1";
 const MAX_IN_FLIGHT: usize = 6;
 const RATE_LIMIT_RETRIES: u32 = 3;
-const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum ApiError {
     #[error("not signed in")]
     NotSignedIn,
     #[error("{message}")]
     Status { status: u16, message: String },
-    #[error(
-        "Spotify is rate limiting the shared app; try again in a moment, or use your own app (Settings)"
-    )]
+    #[error("Spotify is rate limiting requests; try again in a moment")]
     RateLimited,
+    #[error("Spotify's Development Mode quota is exhausted; try again after the quota resets")]
+    QuotaExhausted,
     #[error("your Spotify sign-in expired; please sign in again")]
-    SignInExpired(String),
+    SignInExpired { api_source: ApiSource },
     #[error("network error: {0}")]
     Network(String),
     #[error("unexpected response from Spotify: {0}")]
@@ -49,10 +46,6 @@ impl ApiError {
             Self::Status { status, .. } => Some(*status),
             _ => None,
         }
-    }
-
-    fn is_gone(&self) -> bool {
-        matches!(self.status(), Some(404) | Some(410) | Some(405) | Some(400))
     }
 }
 
@@ -67,6 +60,13 @@ impl From<reqwest::Error> for ApiError {
 }
 
 pub type Result<T> = std::result::Result<T, ApiError>;
+
+fn is_quota_exhausted(body: &str) -> bool {
+    serde_json::from_str::<ApiErrorBody>(body)
+        .ok()
+        .and_then(|body| body.error.reason)
+        .is_some_and(|reason| reason == "QUOTA_EXCEEDED")
+}
 
 /// Where bearer tokens come from.
 ///
@@ -97,6 +97,7 @@ pub struct WebTokens {
     http: reqwest::Client,
     token: tokio::sync::Mutex<crate::auth::StoredToken>,
     path: std::path::PathBuf,
+    source: ApiSource,
 }
 
 impl WebTokens {
@@ -104,11 +105,13 @@ impl WebTokens {
         http: reqwest::Client,
         token: crate::auth::StoredToken,
         path: std::path::PathBuf,
+        source: ApiSource,
     ) -> std::sync::Arc<Self> {
         std::sync::Arc::new(Self {
             http,
             token: tokio::sync::Mutex::new(token),
             path,
+            source,
         })
     }
 
@@ -133,23 +136,15 @@ impl WebTokens {
                         log::warn!("token refresh returned an unusable response: {error}")
                     }
                 },
-                Err(error) => {
-                    // A hard refresh failure means the grant is gone.
-                    if force || guard.needs_refresh() {
-                        return Err(ApiError::SignInExpired(error.to_string()));
-                    }
-                    log::warn!("token refresh failed, using the current token: {error}");
+                Err(_) => {
+                    return Err(ApiError::SignInExpired {
+                        api_source: self.source,
+                    });
                 }
             }
         }
         Ok(guard.access_token.clone())
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum LibraryStyle {
-    Modern,
-    Classic,
 }
 
 /// What to start playing.
@@ -263,19 +258,29 @@ pub struct ApiClient {
     http: reqwest::Client,
     tokens: Mutex<Option<TokenProvider>>,
     limiter: Semaphore,
-    library_style: AtomicU8,
-    search_limit: AtomicU32,
+    cooldown_until: tokio::sync::Mutex<Instant>,
+    search_limit: u32,
+    artist_albums_limit: u32,
+    source: ApiSource,
     activity: Arc<NetActivity>,
 }
 
 impl ApiClient {
-    pub fn new(http: reqwest::Client, activity: Arc<NetActivity>) -> Self {
+    pub fn new(
+        http: reqwest::Client,
+        activity: Arc<NetActivity>,
+        search_limit: u32,
+        artist_albums_limit: u32,
+        source: ApiSource,
+    ) -> Self {
         Self {
             http,
             tokens: Mutex::new(None),
             limiter: Semaphore::new(MAX_IN_FLIGHT),
-            library_style: AtomicU8::new(LibraryStyle::Modern as u8),
-            search_limit: AtomicU32::new(20),
+            cooldown_until: tokio::sync::Mutex::new(Instant::now()),
+            search_limit,
+            artist_albums_limit,
+            source,
             activity,
         }
     }
@@ -292,17 +297,19 @@ impl ApiClient {
             .ok_or(ApiError::NotSignedIn)
     }
 
-    fn style(&self) -> LibraryStyle {
-        if self.library_style.load(Ordering::Relaxed) == LibraryStyle::Classic as u8 {
-            LibraryStyle::Classic
-        } else {
-            LibraryStyle::Modern
+    async fn wait_for_cooldown(&self) {
+        loop {
+            let until = *self.cooldown_until.lock().await;
+            let Some(wait) = until.checked_duration_since(Instant::now()) else {
+                return;
+            };
+            tokio::time::sleep(wait).await;
         }
     }
 
-    fn set_style(&self, style: LibraryStyle) {
-        log::info!("switching library endpoint style to {style:?}");
-        self.library_style.store(style as u8, Ordering::Relaxed);
+    async fn extend_cooldown(&self, wait: Duration) {
+        let mut until = self.cooldown_until.lock().await;
+        *until = (*until).max(Instant::now() + wait);
     }
 
     // ---- transport -------------------------------------------------------
@@ -320,17 +327,19 @@ impl ApiClient {
             format!("{BASE_URL}{path}")
         };
         let provider = self.provider()?;
-        self.activity.begin();
-        let _activity = ActivityGuard(&self.activity);
-        let _permit = self
-            .limiter
-            .acquire()
-            .await
-            .map_err(|_| ApiError::NotSignedIn)?;
+        let started = Instant::now();
 
         let mut attempt = 0;
         loop {
             attempt += 1;
+            self.wait_for_cooldown().await;
+            let permit = self
+                .limiter
+                .acquire()
+                .await
+                .map_err(|_| ApiError::NotSignedIn)?;
+            self.activity.begin();
+            let activity = ActivityGuard(&self.activity);
             let token = provider.access_token().await?;
             let mut request = self
                 .http
@@ -346,7 +355,8 @@ impl ApiClient {
             let status = response.status();
 
             if status == StatusCode::UNAUTHORIZED && attempt == 1 {
-                // The access token was rejected; force a refresh and retry once.
+                drop(activity);
+                drop(permit);
                 provider.invalidate().await;
                 continue;
             }
@@ -356,13 +366,25 @@ impl ApiClient {
                     .get(reqwest::header::RETRY_AFTER)
                     .and_then(|value| value.to_str().ok())
                     .and_then(|value| value.parse::<u64>().ok())
-                    .map_or(Duration::from_secs(1), Duration::from_secs)
-                    .min(MAX_RETRY_AFTER);
-                log::warn!("rate limited on {path}; waiting {wait:?}");
-                tokio::time::sleep(wait).await;
+                    .map_or(Duration::from_secs(1), Duration::from_secs);
+                let text = response.text().await.unwrap_or_default();
+                if is_quota_exhausted(&text) {
+                    return Err(ApiError::QuotaExhausted);
+                }
+                log::warn!("Spotify rate limit source={} wait={wait:?}", self.source);
+                log::info!(
+                    "Spotify cooldown source={} duration_ms={}",
+                    self.source,
+                    wait.as_millis()
+                );
+                drop(activity);
+                drop(permit);
+                self.extend_cooldown(wait).await;
                 continue;
             }
-            if status.is_server_error() && attempt == 1 {
+            if status.is_server_error() && method == Method::GET && attempt == 1 {
+                drop(activity);
+                drop(permit);
                 tokio::time::sleep(Duration::from_millis(800)).await;
                 continue;
             }
@@ -370,6 +392,13 @@ impl ApiClient {
                 return Err(ApiError::RateLimited);
             }
             let text = response.text().await?;
+            log::debug!(
+                "Spotify request source={} method={} status={} duration_ms={}",
+                self.source,
+                method,
+                status.as_u16(),
+                started.elapsed().as_millis()
+            );
             if status.is_success() {
                 return Ok(text);
             }
@@ -433,7 +462,10 @@ impl ApiClient {
         match serde_json::from_str(&text) {
             Ok(value) => Ok(Some(value)),
             Err(error) => {
-                log::debug!("{path} succeeded with a body that is not JSON: {error}");
+                log::debug!(
+                    "Spotify write source={} returned a non-JSON success body: {error}",
+                    self.source
+                );
                 Ok(None)
             }
         }
@@ -583,74 +615,32 @@ impl ApiClient {
         self.get(&format!("/playlists/{id}"), &[]).await
     }
 
-    fn playlist_items_path(&self, id: &str, style: LibraryStyle) -> String {
-        match style {
-            LibraryStyle::Modern => format!("/playlists/{id}/items"),
-            LibraryStyle::Classic => format!("/playlists/{id}/tracks"),
-        }
-    }
-
-    /// Runs `call` with the current endpoint style, switching styles once when
-    /// Spotify says the endpoint does not exist.
-    async fn with_style_fallback<T, F, Fut>(&self, call: F) -> Result<T>
-    where
-        F: Fn(LibraryStyle) -> Fut,
-        Fut: std::future::Future<Output = Result<T>>,
-    {
-        let style = self.style();
-        match call(style).await {
-            Err(error) if error.is_gone() => {
-                let other = match style {
-                    LibraryStyle::Modern => LibraryStyle::Classic,
-                    LibraryStyle::Classic => LibraryStyle::Modern,
-                };
-                match call(other).await {
-                    Ok(value) => {
-                        self.set_style(other);
-                        Ok(value)
-                    }
-                    Err(_) => Err(error),
-                }
-            }
-            result => result,
-        }
-    }
-
     pub async fn playlist_items(
         &self,
         id: &str,
         offset: u32,
         limit: u32,
     ) -> Result<Page<PlaylistItem>> {
-        self.with_style_fallback(|style| async move {
-            self.get(
-                &self.playlist_items_path(id, style),
-                &[
-                    ("limit", limit.to_string()),
-                    ("offset", offset.to_string()),
-                    ("additional_types", "track,episode".to_string()),
-                ],
-            )
-            .await
-        })
+        self.get(
+            &format!("/playlists/{id}/items"),
+            &[
+                ("limit", limit.to_string()),
+                ("offset", offset.to_string()),
+                ("additional_types", "track,episode".to_string()),
+            ],
+        )
         .await
     }
 
     pub async fn create_playlist(
         &self,
-        user_id: &str,
         name: &str,
         public: bool,
         description: &str,
     ) -> Result<Playlist> {
         let body = json!({ "name": name, "public": public, "description": description });
         let value = self
-            .write(
-                Method::POST,
-                &format!("/users/{user_id}/playlists"),
-                &[],
-                Some(&body),
-            )
+            .write(Method::POST, "/me/playlists", &[], Some(&body))
             .await?
             .unwrap_or(Value::Null);
         serde_json::from_value(value).map_err(|error| ApiError::Decode(error.to_string()))
@@ -694,18 +684,12 @@ impl ApiClient {
             body["position"] = json!(position);
         }
         let value = self
-            .with_style_fallback(|style| {
-                let body = body.clone();
-                async move {
-                    self.write(
-                        Method::POST,
-                        &self.playlist_items_path(id, style),
-                        &[],
-                        Some(&body),
-                    )
-                    .await
-                }
-            })
+            .write(
+                Method::POST,
+                &format!("/playlists/{id}/items"),
+                &[],
+                Some(&body),
+            )
             .await?;
         Ok(Self::snapshot(value))
     }
@@ -716,24 +700,18 @@ impl ApiClient {
         uris: &[String],
         snapshot_id: Option<&str>,
     ) -> Result<Option<String>> {
+        let entries: Vec<Value> = uris.iter().map(|uri| json!({ "uri": uri })).collect();
+        let mut body = json!({ "items": entries });
+        if let Some(snapshot) = snapshot_id {
+            body["snapshot_id"] = json!(snapshot);
+        }
         let value = self
-            .with_style_fallback(|style| async move {
-                let entries: Vec<Value> = uris.iter().map(|uri| json!({ "uri": uri })).collect();
-                let mut body = match style {
-                    LibraryStyle::Modern => json!({ "items": entries }),
-                    LibraryStyle::Classic => json!({ "tracks": entries }),
-                };
-                if let Some(snapshot) = snapshot_id {
-                    body["snapshot_id"] = json!(snapshot);
-                }
-                self.write(
-                    Method::DELETE,
-                    &self.playlist_items_path(id, style),
-                    &[],
-                    Some(&body),
-                )
-                .await
-            })
+            .write(
+                Method::DELETE,
+                &format!("/playlists/{id}/items"),
+                &[],
+                Some(&body),
+            )
             .await?;
         Ok(Self::snapshot(value))
     }
@@ -745,24 +723,21 @@ impl ApiClient {
         insert_before: u32,
         snapshot_id: Option<&str>,
     ) -> Result<Option<String>> {
+        let mut body = json!({
+            "range_start": range_start,
+            "insert_before": insert_before,
+            "range_length": 1,
+        });
+        if let Some(snapshot) = snapshot_id {
+            body["snapshot_id"] = json!(snapshot);
+        }
         let value = self
-            .with_style_fallback(|style| async move {
-                let mut body = json!({
-                    "range_start": range_start,
-                    "insert_before": insert_before,
-                    "range_length": 1,
-                });
-                if let Some(snapshot) = snapshot_id {
-                    body["snapshot_id"] = json!(snapshot);
-                }
-                self.write(
-                    Method::PUT,
-                    &self.playlist_items_path(id, style),
-                    &[],
-                    Some(&body),
-                )
-                .await
-            })
+            .write(
+                Method::PUT,
+                &format!("/playlists/{id}/items"),
+                &[],
+                Some(&body),
+            )
             .await?;
         Ok(Self::snapshot(value))
     }
@@ -774,55 +749,23 @@ impl ApiClient {
     }
 
     pub async fn follow_playlist(&self, id: &str) -> Result<()> {
-        self.with_style_fallback(|style| async move {
-            match style {
-                LibraryStyle::Modern => {
-                    self.write(
-                        Method::PUT,
-                        "/me/library",
-                        &[("uris", format!("spotify:playlist:{id}"))],
-                        None,
-                    )
-                    .await
-                }
-                LibraryStyle::Classic => {
-                    self.write(
-                        Method::PUT,
-                        &format!("/playlists/{id}/followers"),
-                        &[],
-                        Some(&json!({ "public": false })),
-                    )
-                    .await
-                }
-            }
-        })
+        self.write(
+            Method::PUT,
+            "/me/library",
+            &[("uris", format!("spotify:playlist:{id}"))],
+            None,
+        )
         .await?;
         Ok(())
     }
 
     pub async fn unfollow_playlist(&self, id: &str) -> Result<()> {
-        self.with_style_fallback(|style| async move {
-            match style {
-                LibraryStyle::Modern => {
-                    self.write(
-                        Method::DELETE,
-                        "/me/library",
-                        &[("uris", format!("spotify:playlist:{id}"))],
-                        None,
-                    )
-                    .await
-                }
-                LibraryStyle::Classic => {
-                    self.write(
-                        Method::DELETE,
-                        &format!("/playlists/{id}/followers"),
-                        &[],
-                        None,
-                    )
-                    .await
-                }
-            }
-        })
+        self.write(
+            Method::DELETE,
+            "/me/library",
+            &[("uris", format!("spotify:playlist:{id}"))],
+            None,
+        )
         .await?;
         Ok(())
     }
@@ -902,51 +845,9 @@ impl ApiClient {
         .await
     }
 
-    fn classic_library_path(uri: &str) -> Option<(&'static str, Vec<(&'static str, String)>)> {
-        let mut parts = uri.split(':');
-        let (_, kind, id) = (parts.next()?, parts.next()?, parts.next()?);
-        let id = id.to_string();
-        Some(match kind {
-            "track" => ("/me/tracks", vec![("ids", id)]),
-            "album" => ("/me/albums", vec![("ids", id)]),
-            "show" => ("/me/shows", vec![("ids", id)]),
-            "episode" => ("/me/episodes", vec![("ids", id)]),
-            "artist" => (
-                "/me/following",
-                vec![("type", "artist".to_string()), ("ids", id)],
-            ),
-            _ => return None,
-        })
-    }
-
     async fn library_write(&self, method: Method, uris: &[String]) -> Result<()> {
-        self.with_style_fallback(|style| {
-            let method = method.clone();
-            async move {
-                match style {
-                    LibraryStyle::Modern => {
-                        self.write(method, "/me/library", &[("uris", uris.join(","))], None)
-                            .await
-                    }
-                    LibraryStyle::Classic => {
-                        for uri in uris {
-                            if uri.starts_with("spotify:playlist:") {
-                                let id = uri.rsplit(':').next().unwrap_or_default();
-                                let path = format!("/playlists/{id}/followers");
-                                self.write(method.clone(), &path, &[], None).await?;
-                                continue;
-                            }
-                            let Some((path, query)) = Self::classic_library_path(uri) else {
-                                continue;
-                            };
-                            self.write(method.clone(), path, &query, None).await?;
-                        }
-                        Ok(None)
-                    }
-                }
-            }
-        })
-        .await?;
+        self.write(method, "/me/library", &[("uris", uris.join(","))], None)
+            .await?;
         Ok(())
     }
 
@@ -960,100 +861,33 @@ impl ApiClient {
     }
 
     /// Whether each URI is in the library, in the same order as `uris`.
-    pub async fn contains(&self, uris: &[String], user_id: &str) -> Result<Vec<bool>> {
-        self.with_style_fallback(|style| async move {
-            match style {
-                LibraryStyle::Modern => {
-                    self.get("/me/library/contains", &[("uris", uris.join(","))])
-                        .await
-                }
-                LibraryStyle::Classic => {
-                    let mut result = Vec::with_capacity(uris.len());
-                    for uri in uris {
-                        if uri.starts_with("spotify:playlist:") {
-                            let id = uri.rsplit(':').next().unwrap_or_default();
-                            let flags: Vec<bool> = self
-                                .get(
-                                    &format!("/playlists/{id}/followers/contains"),
-                                    &[("ids", user_id.to_string())],
-                                )
-                                .await?;
-                            result.push(flags.first().copied().unwrap_or(false));
-                            continue;
-                        }
-                        let Some((path, query)) = Self::classic_library_path(uri) else {
-                            result.push(false);
-                            continue;
-                        };
-                        let flags: Vec<bool> =
-                            self.get(&format!("{path}/contains"), &query).await?;
-                        result.push(flags.first().copied().unwrap_or(false));
-                    }
-                    Ok(result)
-                }
-            }
-        })
-        .await
+    pub async fn contains(&self, uris: &[String]) -> Result<Vec<bool>> {
+        self.get("/me/library/contains", &[("uris", uris.join(","))])
+            .await
     }
 
     // ---- catalog -----------------------------------------------------------
 
     pub async fn search(&self, query: &str, types: &[&str]) -> Result<SearchResults> {
-        let limit = self.search_limit.load(Ordering::Relaxed);
-        let run = |limit: u32| async move {
-            self.get(
-                "/search",
-                &[
-                    ("q", query.to_string()),
-                    ("type", types.join(",")),
-                    ("limit", limit.to_string()),
-                ],
-            )
-            .await
-        };
-        match run(limit).await {
-            Err(error) if limit > 10 && matches!(error.status(), Some(400) | Some(403)) => {
-                self.search_limit.store(10, Ordering::Relaxed);
-                run(10).await
-            }
-            result => result,
-        }
+        self.get(
+            "/search",
+            &[
+                ("q", query.to_string()),
+                ("type", types.join(",")),
+                ("limit", self.search_limit.to_string()),
+            ],
+        )
+        .await
     }
 
     pub async fn artist(&self, id: &str) -> Result<Artist> {
         self.get(&format!("/artists/{id}"), &[]).await
     }
 
-    /// The artist's most popular tracks. Spotify has retired this endpoint for
-    /// newer applications, so a catalog search ranked by popularity stands in
-    /// when it is unavailable.
-    pub async fn artist_top_tracks(&self, id: &str, name: &str) -> Result<Vec<Track>> {
-        match self
-            .get::<TopTracks>(&format!("/artists/{id}/top-tracks"), &[])
+    pub async fn artist_top_tracks(&self, id: &str) -> Result<Vec<Track>> {
+        self.get::<TopTracks>(&format!("/artists/{id}/top-tracks"), &[])
             .await
-        {
-            Ok(top) => Ok(top.tracks),
-            Err(error) if error.is_gone() || error.status() == Some(403) => {
-                let results = self
-                    .search(&format!("artist:\"{name}\""), &["track"])
-                    .await?;
-                let mut tracks: Vec<Track> = results
-                    .tracks
-                    .map(|page| page.items)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|track| {
-                        track
-                            .artists
-                            .iter()
-                            .any(|artist| artist.id.as_deref() == Some(id))
-                    })
-                    .collect();
-                tracks.sort_by_key(|track| std::cmp::Reverse(track.popularity));
-                Ok(tracks)
-            }
-            Err(error) => Err(error),
-        }
+            .map(|top| top.tracks)
     }
 
     pub async fn artist_albums(
@@ -1063,6 +897,7 @@ impl ApiClient {
         offset: u32,
         limit: u32,
     ) -> Result<Page<Album>> {
+        let limit = limit.min(self.artist_albums_limit);
         self.get(
             &format!("/artists/{id}/albums"),
             &[
@@ -1146,29 +981,34 @@ mod tests {
     }
 
     #[test]
-    fn classic_library_paths() {
-        let (path, query) = ApiClient::classic_library_path("spotify:artist:abc").unwrap();
-        assert_eq!(path, "/me/following");
-        assert_eq!(query[1], ("ids", "abc".to_string()));
-        assert!(ApiClient::classic_library_path("spotify:user:abc").is_none());
+    fn quota_exhaustion_is_distinct_from_an_ordinary_rate_limit() {
+        assert!(is_quota_exhausted(
+            r#"{"error":{"status":429,"reason":"QUOTA_EXCEEDED"}}"#
+        ));
+        assert!(!is_quota_exhausted(
+            r#"{"error":{"status":429,"message":"Too many requests"}}"#
+        ));
     }
 
-    #[test]
-    fn gone_errors_trigger_fallback() {
-        assert!(
-            ApiError::Status {
-                status: 404,
-                message: String::new()
-            }
-            .is_gone()
+    #[tokio::test]
+    async fn cooldown_state_is_owned_by_one_session() {
+        let activity = Arc::new(NetActivity::default());
+        let shared = ApiClient::new(
+            reqwest::Client::new(),
+            activity.clone(),
+            20,
+            50,
+            ApiSource::Shared,
         );
-        assert!(
-            !ApiError::Status {
-                status: 500,
-                message: String::new()
-            }
-            .is_gone()
+        let personal = ApiClient::new(
+            reqwest::Client::new(),
+            activity,
+            10,
+            10,
+            ApiSource::Personal,
         );
-        assert!(!ApiError::RateLimited.is_gone());
+        shared.extend_cooldown(Duration::from_secs(10)).await;
+        assert!(*shared.cooldown_until.lock().await > Instant::now());
+        assert!(*personal.cooldown_until.lock().await <= Instant::now());
     }
 }

--- a/src/api/gateway.rs
+++ b/src/api/gateway.rs
@@ -1,0 +1,525 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+
+use super::ApiSource;
+use super::client::{ApiClient, ApiError, NetActivity, TokenProvider};
+use super::models::{Page, Playlist, PlaylistItem};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AccountId(String);
+
+impl AccountId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PlaylistId(String);
+
+impl PlaylistId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionState {
+    Unavailable,
+    Authorizing,
+    Ready { account: AccountId },
+    Failed,
+}
+
+impl SessionState {
+    pub fn account(&self) -> Option<&AccountId> {
+        match self {
+            Self::Ready { account } => Some(account),
+            Self::Unavailable | Self::Authorizing | Self::Failed => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ApiProfile {
+    source: ApiSource,
+    search_limit: u32,
+    artist_albums_limit: u32,
+}
+
+impl ApiProfile {
+    pub const SHARED: Self = Self {
+        source: ApiSource::Shared,
+        search_limit: 20,
+        artist_albums_limit: 50,
+    };
+    pub const PERSONAL: Self = Self {
+        source: ApiSource::Personal,
+        search_limit: 10,
+        artist_albums_limit: 10,
+    };
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PlaylistAccess {
+    Owned,
+    Collaborative,
+    External,
+    #[default]
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Operation {
+    CanonicalAccount,
+    Playback,
+    UserData,
+    PlaylistLibrary,
+    PlaylistCreation,
+    PlaylistSearch,
+    Catalog,
+    PlaylistMetadata(PlaylistAccess),
+    PlaylistItems(PlaylistAccess),
+    PlaylistMutation(PlaylistAccess),
+    UnsupportedDevelopmentMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Route {
+    Dispatch(ApiSource),
+    ClassifyPlaylist,
+}
+
+fn plan(operation: Operation, personal_ready: bool) -> Route {
+    use Operation::*;
+    match operation {
+        CanonicalAccount | PlaylistLibrary | PlaylistSearch | UnsupportedDevelopmentMode => {
+            Route::Dispatch(ApiSource::Shared)
+        }
+        PlaylistItems(PlaylistAccess::Unknown) | PlaylistMutation(PlaylistAccess::Unknown)
+            if personal_ready =>
+        {
+            Route::ClassifyPlaylist
+        }
+        PlaylistMetadata(PlaylistAccess::External | PlaylistAccess::Unknown)
+        | PlaylistItems(PlaylistAccess::External)
+        | PlaylistMutation(PlaylistAccess::External) => Route::Dispatch(ApiSource::Shared),
+        PlaylistMetadata(_) | PlaylistItems(_) | PlaylistMutation(_) if personal_ready => {
+            Route::Dispatch(ApiSource::Personal)
+        }
+        Playback | UserData | PlaylistCreation | Catalog if personal_ready => {
+            Route::Dispatch(ApiSource::Personal)
+        }
+        Playback | UserData | PlaylistCreation | Catalog | PlaylistMetadata(_)
+        | PlaylistItems(_) | PlaylistMutation(_) => Route::Dispatch(ApiSource::Shared),
+    }
+}
+
+fn classify_playlist(account: &AccountId, playlist: &Playlist) -> PlaylistAccess {
+    if playlist.owner.id.as_deref() == Some(account.as_str()) {
+        PlaylistAccess::Owned
+    } else if playlist.collaborative {
+        PlaylistAccess::Collaborative
+    } else if playlist.owner.id.is_some() {
+        PlaylistAccess::External
+    } else {
+        PlaylistAccess::Unknown
+    }
+}
+
+struct Session {
+    state: RwLock<SessionState>,
+    client: Arc<ApiClient>,
+}
+
+impl Session {
+    fn new(http: reqwest::Client, activity: Arc<NetActivity>, profile: ApiProfile) -> Self {
+        Self {
+            state: RwLock::new(SessionState::Unavailable),
+            client: Arc::new(ApiClient::new(
+                http,
+                activity,
+                profile.search_limit,
+                profile.artist_albums_limit,
+                profile.source,
+            )),
+        }
+    }
+
+    fn state(&self) -> SessionState {
+        self.state
+            .read()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .clone()
+    }
+
+    fn set_state(&self, state: SessionState) {
+        *self.state.write().unwrap_or_else(|lock| lock.into_inner()) = state;
+    }
+}
+
+pub struct ApiGateway {
+    shared: Session,
+    personal: Session,
+    playlist_access: Mutex<HashMap<PlaylistId, PlaylistAccess>>,
+}
+
+impl ApiGateway {
+    pub fn new(http: reqwest::Client, activity: Arc<NetActivity>) -> Self {
+        Self {
+            shared: Session::new(http.clone(), activity.clone(), ApiProfile::SHARED),
+            personal: Session::new(http, activity, ApiProfile::PERSONAL),
+            playlist_access: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn session(&self, source: ApiSource) -> &Session {
+        match source {
+            ApiSource::Shared => &self.shared,
+            ApiSource::Personal => &self.personal,
+        }
+    }
+
+    pub fn state(&self, source: ApiSource) -> SessionState {
+        self.session(source).state()
+    }
+
+    pub fn set_state(&self, source: ApiSource, state: SessionState) {
+        self.session(source).set_state(state);
+    }
+
+    pub fn install(
+        &self,
+        source: ApiSource,
+        provider: TokenProvider,
+        account: AccountId,
+    ) -> Result<(), ApiError> {
+        let other = match source {
+            ApiSource::Shared => ApiSource::Personal,
+            ApiSource::Personal => ApiSource::Shared,
+        };
+        if self
+            .state(other)
+            .account()
+            .is_some_and(|active| active != &account)
+        {
+            return Err(ApiError::Status {
+                status: 403,
+                message: "The Spotify grants belong to different accounts".into(),
+            });
+        }
+        let session = self.session(source);
+        session.client.set_token_provider(Some(provider));
+        session.set_state(SessionState::Ready { account });
+        Ok(())
+    }
+
+    pub fn begin_verification(&self, source: ApiSource, provider: TokenProvider) {
+        let session = self.session(source);
+        session.client.set_token_provider(Some(provider));
+        session.set_state(SessionState::Authorizing);
+    }
+
+    pub fn verification_client(&self, source: ApiSource) -> Arc<ApiClient> {
+        Arc::clone(&self.session(source).client)
+    }
+
+    pub fn clear(&self, source: ApiSource) {
+        let session = self.session(source);
+        session.client.set_token_provider(None);
+        session.set_state(SessionState::Unavailable);
+    }
+
+    pub fn fail(&self, source: ApiSource) {
+        let session = self.session(source);
+        session.client.set_token_provider(None);
+        session.set_state(SessionState::Failed);
+    }
+
+    pub fn clear_all(&self) {
+        self.clear(ApiSource::Shared);
+        self.clear(ApiSource::Personal);
+        self.playlist_access
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .clear();
+    }
+
+    pub fn account(&self) -> Option<AccountId> {
+        self.state(ApiSource::Shared)
+            .account()
+            .cloned()
+            .or_else(|| self.state(ApiSource::Personal).account().cloned())
+    }
+
+    pub fn personal_ready(&self) -> bool {
+        matches!(self.state(ApiSource::Personal), SessionState::Ready { .. })
+    }
+
+    fn source_for(&self, operation: Operation) -> Route {
+        plan(operation, self.personal_ready())
+    }
+
+    pub fn client_for(
+        &self,
+        operation: Operation,
+    ) -> Result<(ApiSource, Arc<ApiClient>), ApiError> {
+        let Route::Dispatch(source) = self.source_for(operation) else {
+            return Err(ApiError::Decode(
+                "playlist access must be classified before dispatch".into(),
+            ));
+        };
+        let session = self.session(source);
+        if !matches!(session.state(), SessionState::Ready { .. }) {
+            return Err(ApiError::NotSignedIn);
+        }
+        log::debug!("Spotify route operation={operation:?} source={source}");
+        Ok((source, Arc::clone(&session.client)))
+    }
+
+    pub fn playlist_access(&self, id: &PlaylistId) -> PlaylistAccess {
+        self.playlist_access
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .get(id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn observe_playlist(&self, playlist: &Playlist) {
+        let Some(account) = self.account() else {
+            return;
+        };
+        let access = classify_playlist(&account, playlist);
+        self.playlist_access
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .insert(PlaylistId::new(playlist.id.clone()), access);
+    }
+
+    pub fn observe_playlists<'a>(&self, playlists: impl IntoIterator<Item = &'a Playlist>) {
+        for playlist in playlists {
+            self.observe_playlist(playlist);
+        }
+    }
+
+    pub fn invalidate_playlist_access(&self, id: &PlaylistId) {
+        self.playlist_access
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .insert(id.clone(), PlaylistAccess::Unknown);
+    }
+
+    async fn playlist_client(
+        &self,
+        id: &PlaylistId,
+        mutation: bool,
+    ) -> Result<(ApiSource, Arc<ApiClient>), ApiError> {
+        let access = self.playlist_access(id);
+        let operation = if mutation {
+            Operation::PlaylistMutation(access)
+        } else {
+            Operation::PlaylistItems(access)
+        };
+        if self.source_for(operation) == Route::ClassifyPlaylist {
+            let (_, shared) =
+                self.client_for(Operation::PlaylistMetadata(PlaylistAccess::Unknown))?;
+            let metadata = shared.playlist(id.as_str()).await?;
+            self.observe_playlist(&metadata);
+        }
+        let access = self.playlist_access(id);
+        let operation = if mutation {
+            Operation::PlaylistMutation(access)
+        } else {
+            Operation::PlaylistItems(access)
+        };
+        self.client_for(operation)
+    }
+
+    pub async fn playlist_items(
+        &self,
+        id: &str,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Page<PlaylistItem>, ApiError> {
+        let id = PlaylistId::new(id);
+        let (_, client) = self.playlist_client(&id, false).await?;
+        let result = client.playlist_items(id.as_str(), offset, limit).await;
+        if result.as_ref().err().and_then(ApiError::status) == Some(403) {
+            self.invalidate_playlist_access(&id);
+        }
+        result
+    }
+
+    pub async fn playlist_mutation_client(
+        &self,
+        id: &str,
+    ) -> Result<(ApiSource, Arc<ApiClient>), ApiError> {
+        self.playlist_client(&PlaylistId::new(id), true).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(name: &str, source: ApiSource) -> TokenProvider {
+        let path = std::env::temp_dir().join(format!("fastpotify-{name}-unused-token.json"));
+        TokenProvider::Web(super::super::client::WebTokens::new(
+            reqwest::Client::new(),
+            crate::auth::StoredToken::default(),
+            path,
+            source,
+        ))
+    }
+
+    #[test]
+    fn routing_matrix_selects_source() {
+        let personal = true;
+        for operation in [
+            Operation::Playback,
+            Operation::UserData,
+            Operation::PlaylistCreation,
+            Operation::Catalog,
+            Operation::PlaylistMetadata(PlaylistAccess::Owned),
+            Operation::PlaylistMetadata(PlaylistAccess::Collaborative),
+            Operation::PlaylistItems(PlaylistAccess::Owned),
+            Operation::PlaylistItems(PlaylistAccess::Collaborative),
+        ] {
+            assert_eq!(
+                plan(operation, personal),
+                Route::Dispatch(ApiSource::Personal)
+            );
+        }
+        for operation in [
+            Operation::CanonicalAccount,
+            Operation::PlaylistLibrary,
+            Operation::PlaylistSearch,
+            Operation::UnsupportedDevelopmentMode,
+            Operation::PlaylistMetadata(PlaylistAccess::External),
+            Operation::PlaylistMetadata(PlaylistAccess::Unknown),
+            Operation::PlaylistItems(PlaylistAccess::External),
+            Operation::PlaylistMutation(PlaylistAccess::External),
+        ] {
+            assert_eq!(
+                plan(operation, personal),
+                Route::Dispatch(ApiSource::Shared)
+            );
+        }
+        assert_eq!(
+            plan(Operation::PlaylistItems(PlaylistAccess::Unknown), personal),
+            Route::ClassifyPlaylist
+        );
+        assert_eq!(
+            plan(
+                Operation::PlaylistMutation(PlaylistAccess::Unknown),
+                personal
+            ),
+            Route::ClassifyPlaylist
+        );
+        for operation in [
+            Operation::Playback,
+            Operation::UserData,
+            Operation::PlaylistLibrary,
+            Operation::PlaylistCreation,
+            Operation::PlaylistSearch,
+            Operation::Catalog,
+            Operation::PlaylistMetadata(PlaylistAccess::Unknown),
+            Operation::PlaylistItems(PlaylistAccess::Unknown),
+        ] {
+            assert_eq!(plan(operation, false), Route::Dispatch(ApiSource::Shared));
+        }
+    }
+
+    #[test]
+    fn playlist_access_keeps_unknown_explicit() {
+        let account = AccountId::new("me");
+        let mut playlist = Playlist {
+            id: "p".into(),
+            ..Playlist::default()
+        };
+        assert_eq!(
+            classify_playlist(&account, &playlist),
+            PlaylistAccess::Unknown
+        );
+        playlist.owner.id = Some("other".into());
+        assert_eq!(
+            classify_playlist(&account, &playlist),
+            PlaylistAccess::External
+        );
+        playlist.collaborative = true;
+        assert_eq!(
+            classify_playlist(&account, &playlist),
+            PlaylistAccess::Collaborative
+        );
+        playlist.owner.id = Some("me".into());
+        assert_eq!(
+            classify_playlist(&account, &playlist),
+            PlaylistAccess::Owned
+        );
+    }
+
+    #[test]
+    fn dual_sessions_require_the_same_account() {
+        let gateway = ApiGateway::new(reqwest::Client::new(), Arc::new(NetActivity::default()));
+        gateway
+            .install(
+                ApiSource::Shared,
+                provider("shared", ApiSource::Shared),
+                AccountId::new("same"),
+            )
+            .unwrap();
+        gateway
+            .install(
+                ApiSource::Personal,
+                provider("personal", ApiSource::Personal),
+                AccountId::new("same"),
+            )
+            .unwrap();
+        assert!(gateway.personal_ready());
+        gateway.clear(ApiSource::Personal);
+        assert!(
+            gateway
+                .install(
+                    ApiSource::Personal,
+                    provider("other", ApiSource::Personal),
+                    AccountId::new("other"),
+                )
+                .is_err()
+        );
+        assert!(matches!(
+            gateway.state(ApiSource::Shared),
+            SessionState::Ready { .. }
+        ));
+
+        gateway
+            .install(
+                ApiSource::Personal,
+                provider("personal-again", ApiSource::Personal),
+                AccountId::new("same"),
+            )
+            .unwrap();
+        gateway.clear(ApiSource::Shared);
+        assert!(
+            gateway
+                .install(
+                    ApiSource::Shared,
+                    provider("other-shared", ApiSource::Shared),
+                    AccountId::new("other"),
+                )
+                .is_err()
+        );
+        assert!(matches!(
+            gateway.state(ApiSource::Personal),
+            SessionState::Ready { .. }
+        ));
+    }
+}

--- a/src/api/gateway.rs
+++ b/src/api/gateway.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use super::ApiSource;
 use super::client::{ApiClient, ApiError, NetActivity, TokenProvider};
-use super::models::{Page, Playlist, PlaylistItem};
+use super::models::Playlist;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AccountId(String);
@@ -31,19 +31,24 @@ impl PlaylistId {
     }
 }
 
+impl std::borrow::Borrow<str> for PlaylistId {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionState {
     Unavailable,
     Authorizing,
     Ready { account: AccountId },
-    Failed,
 }
 
 impl SessionState {
     pub fn account(&self) -> Option<&AccountId> {
         match self {
             Self::Ready { account } => Some(account),
-            Self::Unavailable | Self::Authorizing | Self::Failed => None,
+            Self::Unavailable | Self::Authorizing => None,
         }
     }
 }
@@ -92,34 +97,23 @@ pub enum Operation {
     UnsupportedDevelopmentMode,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Route {
-    Dispatch(ApiSource),
-    ClassifyPlaylist,
-}
-
-fn plan(operation: Operation, personal_ready: bool) -> Route {
+/// A playlist with unknown access dispatches to the shared app, which can
+/// serve anything; later requests move once a response reveals the owner.
+fn plan(operation: Operation, personal_ready: bool) -> ApiSource {
     use Operation::*;
     match operation {
         CanonicalAccount | PlaylistLibrary | PlaylistSearch | UnsupportedDevelopmentMode => {
-            Route::Dispatch(ApiSource::Shared)
-        }
-        PlaylistItems(PlaylistAccess::Unknown) | PlaylistMutation(PlaylistAccess::Unknown)
-            if personal_ready =>
-        {
-            Route::ClassifyPlaylist
+            ApiSource::Shared
         }
         PlaylistMetadata(PlaylistAccess::External | PlaylistAccess::Unknown)
-        | PlaylistItems(PlaylistAccess::External)
-        | PlaylistMutation(PlaylistAccess::External) => Route::Dispatch(ApiSource::Shared),
+        | PlaylistItems(PlaylistAccess::External | PlaylistAccess::Unknown)
+        | PlaylistMutation(PlaylistAccess::External | PlaylistAccess::Unknown) => ApiSource::Shared,
         PlaylistMetadata(_) | PlaylistItems(_) | PlaylistMutation(_) if personal_ready => {
-            Route::Dispatch(ApiSource::Personal)
+            ApiSource::Personal
         }
-        Playback | UserData | PlaylistCreation | Catalog if personal_ready => {
-            Route::Dispatch(ApiSource::Personal)
-        }
+        Playback | UserData | PlaylistCreation | Catalog if personal_ready => ApiSource::Personal,
         Playback | UserData | PlaylistCreation | Catalog | PlaylistMetadata(_)
-        | PlaylistItems(_) | PlaylistMutation(_) => Route::Dispatch(ApiSource::Shared),
+        | PlaylistItems(_) | PlaylistMutation(_) => ApiSource::Shared,
     }
 }
 
@@ -196,12 +190,9 @@ impl ApiGateway {
         self.session(source).set_state(state);
     }
 
-    pub fn install(
-        &self,
-        source: ApiSource,
-        provider: TokenProvider,
-        account: AccountId,
-    ) -> Result<(), ApiError> {
+    /// Marks a verified session ready, keeping the token provider that
+    /// `begin_verification` installed.
+    pub fn install(&self, source: ApiSource, account: AccountId) -> Result<(), ApiError> {
         let other = match source {
             ApiSource::Shared => ApiSource::Personal,
             ApiSource::Personal => ApiSource::Shared,
@@ -216,9 +207,8 @@ impl ApiGateway {
                 message: "The Spotify grants belong to different accounts".into(),
             });
         }
-        let session = self.session(source);
-        session.client.set_token_provider(Some(provider));
-        session.set_state(SessionState::Ready { account });
+        self.session(source)
+            .set_state(SessionState::Ready { account });
         Ok(())
     }
 
@@ -236,12 +226,6 @@ impl ApiGateway {
         let session = self.session(source);
         session.client.set_token_provider(None);
         session.set_state(SessionState::Unavailable);
-    }
-
-    pub fn fail(&self, source: ApiSource) {
-        let session = self.session(source);
-        session.client.set_token_provider(None);
-        session.set_state(SessionState::Failed);
     }
 
     pub fn clear_all(&self) {
@@ -264,28 +248,17 @@ impl ApiGateway {
         matches!(self.state(ApiSource::Personal), SessionState::Ready { .. })
     }
 
-    fn source_for(&self, operation: Operation) -> Route {
-        plan(operation, self.personal_ready())
-    }
-
-    pub fn client_for(
-        &self,
-        operation: Operation,
-    ) -> Result<(ApiSource, Arc<ApiClient>), ApiError> {
-        let Route::Dispatch(source) = self.source_for(operation) else {
-            return Err(ApiError::Decode(
-                "playlist access must be classified before dispatch".into(),
-            ));
-        };
+    pub fn client_for(&self, operation: Operation) -> Result<Arc<ApiClient>, ApiError> {
+        let source = plan(operation, self.personal_ready());
         let session = self.session(source);
         if !matches!(session.state(), SessionState::Ready { .. }) {
             return Err(ApiError::NotSignedIn);
         }
         log::debug!("Spotify route operation={operation:?} source={source}");
-        Ok((source, Arc::clone(&session.client)))
+        Ok(Arc::clone(&session.client))
     }
 
-    pub fn playlist_access(&self, id: &PlaylistId) -> PlaylistAccess {
+    pub fn playlist_access(&self, id: &str) -> PlaylistAccess {
         self.playlist_access
             .lock()
             .unwrap_or_else(|lock| lock.into_inner())
@@ -317,54 +290,6 @@ impl ApiGateway {
             .unwrap_or_else(|lock| lock.into_inner())
             .insert(id.clone(), PlaylistAccess::Unknown);
     }
-
-    async fn playlist_client(
-        &self,
-        id: &PlaylistId,
-        mutation: bool,
-    ) -> Result<(ApiSource, Arc<ApiClient>), ApiError> {
-        let access = self.playlist_access(id);
-        let operation = if mutation {
-            Operation::PlaylistMutation(access)
-        } else {
-            Operation::PlaylistItems(access)
-        };
-        if self.source_for(operation) == Route::ClassifyPlaylist {
-            let (_, shared) =
-                self.client_for(Operation::PlaylistMetadata(PlaylistAccess::Unknown))?;
-            let metadata = shared.playlist(id.as_str()).await?;
-            self.observe_playlist(&metadata);
-        }
-        let access = self.playlist_access(id);
-        let operation = if mutation {
-            Operation::PlaylistMutation(access)
-        } else {
-            Operation::PlaylistItems(access)
-        };
-        self.client_for(operation)
-    }
-
-    pub async fn playlist_items(
-        &self,
-        id: &str,
-        offset: u32,
-        limit: u32,
-    ) -> Result<Page<PlaylistItem>, ApiError> {
-        let id = PlaylistId::new(id);
-        let (_, client) = self.playlist_client(&id, false).await?;
-        let result = client.playlist_items(id.as_str(), offset, limit).await;
-        if result.as_ref().err().and_then(ApiError::status) == Some(403) {
-            self.invalidate_playlist_access(&id);
-        }
-        result
-    }
-
-    pub async fn playlist_mutation_client(
-        &self,
-        id: &str,
-    ) -> Result<(ApiSource, Arc<ApiClient>), ApiError> {
-        self.playlist_client(&PlaylistId::new(id), true).await
-    }
 }
 
 #[cfg(test)]
@@ -394,10 +319,7 @@ mod tests {
             Operation::PlaylistItems(PlaylistAccess::Owned),
             Operation::PlaylistItems(PlaylistAccess::Collaborative),
         ] {
-            assert_eq!(
-                plan(operation, personal),
-                Route::Dispatch(ApiSource::Personal)
-            );
+            assert_eq!(plan(operation, personal), ApiSource::Personal);
         }
         for operation in [
             Operation::CanonicalAccount,
@@ -407,24 +329,12 @@ mod tests {
             Operation::PlaylistMetadata(PlaylistAccess::External),
             Operation::PlaylistMetadata(PlaylistAccess::Unknown),
             Operation::PlaylistItems(PlaylistAccess::External),
+            Operation::PlaylistItems(PlaylistAccess::Unknown),
             Operation::PlaylistMutation(PlaylistAccess::External),
+            Operation::PlaylistMutation(PlaylistAccess::Unknown),
         ] {
-            assert_eq!(
-                plan(operation, personal),
-                Route::Dispatch(ApiSource::Shared)
-            );
+            assert_eq!(plan(operation, personal), ApiSource::Shared);
         }
-        assert_eq!(
-            plan(Operation::PlaylistItems(PlaylistAccess::Unknown), personal),
-            Route::ClassifyPlaylist
-        );
-        assert_eq!(
-            plan(
-                Operation::PlaylistMutation(PlaylistAccess::Unknown),
-                personal
-            ),
-            Route::ClassifyPlaylist
-        );
         for operation in [
             Operation::Playback,
             Operation::UserData,
@@ -435,7 +345,7 @@ mod tests {
             Operation::PlaylistMetadata(PlaylistAccess::Unknown),
             Operation::PlaylistItems(PlaylistAccess::Unknown),
         ] {
-            assert_eq!(plan(operation, false), Route::Dispatch(ApiSource::Shared));
+            assert_eq!(plan(operation, false), ApiSource::Shared);
         }
     }
 
@@ -470,29 +380,23 @@ mod tests {
     #[test]
     fn dual_sessions_require_the_same_account() {
         let gateway = ApiGateway::new(reqwest::Client::new(), Arc::new(NetActivity::default()));
+        gateway.begin_verification(ApiSource::Shared, provider("shared", ApiSource::Shared));
         gateway
-            .install(
-                ApiSource::Shared,
-                provider("shared", ApiSource::Shared),
-                AccountId::new("same"),
-            )
+            .install(ApiSource::Shared, AccountId::new("same"))
             .unwrap();
+        gateway.begin_verification(
+            ApiSource::Personal,
+            provider("personal", ApiSource::Personal),
+        );
         gateway
-            .install(
-                ApiSource::Personal,
-                provider("personal", ApiSource::Personal),
-                AccountId::new("same"),
-            )
+            .install(ApiSource::Personal, AccountId::new("same"))
             .unwrap();
         assert!(gateway.personal_ready());
         gateway.clear(ApiSource::Personal);
+        gateway.begin_verification(ApiSource::Personal, provider("other", ApiSource::Personal));
         assert!(
             gateway
-                .install(
-                    ApiSource::Personal,
-                    provider("other", ApiSource::Personal),
-                    AccountId::new("other"),
-                )
+                .install(ApiSource::Personal, AccountId::new("other"))
                 .is_err()
         );
         assert!(matches!(
@@ -500,21 +404,21 @@ mod tests {
             SessionState::Ready { .. }
         ));
 
+        gateway.begin_verification(
+            ApiSource::Personal,
+            provider("personal-again", ApiSource::Personal),
+        );
         gateway
-            .install(
-                ApiSource::Personal,
-                provider("personal-again", ApiSource::Personal),
-                AccountId::new("same"),
-            )
+            .install(ApiSource::Personal, AccountId::new("same"))
             .unwrap();
         gateway.clear(ApiSource::Shared);
+        gateway.begin_verification(
+            ApiSource::Shared,
+            provider("other-shared", ApiSource::Shared),
+        );
         assert!(
             gateway
-                .install(
-                    ApiSource::Shared,
-                    provider("other-shared", ApiSource::Shared),
-                    AccountId::new("other"),
-                )
+                .install(ApiSource::Shared, AccountId::new("other"))
                 .is_err()
         );
         assert!(matches!(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,25 @@
 //! Spotify Web API client.
 
+use std::fmt;
+
 pub mod client;
+pub mod gateway;
 pub mod models;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ApiSource {
+    Shared,
+    Personal,
+}
+
+impl fmt::Display for ApiSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Shared => formatter.write_str("shared"),
+            Self::Personal => formatter.write_str("personal"),
+        }
+    }
+}
+
 pub use client::{ApiClient, ApiError, NetActivity, PlayRequest, TokenProvider, WebTokens};
+pub use gateway::{AccountId, ApiGateway, Operation, PlaylistAccess, PlaylistId, SessionState};

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -41,6 +41,13 @@ pub struct Page<T> {
     pub next: Option<String>,
 }
 
+impl<T> Page<T> {
+    pub fn next_offset(&self) -> Option<u32> {
+        let consumed = self.limit.max(self.items.len() as u32);
+        (self.next.is_some() && consumed > 0).then_some(self.offset + consumed)
+    }
+}
+
 /// A cursor-paginated collection (followed artists, recently played).
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 #[serde(bound(deserialize = "T: Deserialize<'de>"))]
@@ -734,8 +741,10 @@ mod tests {
 
     #[test]
     fn search_playlists_skip_null_entries() {
-        let json = r#"{"playlists":{"items":[null,{"id":"p","name":"P","uri":"spotify:playlist:p"}],"total":2}}"#;
+        let json = r#"{"playlists":{"items":[null,{"id":"p","name":"P","uri":"spotify:playlist:p"}],"total":2,"limit":2,"offset":0,"next":"next page"}}"#;
         let results: SearchResults = serde_json::from_str(json).unwrap();
-        assert_eq!(results.playlists.unwrap().items.len(), 1);
+        let playlists = results.playlists.unwrap();
+        assert_eq!(playlists.items.len(), 1);
+        assert_eq!(playlists.next_offset(), Some(2));
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::api::models::{
 };
 use crate::backend::{
     ApiRequest, ApiResponse, AuthStatus, Backend, Command, Event, LocalPlayback, LyricsRequest,
-    RemoteAction, Waker,
+    PLAYLIST_PAGE_SIZE, RemoteAction, Waker,
 };
 use crate::media::{MediaCommand, MediaState, MediaTrack};
 use crate::media_controls::MediaService;
@@ -44,7 +44,7 @@ const PLAYBACK_HOLD: Duration = Duration::from_secs(6);
 /// A second look after a command, so the button settles quickly rather than
 /// waiting for the ordinary poll.
 const REMOTE_RECHECK: Duration = Duration::from_millis(1200);
-const CONTAINS_BATCH: usize = 50;
+const CONTAINS_BATCH: usize = 40;
 
 pub struct RemoteSnapshot {
     pub state: PlaybackState,
@@ -164,6 +164,7 @@ pub struct App {
     pub home: HomeData,
     pub search: SearchState,
     pub playlist_pages: HashMap<String, PlaylistPage>,
+    load_generation: u64,
     pub album_pages: HashMap<String, AlbumPage>,
     pub artist_pages: HashMap<String, ArtistPage>,
     pub show_pages: HashMap<String, ShowPage>,
@@ -213,8 +214,7 @@ pub struct App {
     pub volume_preview: Option<f32>,
     last_eviction: Instant,
     pub sign_in_url: Option<String>,
-    /// The Web API application the current sign-in belongs to, so Settings
-    /// can say whether the one named there is in use yet.
+    /// The verified personal Web API application, when acceleration is ready.
     pub web_app: Option<String>,
     pending_remote_position: Option<(u32, Instant)>,
     pending_remote_volume: Option<(u8, Instant)>,
@@ -343,6 +343,7 @@ impl App {
             home: HomeData::default(),
             search: SearchState::default(),
             playlist_pages: HashMap::new(),
+            load_generation: 0,
             album_pages: HashMap::new(),
             artist_pages: HashMap::new(),
             show_pages: HashMap::new(),
@@ -491,14 +492,6 @@ impl App {
         } else {
             Target::Remote(None)
         }
-    }
-
-    /// Whether the Web API sign-in belongs to an app of the user's own
-    /// rather than the shared one.
-    pub fn own_web_app(&self) -> bool {
-        self.web_app
-            .as_deref()
-            .is_some_and(|id| id != crate::auth::DEFAULT_WEB_CLIENT_ID)
     }
 
     /// The context playing as the interface should show it: the one just
@@ -759,10 +752,14 @@ impl App {
                     }
                 }
                 Event::PlaylistCache {
+                    account_id,
                     id,
                     snapshot,
                     items,
                 } => {
+                    if self.user_id() != Some(account_id.as_str()) {
+                        continue;
+                    }
                     if let Some(page) = self.playlist_pages.get_mut(&id) {
                         page.pending_cache = Some((snapshot, items));
                     }
@@ -771,7 +768,7 @@ impl App {
                 Event::UserName { id, name } => {
                     self.user_names.insert(id, name);
                 }
-                Event::WebApp { client_id } => self.web_app = Some(client_id),
+                Event::WebApp { client_id } => self.web_app = client_id,
                 Event::UpdateAvailable { version, url } => {
                     let notice = crate::updates::Release { version, url };
                     if self.update.as_ref() != Some(&notice) {
@@ -1252,16 +1249,32 @@ impl App {
                 }
             }
             Page::Playlist(id) => {
+                let needs_generation = self
+                    .playlist_pages
+                    .get(&id)
+                    .is_none_or(|page| page.generation == 0);
+                if needs_generation {
+                    self.load_generation += 1;
+                    self.playlist_pages
+                        .entry(id.clone())
+                        .or_default()
+                        .generation = self.load_generation;
+                }
                 let page = self.playlist_pages.entry(id.clone()).or_default();
+                let generation = page.generation;
                 if page.playlist.needs_load() {
                     page.playlist = Loadable::Loading;
-                    self.backend.api(ApiRequest::Playlist { id: id.clone() });
+                    self.backend.api(ApiRequest::Playlist {
+                        id: id.clone(),
+                        generation,
+                    });
                 }
                 if !page.items.loaded_once && page.items.can_load_more() {
                     page.items.loading = true;
                     self.backend.api(ApiRequest::PlaylistItems {
                         id: id.clone(),
                         offset: 0,
+                        generation,
                     });
                     // The disk may hold the whole list already; it is
                     // adopted only if Spotify's snapshot still matches.
@@ -1335,21 +1348,37 @@ impl App {
         }
         self.home.requested = true;
         self.home.loaded_at = Some(Instant::now());
-        self.home.recently_played = Loadable::Loading;
-        self.home.top_artists = Loadable::Loading;
-        self.home.top_tracks = Loadable::Loading;
-        self.backend.api(ApiRequest::RecentlyPlayed);
-        self.backend.api(ApiRequest::TopArtists);
+        self.home.generation += 1;
+        let generation = self.home.generation;
+        if self.home.recently_played.get().is_none() {
+            self.home.recently_played = Loadable::Loading;
+        }
+        if self.home.top_artists.get().is_none() {
+            self.home.top_artists = Loadable::Loading;
+        }
+        if self.home.top_tracks.get().is_none() {
+            self.home.top_tracks = Loadable::Loading;
+        }
+        self.backend.api(ApiRequest::RecentlyPlayed { generation });
+        self.backend.api(ApiRequest::TopArtists { generation });
         self.backend.api(ApiRequest::TopTracks {
             offset: 0,
             full: false,
+            generation,
         });
+        self.home.discover_pending.clear();
         for term in DISCOVER_TERMS {
             self.home
-                .discover
+                .discover_pending
                 .insert((*term).to_string(), Loadable::Loading);
+            if !self.home.discover.contains_key(*term) {
+                self.home
+                    .discover
+                    .insert((*term).to_string(), Loadable::Loading);
+            }
             self.backend.api(ApiRequest::Discover {
                 term: (*term).to_string(),
+                generation,
             });
         }
     }
@@ -1361,9 +1390,11 @@ impl App {
         self.home.top_songs = Loadable::Loading;
         self.home.top_songs_loading = true;
         self.home.top_songs_complete = false;
+        self.home.top_songs_generation += 1;
         self.backend.api(ApiRequest::TopTracks {
             offset: 0,
             full: true,
+            generation: self.home.top_songs_generation,
         });
     }
 
@@ -1411,7 +1442,11 @@ impl App {
                     let list = &mut page.items;
                     if let Some(offset) = list.next_offset.filter(|_| list.can_load_more()) {
                         list.loading = true;
-                        self.backend.api(ApiRequest::PlaylistItems { id, offset });
+                        self.backend.api(ApiRequest::PlaylistItems {
+                            id,
+                            offset,
+                            generation: page.generation,
+                        });
                     }
                 }
             }
@@ -1452,7 +1487,23 @@ impl App {
             Page::Podcasts => self.library.shows.reset(),
             Page::Episodes => self.library.episodes.reset(),
             Page::Playlist(id) => {
-                self.playlist_pages.remove(id);
+                if let Some(playlist) = self.playlist_pages.get_mut(id) {
+                    self.load_generation += 1;
+                    playlist.generation = self.load_generation;
+                    playlist.items.loading = true;
+                    playlist.cache_complete = false;
+                    playlist.pending_cache = None;
+                    self.backend.api(ApiRequest::Playlist {
+                        id: id.clone(),
+                        generation: playlist.generation,
+                    });
+                    self.backend.api(ApiRequest::PlaylistItems {
+                        id: id.clone(),
+                        offset: 0,
+                        generation: playlist.generation,
+                    });
+                    return;
+                }
             }
             Page::Album(id) => {
                 self.album_pages.remove(id);
@@ -1514,7 +1565,10 @@ impl App {
         }
         self.search.serial += 1;
         self.search.committed = query.clone();
-        self.search.results = Loadable::Loading;
+        self.search.refreshing = true;
+        if self.search.results.get().is_none() {
+            self.search.results = Loadable::Loading;
+        }
         self.backend.api(ApiRequest::Search {
             query,
             serial: self.search.serial,
@@ -1538,9 +1592,6 @@ impl App {
     }
 
     pub fn request_contains(&mut self, uris: Vec<String>) {
-        let Some(user_id) = self.user_id().map(str::to_string) else {
-            return;
-        };
         let mut batch = Vec::new();
         for uri in uris {
             if uri.is_empty()
@@ -1555,22 +1606,17 @@ impl App {
             if batch.len() == CONTAINS_BATCH {
                 self.backend.api(ApiRequest::Contains {
                     uris: std::mem::take(&mut batch),
-                    user_id: user_id.clone(),
                 });
             }
         }
         if !batch.is_empty() {
-            self.backend.api(ApiRequest::Contains {
-                uris: batch,
-                user_id,
-            });
+            self.backend.api(ApiRequest::Contains { uris: batch });
         }
     }
 
     // ---- api responses -------------------------------------------------------
 
     fn handle_api(&mut self, response: ApiResponse) {
-        let own_app = self.own_web_app();
         match response {
             ApiResponse::Me(result) => match result {
                 Ok(user) => {
@@ -1582,11 +1628,10 @@ impl App {
                     }
                 }
                 Err(error) => {
-                    if matches!(error, crate::api::ApiError::SignInExpired(_)) {
+                    if matches!(error, crate::api::ApiError::SignInExpired { .. }) {
                         self.auth = AuthStatus::Failed(
                             "Your Spotify sign-in expired. Please sign in again.".into(),
                         );
-                        self.backend.send(Command::SignOut);
                     } else {
                         self.toast_error(format!("Couldn't load your profile: {error}"));
                     }
@@ -1703,7 +1748,10 @@ impl App {
                     self.request_contains(uris);
                 }
             }
-            ApiResponse::RecentlyPlayed(result) => {
+            ApiResponse::RecentlyPlayed { generation, result } => {
+                if generation != self.home.generation {
+                    return;
+                }
                 if let Ok(history) = &result {
                     // Oldest first, so the newest ends up at the front.
                     let contexts: Vec<String> = history
@@ -1715,14 +1763,20 @@ impl App {
                         self.note_recent_context(&context);
                     }
                 }
-                self.home.recently_played = Loadable::from_result(result);
+                if result.is_ok() || self.home.recently_played.get().is_none() {
+                    self.home.recently_played = Loadable::from_result(result);
+                }
             }
             ApiResponse::TopTracks {
                 offset,
                 full,
+                generation,
                 result,
             } => {
                 if full {
+                    if generation != self.home.top_songs_generation {
+                        return;
+                    }
                     match result {
                         Ok(page) => {
                             let received = page.items.len() as u32;
@@ -1739,6 +1793,7 @@ impl App {
                                 self.backend.api(ApiRequest::TopTracks {
                                     offset: offset + received,
                                     full: true,
+                                    generation,
                                 });
                             } else {
                                 self.home.top_songs_loading = false;
@@ -1746,44 +1801,70 @@ impl App {
                             }
                         }
                         Err(error) => {
-                            self.home.top_songs = Loadable::Failed(error.to_string());
+                            if self.home.top_songs.get().is_none() {
+                                self.home.top_songs = Loadable::Failed(error.to_string());
+                            }
                             self.home.top_songs_loading = false;
                         }
                     }
-                } else if let Ok(page) = result {
+                } else if generation == self.home.generation
+                    && let Ok(page) = result
+                {
                     let tracks = page.items;
                     let seeds: Vec<String> = tracks
                         .iter()
                         .filter_map(|track| track.id.clone())
                         .take(5)
                         .collect();
-                    if !seeds.is_empty() && self.home.recommendations.needs_load() {
-                        self.home.recommendations = Loadable::Loading;
+                    if !seeds.is_empty() {
+                        if self.home.recommendations.get().is_none() {
+                            self.home.recommendations = Loadable::Loading;
+                        }
                         self.backend.api(ApiRequest::Recommendations {
                             seed_tracks: seeds,
                             seed_artists: Vec::new(),
+                            generation,
                         });
                     }
                     let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
                     self.request_contains(uris);
                     self.home.top_tracks = Loadable::Loaded(tracks);
-                } else if offset == 0
+                } else if generation == self.home.generation
+                    && offset == 0
                     && let Err(error) = result
+                    && self.home.top_tracks.get().is_none()
                 {
                     self.home.top_tracks = Loadable::Failed(error.to_string());
                 }
             }
-            ApiResponse::TopArtists(result) => {
-                self.home.top_artists = Loadable::from_result(result);
+            ApiResponse::TopArtists { generation, result } => {
+                if generation != self.home.generation {
+                    return;
+                }
+                if result.is_ok() || self.home.top_artists.get().is_none() {
+                    self.home.top_artists = Loadable::from_result(result);
+                }
             }
-            ApiResponse::Recommendations(result) => {
+            ApiResponse::Recommendations { generation, result } => {
+                if generation != self.home.generation {
+                    return;
+                }
                 if let Ok(tracks) = &result {
                     let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
                     self.request_contains(uris);
                 }
-                self.home.recommendations = Loadable::from_result(result);
+                if result.is_ok() || self.home.recommendations.get().is_none() {
+                    self.home.recommendations = Loadable::from_result(result);
+                }
             }
-            ApiResponse::Discover { term, result } => {
+            ApiResponse::Discover {
+                term,
+                generation,
+                result,
+            } => {
+                if generation != self.home.generation {
+                    return;
+                }
                 let filtered = result.map(|playlists| {
                     let needle = term.to_lowercase();
                     let mut seen = std::collections::HashSet::new();
@@ -1800,19 +1881,27 @@ impl App {
                     matching
                 });
                 self.home
-                    .discover
+                    .discover_pending
                     .insert(term, Loadable::from_result(filtered));
+                let complete = DISCOVER_TERMS.iter().all(|term| {
+                    self.home
+                        .discover_pending
+                        .get(*term)
+                        .is_some_and(|result| !result.is_loading())
+                });
+                if complete {
+                    self.home.discover = std::mem::take(&mut self.home.discover_pending);
+                }
             }
             ApiResponse::MyPlaylists { offset, result } => match result {
                 Ok(page) => {
-                    let has_more = page.next.is_some() && !page.items.is_empty();
-                    let received = page.items.len() as u32;
+                    let next_offset = page.next_offset();
                     match &mut self.library.playlists {
                         Loadable::Loaded(existing) if offset > 0 => existing.extend(page.items),
                         slot => *slot = Loadable::Loaded(page.items),
                     }
-                    self.library.playlists_next = has_more.then_some(offset + received);
-                    if has_more {
+                    self.library.playlists_next = next_offset;
+                    if next_offset.is_some() {
                         self.load_more(Page::Home);
                     }
                     if let Some(playlists) = self.library.playlists.get() {
@@ -1829,18 +1918,43 @@ impl App {
                     }
                 }
             },
-            ApiResponse::Playlist { id, result } => {
+            ApiResponse::Playlist {
+                id,
+                generation,
+                result,
+            } => {
+                if self
+                    .playlist_pages
+                    .get(&id)
+                    .is_none_or(|page| page.generation != generation)
+                {
+                    return;
+                }
                 if let Ok(playlist) = &result
                     && let Some(image) = pick_image(&playlist.images, 300)
                 {
                     self.tint_for(Some(image));
                 }
-                if let Some(page) = self.playlist_pages.get_mut(&id) {
+                if let Some(page) = self.playlist_pages.get_mut(&id)
+                    && (result.is_ok() || page.playlist.get().is_none())
+                {
                     page.playlist = Loadable::from_result(result);
                 }
                 self.try_adopt_playlist_cache(&id);
             }
-            ApiResponse::PlaylistItems { id, offset, result } => {
+            ApiResponse::PlaylistItems {
+                id,
+                offset,
+                generation,
+                result,
+            } => {
+                if self
+                    .playlist_pages
+                    .get(&id)
+                    .is_none_or(|page| page.generation != generation)
+                {
+                    return;
+                }
                 let mut uris = Vec::new();
                 let mut adders: Vec<String> = Vec::new();
                 if let Some(page) = self.playlist_pages.get_mut(&id) {
@@ -1873,12 +1987,13 @@ impl App {
                                 {
                                     self.backend.api(ApiRequest::PlaylistSample {
                                         id: id.clone(),
-                                        offset: total.saturating_sub(100),
+                                        offset: total.saturating_sub(PLAYLIST_PAGE_SIZE),
+                                        generation,
                                     });
                                 }
                             }
                         }
-                        Err(error) => page.items.fail(friendly_page_error(&error, own_app)),
+                        Err(error) => page.items.fail(friendly_page_error(&error)),
                     }
                 }
                 self.request_contains(uris);
@@ -1903,7 +2018,18 @@ impl App {
                     self.load_more(Page::Playlist(id));
                 }
             }
-            ApiResponse::PlaylistSample { id, result } => {
+            ApiResponse::PlaylistSample {
+                id,
+                generation,
+                result,
+            } => {
+                if self
+                    .playlist_pages
+                    .get(&id)
+                    .is_none_or(|page| page.generation != generation)
+                {
+                    return;
+                }
                 let mut adders: Vec<String> = Vec::new();
                 if let Ok(items) = result
                     && let Some(page) = self.playlist_pages.get_mut(&id)
@@ -2162,6 +2288,7 @@ impl App {
                 if serial != self.search.serial || query != self.search.committed {
                     return;
                 }
+                self.search.refreshing = false;
                 if let Ok(results) = &result {
                     let uris: Vec<String> = results
                         .tracks
@@ -2173,22 +2300,21 @@ impl App {
                     self.settings.remember_search(&query);
                     self.settings_dirty = true;
                 }
-                self.search.results = Loadable::from_result(result);
+                if result.is_ok() || self.search.results.get().is_none() {
+                    self.search.results = Loadable::from_result(result);
+                }
             }
             ApiResponse::Artist { id, result } => {
                 if let Ok(artist) = &result {
                     if let Some(image) = pick_image(&artist.images, 300) {
                         self.tint_for(Some(image));
                     }
-                    let name = artist.name.clone();
                     if let Some(page) = self.artist_pages.get_mut(&id)
                         && page.top_tracks.needs_load()
                     {
                         page.top_tracks = Loadable::Loading;
-                        self.backend.api(ApiRequest::ArtistTopTracks {
-                            id: id.clone(),
-                            name,
-                        });
+                        self.backend
+                            .api(ApiRequest::ArtistTopTracks { id: id.clone() });
                     }
                 }
                 if let Some(page) = self.artist_pages.get_mut(&id) {
@@ -2496,56 +2622,62 @@ impl App {
         }
     }
 
-    /// Adopt a playlist's disk cache once both it and the live playlist
-    /// are here and Spotify's snapshot still matches; a stale cache is
-    /// discarded, never shown.
     fn try_adopt_playlist_cache(&mut self, id: &str) {
         let mut uris = Vec::new();
         let mut adders: Vec<String> = Vec::new();
+        let mut reload = None;
         if let Some(page) = self.playlist_pages.get_mut(id) {
-            let Some(snapshot_now) = page
-                .playlist
-                .get()
-                .and_then(|playlist| playlist.snapshot_id.clone())
-            else {
-                return;
-            };
-            match &page.pending_cache {
-                Some((held, _)) if *held == snapshot_now => {}
-                Some(_) => {
-                    // The playlist changed since; the cache is history.
-                    page.pending_cache = None;
-                    return;
-                }
-                None => return,
-            }
-            if page.items.is_complete() || page.cache_complete {
+            if page.items.loaded_once && !page.cache_complete {
                 page.pending_cache = None;
                 return;
             }
-            let Some((_, items)) = page.pending_cache.take() else {
-                return;
-            };
-            uris = items
-                .iter()
-                .filter_map(|item| item.playable())
-                .map(|item| item.uri().to_string())
-                .collect();
-            adders = items
-                .iter()
-                .filter_map(|item| item.added_by.as_ref()?.id.clone())
-                .collect();
-            page.contributors.extend(adders.iter().cloned());
-            page.items.total = Some(items.len() as u32);
-            page.items.items = items;
-            page.items.next_offset = None;
-            page.items.loading = false;
-            page.items.loaded_once = true;
-            page.items.error = None;
-            page.cache_complete = true;
+            if !page.cache_complete
+                && let Some((_, items)) = &page.pending_cache
+            {
+                uris = items
+                    .iter()
+                    .filter_map(|item| item.playable())
+                    .map(|item| item.uri().to_string())
+                    .collect();
+                adders = items
+                    .iter()
+                    .filter_map(|item| item.added_by.as_ref()?.id.clone())
+                    .collect();
+                page.contributors.extend(adders.iter().cloned());
+                page.items.total = Some(items.len() as u32);
+                page.items.items = items.clone();
+                page.items.next_offset = None;
+                page.items.loading = false;
+                page.items.loaded_once = true;
+                page.items.error = None;
+                page.cache_complete = true;
+            }
+            if let Some(snapshot_now) = page
+                .playlist
+                .get()
+                .and_then(|playlist| playlist.snapshot_id.as_deref())
+                && let Some((cached_snapshot, _)) = &page.pending_cache
+            {
+                if cached_snapshot == snapshot_now {
+                    page.pending_cache = None;
+                } else {
+                    page.pending_cache = None;
+                    page.cache_complete = false;
+                    page.items.reset();
+                    page.items.loading = true;
+                    reload = Some(page.generation);
+                }
+            }
         }
         self.request_contains(uris);
         self.request_user_names(adders);
+        if let Some(generation) = reload {
+            self.backend.api(ApiRequest::PlaylistItems {
+                id: id.to_string(),
+                offset: 0,
+                generation,
+            });
+        }
     }
 
     /// Play what was playing when the app last closed. `false` when
@@ -3004,9 +3136,6 @@ impl App {
                 public,
                 add_uris,
             } => {
-                let Some(user_id) = self.user_id().map(str::to_string) else {
-                    return;
-                };
                 self.playlist_busy = true;
                 self.dialog = Some(Dialog::CreatePlaylist {
                     name: name.clone(),
@@ -3014,7 +3143,6 @@ impl App {
                     add_uris,
                 });
                 self.backend.api(ApiRequest::CreatePlaylist {
-                    user_id,
                     name,
                     public,
                     description: String::new(),
@@ -3112,10 +3240,11 @@ impl App {
                 self.sign_in_url = None;
                 self.auth = AuthStatus::SignedOut;
             }
-            Action::SwitchWebApp => {
+            Action::ConfigurePersonalWebApp => {
                 self.save_settings();
-                self.backend
-                    .send(Command::SwitchWebApp(self.settings.web_client_id.clone()));
+                self.backend.send(Command::ConfigurePersonalWebApp(
+                    self.settings.web_client_id.clone(),
+                ));
             }
             Action::SignOut => {
                 self.backend.send(Command::SignOut);
@@ -3474,14 +3603,8 @@ fn remote_action_label(action: RemoteAction) -> &'static str {
     }
 }
 
-/// Since February 2026 a personal app (Development Mode) may read only the
-/// playlists its user owns or collaborates on; the shared app predates
-/// that and reads anything public.
-fn friendly_page_error(error: &crate::api::ApiError, own_app: bool) -> String {
+fn friendly_page_error(error: &crate::api::ApiError) -> String {
     match error.status() {
-        Some(403) | Some(404) if own_app => {
-            "Spotify lets a personal app open only the playlists you own or collaborate on. Switch back to the shared app in Settings to open this one.".to_string()
-        }
         Some(403) | Some(404) => {
             "Spotify doesn't make this playlist's songs available to third-party apps.".to_string()
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1565,7 +1565,6 @@ impl App {
         }
         self.search.serial += 1;
         self.search.committed = query.clone();
-        self.search.refreshing = true;
         if self.search.results.get().is_none() {
             self.search.results = Loadable::Loading;
         }
@@ -1763,9 +1762,7 @@ impl App {
                         self.note_recent_context(&context);
                     }
                 }
-                if result.is_ok() || self.home.recently_played.get().is_none() {
-                    self.home.recently_played = Loadable::from_result(result);
-                }
+                self.home.recently_played.refresh(result);
             }
             ApiResponse::TopTracks {
                 offset,
@@ -1801,9 +1798,7 @@ impl App {
                             }
                         }
                         Err(error) => {
-                            if self.home.top_songs.get().is_none() {
-                                self.home.top_songs = Loadable::Failed(error.to_string());
-                            }
+                            self.home.top_songs.refresh(Err::<Vec<Track>, _>(error));
                             self.home.top_songs_loading = false;
                         }
                     }
@@ -1841,9 +1836,7 @@ impl App {
                 if generation != self.home.generation {
                     return;
                 }
-                if result.is_ok() || self.home.top_artists.get().is_none() {
-                    self.home.top_artists = Loadable::from_result(result);
-                }
+                self.home.top_artists.refresh(result);
             }
             ApiResponse::Recommendations { generation, result } => {
                 if generation != self.home.generation {
@@ -1853,9 +1846,7 @@ impl App {
                     let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
                     self.request_contains(uris);
                 }
-                if result.is_ok() || self.home.recommendations.get().is_none() {
-                    self.home.recommendations = Loadable::from_result(result);
-                }
+                self.home.recommendations.refresh(result);
             }
             ApiResponse::Discover {
                 term,
@@ -1935,10 +1926,8 @@ impl App {
                 {
                     self.tint_for(Some(image));
                 }
-                if let Some(page) = self.playlist_pages.get_mut(&id)
-                    && (result.is_ok() || page.playlist.get().is_none())
-                {
-                    page.playlist = Loadable::from_result(result);
+                if let Some(page) = self.playlist_pages.get_mut(&id) {
+                    page.playlist.refresh(result);
                 }
                 self.try_adopt_playlist_cache(&id);
             }
@@ -2288,7 +2277,6 @@ impl App {
                 if serial != self.search.serial || query != self.search.committed {
                     return;
                 }
-                self.search.refreshing = false;
                 if let Ok(results) = &result {
                     let uris: Vec<String> = results
                         .tracks
@@ -2300,9 +2288,7 @@ impl App {
                     self.settings.remember_search(&query);
                     self.settings_dirty = true;
                 }
-                if result.is_ok() || self.search.results.get().is_none() {
-                    self.search.results = Loadable::from_result(result);
-                }
+                self.search.results.refresh(result);
             }
             ApiResponse::Artist { id, result } => {
                 if let Ok(artist) = &result {
@@ -2622,62 +2608,56 @@ impl App {
         }
     }
 
+    /// Adopt a playlist's disk cache once both it and the live playlist
+    /// are here and Spotify's snapshot still matches; a stale cache is
+    /// discarded, never shown.
     fn try_adopt_playlist_cache(&mut self, id: &str) {
         let mut uris = Vec::new();
         let mut adders: Vec<String> = Vec::new();
-        let mut reload = None;
         if let Some(page) = self.playlist_pages.get_mut(id) {
-            if page.items.loaded_once && !page.cache_complete {
+            let Some(snapshot_now) = page
+                .playlist
+                .get()
+                .and_then(|playlist| playlist.snapshot_id.clone())
+            else {
+                return;
+            };
+            match &page.pending_cache {
+                Some((held, _)) if *held == snapshot_now => {}
+                Some(_) => {
+                    // The playlist changed since; the cache is history.
+                    page.pending_cache = None;
+                    return;
+                }
+                None => return,
+            }
+            if page.items.is_complete() || page.cache_complete {
                 page.pending_cache = None;
                 return;
             }
-            if !page.cache_complete
-                && let Some((_, items)) = &page.pending_cache
-            {
-                uris = items
-                    .iter()
-                    .filter_map(|item| item.playable())
-                    .map(|item| item.uri().to_string())
-                    .collect();
-                adders = items
-                    .iter()
-                    .filter_map(|item| item.added_by.as_ref()?.id.clone())
-                    .collect();
-                page.contributors.extend(adders.iter().cloned());
-                page.items.total = Some(items.len() as u32);
-                page.items.items = items.clone();
-                page.items.next_offset = None;
-                page.items.loading = false;
-                page.items.loaded_once = true;
-                page.items.error = None;
-                page.cache_complete = true;
-            }
-            if let Some(snapshot_now) = page
-                .playlist
-                .get()
-                .and_then(|playlist| playlist.snapshot_id.as_deref())
-                && let Some((cached_snapshot, _)) = &page.pending_cache
-            {
-                if cached_snapshot == snapshot_now {
-                    page.pending_cache = None;
-                } else {
-                    page.pending_cache = None;
-                    page.cache_complete = false;
-                    page.items.reset();
-                    page.items.loading = true;
-                    reload = Some(page.generation);
-                }
-            }
+            let Some((_, items)) = page.pending_cache.take() else {
+                return;
+            };
+            uris = items
+                .iter()
+                .filter_map(|item| item.playable())
+                .map(|item| item.uri().to_string())
+                .collect();
+            adders = items
+                .iter()
+                .filter_map(|item| item.added_by.as_ref()?.id.clone())
+                .collect();
+            page.contributors.extend(adders.iter().cloned());
+            page.items.total = Some(items.len() as u32);
+            page.items.items = items;
+            page.items.next_offset = None;
+            page.items.loading = false;
+            page.items.loaded_once = true;
+            page.items.error = None;
+            page.cache_complete = true;
         }
         self.request_contains(uris);
         self.request_user_names(adders);
-        if let Some(generation) = reload {
-            self.backend.api(ApiRequest::PlaylistItems {
-                id: id.to_string(),
-                offset: 0,
-                generation,
-            });
-        }
     }
 
     /// Play what was playing when the app last closed. `false` when

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,12 +1,9 @@
 //! Spotify sign-in with the Authorization Code + PKCE flow.
 //!
-//! Two grants exist because Spotify treats them differently:
+//! Three independent grants may exist because Spotify treats them differently:
 //!
-//! - The **Web API grant** uses a registered application identity. Its
-//!   access token is what every `api.spotify.com` call carries, and its
-//!   refresh token is kept in the state directory so the browser is needed
-//!   once per machine. Tokens minted for Spotify's own desktop client are
-//!   throttled on the Web API, which is why this is a separate identity.
+//! - The shared and optional personal **Web API grants** use separate
+//!   registered application identities, token files, and request sessions.
 //! - The **playback grant** uses Spotify's desktop client identity, the one
 //!   librespot streams with. Its access token is exchanged once for a
 //!   reusable credential that librespot caches itself.
@@ -34,7 +31,7 @@ pub const PLAYBACK_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
 pub const PLAYBACK_REDIRECT_PORT: u16 = 8898;
 
 /// The public Web API application shared by spotify-player, ncspot, and
-/// Omarchy Spotify. A personal application id can replace it in Settings.
+/// Omarchy Spotify.
 pub const DEFAULT_WEB_CLIENT_ID: &str = "d420a117a32841c2b3474932e49fb54b";
 pub const WEB_REDIRECT_PORT: u16 = 8989;
 
@@ -93,16 +90,24 @@ impl Grant {
         }
     }
 
-    pub fn web_api(client_id: Option<&str>) -> Self {
+    pub fn shared_web_api() -> Self {
         Self {
-            client_id: client_id
-                .map(str::trim)
-                .filter(|id| !id.is_empty())
-                .unwrap_or(DEFAULT_WEB_CLIENT_ID)
-                .to_string(),
+            client_id: DEFAULT_WEB_CLIENT_ID.to_string(),
             redirect_port: WEB_REDIRECT_PORT,
             scopes: WEB_SCOPES,
         }
+    }
+
+    pub fn personal_web_api(client_id: &str) -> Result<Self> {
+        let client_id = client_id.trim();
+        if client_id.is_empty() {
+            bail!("a personal Spotify Client ID is required");
+        }
+        Ok(Self {
+            client_id: client_id.to_string(),
+            redirect_port: WEB_REDIRECT_PORT,
+            scopes: WEB_SCOPES,
+        })
     }
 
     pub fn redirect_uri(&self) -> String {
@@ -362,6 +367,26 @@ impl StoredToken {
     pub fn remove(path: &Path) {
         let _ = std::fs::remove_file(path);
     }
+
+    pub fn migrate_legacy(legacy: &Path, shared: &Path, personal: &Path) -> Result<()> {
+        let Some(token) = Self::load(legacy) else {
+            return Ok(());
+        };
+        let target = if token.client_id == DEFAULT_WEB_CLIENT_ID {
+            shared
+        } else {
+            personal
+        };
+        if let Some(existing) = Self::load(target) {
+            if existing != token {
+                return Ok(());
+            }
+        } else {
+            token.save(target)?;
+        }
+        Self::remove(legacy);
+        Ok(())
+    }
 }
 
 fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
@@ -421,7 +446,7 @@ mod tests {
 
     #[test]
     fn begin_produces_valid_pkce_material() {
-        let flow = begin(Grant::web_api(None));
+        let flow = begin(Grant::shared_web_api());
         assert!(flow.verifier.len() >= 43);
         assert!(flow.url.contains("code_challenge_method=S256"));
         assert!(flow.url.contains(&format!("state={}", flow.state)));
@@ -440,9 +465,9 @@ mod tests {
     }
 
     #[test]
-    fn custom_web_client_id_wins_when_present() {
-        assert_eq!(Grant::web_api(Some("  abc ")).client_id, "abc");
-        assert_eq!(Grant::web_api(Some("  ")).client_id, DEFAULT_WEB_CLIENT_ID);
+    fn personal_client_id_is_validated_at_the_boundary() {
+        assert_eq!(Grant::personal_web_api("  abc ").unwrap().client_id, "abc");
+        assert!(Grant::personal_web_api("  ").is_err());
     }
 
     #[test]
@@ -479,6 +504,35 @@ mod tests {
         token.save(&path).unwrap();
         assert_eq!(StoredToken::load(&path), Some(token));
         StoredToken::remove(&path);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn legacy_tokens_move_to_the_matching_session() {
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-token-migration-{}-{}",
+            std::process::id(),
+            now_secs()
+        ));
+        let legacy = dir.join("legacy.json");
+        let shared = dir.join("shared.json");
+        let personal = dir.join("personal.json");
+        for (client_id, target) in [
+            (DEFAULT_WEB_CLIENT_ID, &shared),
+            ("personal-client", &personal),
+        ] {
+            let token = StoredToken {
+                client_id: client_id.into(),
+                access_token: "access".into(),
+                refresh_token: "refresh".into(),
+                expires_at: now_secs() + 3600,
+                ..StoredToken::default()
+            };
+            token.save(&legacy).unwrap();
+            StoredToken::migrate_legacy(&legacy, &shared, &personal).unwrap();
+            assert_eq!(StoredToken::load(target), Some(token));
+            assert!(!legacy.exists());
+        }
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -260,13 +260,14 @@ pub async fn exchange_code(
         ],
     )
     .await
+    .map_err(|error| anyhow!("{error}"))
 }
 
 pub async fn refresh(
     http: &reqwest::Client,
     client_id: &str,
     refresh_token: &str,
-) -> Result<TokenResponse> {
+) -> std::result::Result<TokenResponse, TokenEndpointError> {
     token_request(
         http,
         &[
@@ -278,16 +279,29 @@ pub async fn refresh(
     .await
 }
 
-async fn token_request(http: &reqwest::Client, form: &[(&str, &str)]) -> Result<TokenResponse> {
+#[derive(Debug, thiserror::Error)]
+pub enum TokenEndpointError {
+    /// Spotify refused the grant itself; only the browser can mint a new one.
+    #[error("Spotify rejected the token request ({status}): {detail}")]
+    Rejected { status: u16, detail: String },
+    /// The endpoint could not answer; the grant may still be valid.
+    #[error("token request failed: {0}")]
+    Unreachable(String),
+}
+
+async fn token_request(
+    http: &reqwest::Client,
+    form: &[(&str, &str)],
+) -> std::result::Result<TokenResponse, TokenEndpointError> {
     let response = http
         .post(TOKEN_URL)
         .form(form)
         .send()
         .await
-        .context("token request failed")?;
+        .map_err(|error| TokenEndpointError::Unreachable(error.to_string()))?;
     let status = response.status();
     let text = response.text().await.unwrap_or_default();
-    if !status.is_success() {
+    if status.is_client_error() {
         let detail = serde_json::from_str::<serde_json::Value>(&text)
             .ok()
             .and_then(|value| {
@@ -297,9 +311,20 @@ async fn token_request(http: &reqwest::Client, form: &[(&str, &str)]) -> Result<
                     .map(str::to_string)
             })
             .unwrap_or_else(|| redact(&text));
-        bail!("Spotify rejected the token request ({status}): {detail}");
+        return Err(TokenEndpointError::Rejected {
+            status: status.as_u16(),
+            detail,
+        });
     }
-    serde_json::from_str(&text).context("unexpected token response")
+    if !status.is_success() {
+        return Err(TokenEndpointError::Unreachable(format!(
+            "Spotify answered {status}: {}",
+            redact(&text)
+        )));
+    }
+    serde_json::from_str(&text).map_err(|error| {
+        TokenEndpointError::Unreachable(format!("unexpected token response: {error}"))
+    })
 }
 
 fn redact(text: &str) -> String {
@@ -339,6 +364,10 @@ impl StoredToken {
 
     pub fn needs_refresh(&self) -> bool {
         now_secs() + REFRESH_MARGIN.as_secs() >= self.expires_at
+    }
+
+    pub fn expired(&self) -> bool {
+        now_secs() >= self.expires_at
     }
 
     /// Whether the grant covers every scope in `scopes`. A grant cannot be

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -13,7 +13,10 @@ use librespot_core::authentication::Credentials;
 use tokio::sync::{mpsc, watch};
 
 use crate::api::models::*;
-use crate::api::{ApiClient, ApiError, NetActivity, PlayRequest, TokenProvider, WebTokens};
+use crate::api::{
+    AccountId, ApiError, ApiGateway, ApiSource, NetActivity, Operation, PlayRequest, PlaylistId,
+    SessionState, TokenProvider, WebTokens,
+};
 use crate::images::{ArtLoader, accent_color};
 use crate::paths::AppDirs;
 use crate::player::{Engine, EngineConfig, EngineEvent, LocalState, PlayerCommand};
@@ -21,6 +24,7 @@ use crate::player::{Engine, EngineConfig, EngineEvent, LocalState, PlayerCommand
 pub type ApiResult<T> = Result<T, ApiError>;
 
 const PREMIUM_NEEDED: &str = "Local playback needs Spotify Premium.";
+pub const PLAYLIST_PAGE_SIZE: u32 = 50;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AuthStatus {
@@ -52,37 +56,46 @@ pub enum ApiRequest {
         seq: u64,
     },
     Queue,
-    RecentlyPlayed,
+    RecentlyPlayed {
+        generation: u64,
+    },
     TopTracks {
         offset: u32,
         full: bool,
+        generation: u64,
     },
-    TopArtists,
+    TopArtists {
+        generation: u64,
+    },
     Recommendations {
         seed_tracks: Vec<String>,
         seed_artists: Vec<String>,
+        generation: u64,
     },
     Discover {
         term: String,
+        generation: u64,
     },
     MyPlaylists {
         offset: u32,
     },
     Playlist {
         id: String,
+        generation: u64,
     },
     PlaylistItems {
         id: String,
         offset: u32,
+        generation: u64,
     },
     /// A slice of a playlist read only for who added its songs; the rows
     /// on screen stay untouched.
     PlaylistSample {
         id: String,
         offset: u32,
+        generation: u64,
     },
     CreatePlaylist {
-        user_id: String,
         name: String,
         public: bool,
         description: String,
@@ -134,7 +147,6 @@ pub enum ApiRequest {
     },
     Contains {
         uris: Vec<String>,
-        user_id: String,
     },
     Search {
         query: String,
@@ -145,7 +157,6 @@ pub enum ApiRequest {
     },
     ArtistTopTracks {
         id: String,
-        name: String,
     },
     ArtistAlbums {
         id: String,
@@ -198,6 +209,23 @@ pub enum ApiRequest {
     },
 }
 
+impl ApiRequest {
+    fn background(&self) -> bool {
+        matches!(
+            self,
+            Self::PlaybackState { .. }
+                | Self::RecentlyPlayed { .. }
+                | Self::TopTracks { .. }
+                | Self::TopArtists { .. }
+                | Self::Recommendations { .. }
+                | Self::Discover { .. }
+                | Self::MyPlaylists { .. }
+                | Self::PlaylistSample { .. }
+                | Self::Contains { .. }
+        )
+    }
+}
+
 #[derive(Debug)]
 pub enum ApiResponse {
     Me(ApiResult<User>),
@@ -207,16 +235,27 @@ pub enum ApiResponse {
         result: ApiResult<Option<PlaybackState>>,
     },
     Queue(ApiResult<Queue>),
-    RecentlyPlayed(ApiResult<Vec<PlayHistory>>),
+    RecentlyPlayed {
+        generation: u64,
+        result: ApiResult<Vec<PlayHistory>>,
+    },
     TopTracks {
         offset: u32,
         full: bool,
+        generation: u64,
         result: ApiResult<Page<Track>>,
     },
-    TopArtists(ApiResult<Vec<Artist>>),
-    Recommendations(ApiResult<Vec<Track>>),
+    TopArtists {
+        generation: u64,
+        result: ApiResult<Vec<Artist>>,
+    },
+    Recommendations {
+        generation: u64,
+        result: ApiResult<Vec<Track>>,
+    },
     Discover {
         term: String,
+        generation: u64,
         result: ApiResult<Vec<Playlist>>,
     },
     MyPlaylists {
@@ -225,15 +264,18 @@ pub enum ApiResponse {
     },
     Playlist {
         id: String,
+        generation: u64,
         result: ApiResult<Playlist>,
     },
     PlaylistItems {
         id: String,
         offset: u32,
+        generation: u64,
         result: ApiResult<Page<PlaylistItem>>,
     },
     PlaylistSample {
         id: String,
+        generation: u64,
         result: ApiResult<Page<PlaylistItem>>,
     },
     PlaylistCreated(ApiResult<Playlist>),
@@ -339,6 +381,117 @@ pub enum ApiResponse {
     },
 }
 
+impl ApiResponse {
+    fn error(&self) -> Option<&ApiError> {
+        match self {
+            Self::Me(Err(error))
+            | Self::Devices(Err(error))
+            | Self::Queue(Err(error))
+            | Self::PlaylistCreated(Err(error))
+            | Self::TopArtists {
+                result: Err(error), ..
+            }
+            | Self::RecentlyPlayed {
+                result: Err(error), ..
+            }
+            | Self::Recommendations {
+                result: Err(error), ..
+            }
+            | Self::PlaybackState {
+                result: Err(error), ..
+            }
+            | Self::TopTracks {
+                result: Err(error), ..
+            }
+            | Self::Discover {
+                result: Err(error), ..
+            }
+            | Self::MyPlaylists {
+                result: Err(error), ..
+            }
+            | Self::Playlist {
+                result: Err(error), ..
+            }
+            | Self::PlaylistItems {
+                result: Err(error), ..
+            }
+            | Self::PlaylistSample {
+                result: Err(error), ..
+            }
+            | Self::PlaylistUpdated {
+                result: Err(error), ..
+            }
+            | Self::PlaylistItemsChanged {
+                result: Err(error), ..
+            }
+            | Self::PlaylistFollowChanged {
+                result: Err(error), ..
+            }
+            | Self::SavedTracks {
+                result: Err(error), ..
+            }
+            | Self::SavedAlbums {
+                result: Err(error), ..
+            }
+            | Self::FollowedArtists {
+                result: Err(error), ..
+            }
+            | Self::SavedShows {
+                result: Err(error), ..
+            }
+            | Self::SavedEpisodes {
+                result: Err(error), ..
+            }
+            | Self::SavedChanged {
+                result: Err(error), ..
+            }
+            | Self::Contains {
+                result: Err(error), ..
+            }
+            | Self::Search {
+                result: Err(error), ..
+            }
+            | Self::Artist {
+                result: Err(error), ..
+            }
+            | Self::ArtistTopTracks {
+                result: Err(error), ..
+            }
+            | Self::ArtistAlbums {
+                result: Err(error), ..
+            }
+            | Self::RelatedArtists {
+                result: Err(error), ..
+            }
+            | Self::Album {
+                result: Err(error), ..
+            }
+            | Self::AlbumTracks {
+                result: Err(error), ..
+            }
+            | Self::Show {
+                result: Err(error), ..
+            }
+            | Self::ShowEpisodes {
+                result: Err(error), ..
+            }
+            | Self::Track {
+                result: Err(error), ..
+            }
+            | Self::Remote {
+                result: Err(error), ..
+            }
+            | Self::Transferred {
+                result: Err(error), ..
+            }
+            | Self::QueueAdded {
+                result: Err(error), ..
+            } => Some(error),
+            _ => None,
+        }
+    }
+}
+
 pub enum Command {
     /// Start (or restart) the Web API sign-in in the browser.
     SignIn,
@@ -355,7 +508,15 @@ pub enum Command {
     },
     Shutdown,
     /// Internal: the Web API browser flow produced a grant.
-    WebSignedIn(Box<crate::auth::StoredToken>),
+    WebSignedIn {
+        source: ApiSource,
+        token: Box<crate::auth::StoredToken>,
+    },
+    WebVerified {
+        source: ApiSource,
+        token: Box<crate::auth::StoredToken>,
+        user: Box<User>,
+    },
     /// Internal: a browser flow ended (success or not).
     SignInEnded,
     /// Internal: the Web API said which plan the account is on (`None` when
@@ -382,9 +543,8 @@ pub enum Command {
     CheckForUpdates,
     /// The words of a track, from LRCLIB.
     Lyrics(Box<LyricsRequest>),
-    /// Sign in again with another Web API application (`None` for the
-    /// shared one). Local playback keeps its own grant.
-    SwitchWebApp(Option<String>),
+    /// Add, replace, or remove the optional personal Web API application.
+    ConfigurePersonalWebApp(Option<String>),
     /// Read a playlist's cached items from disk.
     LoadPlaylistCache {
         id: String,
@@ -433,6 +593,7 @@ pub enum Event {
     },
     /// A playlist's items as last cached, with the snapshot they belong to.
     PlaylistCache {
+        account_id: String,
         id: String,
         snapshot: String,
         items: Vec<PlaylistItem>,
@@ -442,9 +603,9 @@ pub enum Event {
         id: String,
         name: Option<String>,
     },
-    /// The Web API application the current sign-in belongs to.
+    /// The verified personal Web API app, or `None` when it is disabled.
     WebApp {
-        client_id: String,
+        client_id: Option<String>,
     },
 }
 
@@ -605,7 +766,8 @@ struct Worker {
     engine_config: EngineConfig,
     web_client_id: Option<String>,
     http: reqwest::Client,
-    api: Arc<ApiClient>,
+    api: Arc<ApiGateway>,
+    background_api: Arc<tokio::sync::Semaphore>,
     art: ArtLoader,
     events: std::sync::mpsc::Sender<Event>,
     commands: mpsc::UnboundedSender<Command>,
@@ -618,6 +780,8 @@ struct Worker {
     /// The plan, once the Web API has answered.
     premium: Option<bool>,
     cancel_signin: Option<watch::Sender<bool>>,
+    authorizing_source: Option<ApiSource>,
+    pending_authorization: Option<ApiSource>,
     reconnects: Vec<Instant>,
 }
 
@@ -638,7 +802,8 @@ impl Worker {
             dirs,
             engine_config,
             web_client_id,
-            api: Arc::new(ApiClient::new(http.clone(), activity)),
+            api: Arc::new(ApiGateway::new(http.clone(), activity)),
+            background_api: Arc::new(tokio::sync::Semaphore::new(4)),
             http,
             art,
             events,
@@ -649,6 +814,8 @@ impl Worker {
             signed_in: false,
             premium: None,
             cancel_signin: None,
+            authorizing_source: None,
+            pending_authorization: None,
             reconnects: Vec::new(),
         }
     }
@@ -668,6 +835,7 @@ impl Worker {
                     if let Some(cancel) = self.cancel_signin.take() {
                         let _ = cancel.send(true);
                     }
+                    self.authorizing_source = None;
                 }
                 Command::SignOut => self.sign_out(),
                 Command::AuthorizePlayback => self.authorize_playback(),
@@ -687,14 +855,33 @@ impl Worker {
                 },
                 Command::Api(request) => self.dispatch(request),
                 Command::Accent { url } => self.accent(url),
-                Command::WebSignedIn(token) => self.on_web_signed_in(*token),
+                Command::WebSignedIn { source, token } => {
+                    if self.authorizing_source == Some(source) {
+                        self.on_web_signed_in(source, *token);
+                    }
+                }
+                Command::WebVerified {
+                    source,
+                    token,
+                    user,
+                } => self.on_web_verified(source, *token, *user),
                 Command::PlaybackAuthorized { access_token } => {
                     self.connect_engine(Credentials::with_access_token(access_token))
                 }
                 Command::EngineConnected { engine, error } => {
                     self.on_engine_connected(*engine, error)
                 }
-                Command::SignInEnded => self.cancel_signin = None,
+                Command::SignInEnded => {
+                    self.cancel_signin = None;
+                    if let Some(source) = self.authorizing_source.take()
+                        && matches!(self.api.state(source), SessionState::Authorizing)
+                    {
+                        self.api.clear(source);
+                    }
+                    if let Some(source) = self.pending_authorization.take() {
+                        self.sign_in_source(source);
+                    }
+                }
                 Command::AccountChecked { premium } => self.on_account_checked(premium),
                 Command::Reconnect => self.reconnect_engine(),
                 Command::DiscoverReceivers => self.discover_receivers(),
@@ -708,7 +895,9 @@ impl Worker {
                     items,
                 } => self.store_playlist_cache(id, snapshot, items),
                 Command::UserNames(ids) => self.fetch_user_names(ids),
-                Command::SwitchWebApp(client_id) => self.switch_web_app(client_id),
+                Command::ConfigurePersonalWebApp(client_id) => {
+                    self.configure_personal_web_app(client_id)
+                }
             }
         }
         if let Some(engine) = self.engine.take() {
@@ -718,63 +907,190 @@ impl Worker {
 
     // ---- Web API sign-in --------------------------------------------------
 
-    /// On startup, resume a saved Web API grant. The local engine follows
-    /// once the plan is known (`on_account_checked`), never before.
     fn restore_session(&mut self) {
-        match crate::auth::StoredToken::load(&self.dirs.web_token_file()) {
-            Some(token) if !token.has_scopes(crate::auth::WEB_SCOPES) => {
-                // Granted before a scope this version relies on; only the
-                // browser can widen it.
-                self.emit(Event::Auth(AuthStatus::Failed(
-                    "Fastpotify needs one more Spotify permission. Please sign in again.".into(),
-                )));
+        self.migrate_legacy_token();
+        let shared = crate::auth::StoredToken::load(&self.dirs.shared_web_token_file());
+        let personal = self.web_client_id.as_deref().and_then(|client_id| {
+            crate::auth::StoredToken::load(&self.dirs.personal_web_token_file())
+                .filter(|token| token.client_id == client_id)
+        });
+        let shared_ready = shared
+            .as_ref()
+            .is_some_and(|token| token.has_scopes(crate::auth::WEB_SCOPES));
+        let personal_ready = personal
+            .as_ref()
+            .is_some_and(|token| token.has_scopes(crate::auth::WEB_SCOPES));
+
+        if shared_ready {
+            self.emit(Event::Auth(AuthStatus::Connecting));
+        }
+        match shared {
+            Some(token) if token.has_scopes(crate::auth::WEB_SCOPES) => {
+                self.on_web_signed_in(ApiSource::Shared, token);
             }
-            Some(token) => {
-                self.activate_web_token(token);
-                self.emit(Event::Auth(AuthStatus::Connecting));
-                self.dispatch(ApiRequest::Me);
-                self.signed_in = true;
-                self.emit(Event::Auth(AuthStatus::Connected {
-                    username: String::new(),
-                }));
-            }
+            Some(_) => self.emit(Event::Auth(AuthStatus::Failed(
+                "Fastpotify needs one more Spotify permission. Please sign in again.".into(),
+            ))),
             None => self.emit(Event::Auth(AuthStatus::SignedOut)),
         }
+        if let Some(token) = personal.filter(|_| personal_ready) {
+            self.on_web_signed_in(ApiSource::Personal, token);
+        }
     }
 
-    fn activate_web_token(&self, token: crate::auth::StoredToken) {
-        self.emit(Event::WebApp {
-            client_id: token.client_id.clone(),
-        });
-        let tokens = WebTokens::new(self.http.clone(), token, self.dirs.web_token_file());
+    fn migrate_legacy_token(&self) {
+        if let Err(error) = crate::auth::StoredToken::migrate_legacy(
+            &self.dirs.legacy_web_token_file(),
+            &self.dirs.shared_web_token_file(),
+            &self.dirs.personal_web_token_file(),
+        ) {
+            log::warn!("unable to migrate the previous Spotify sign-in: {error}");
+        }
+    }
+
+    fn token_path(&self, source: ApiSource) -> std::path::PathBuf {
+        match source {
+            ApiSource::Shared => self.dirs.shared_web_token_file(),
+            ApiSource::Personal => self.dirs.personal_web_token_file(),
+        }
+    }
+
+    fn on_web_signed_in(&mut self, source: ApiSource, token: crate::auth::StoredToken) {
+        let tokens = WebTokens::new(
+            self.http.clone(),
+            token.clone(),
+            self.token_path(source),
+            source,
+        );
         self.api
-            .set_token_provider(Some(TokenProvider::Web(tokens)));
+            .begin_verification(source, TokenProvider::Web(tokens));
+        let client = self.api.verification_client(source);
+        let gateway = Arc::clone(&self.api);
+        let commands = self.commands.clone();
+        let events = self.events.clone();
+        let waker = self.waker.clone();
+        tokio::spawn(async move {
+            match client.me().await {
+                Ok(user) => {
+                    let _ = commands.send(Command::WebVerified {
+                        source,
+                        token: Box::new(token),
+                        user: Box::new(user),
+                    });
+                }
+                Err(error) => {
+                    gateway.set_state(source, SessionState::Failed);
+                    let message = match source {
+                        ApiSource::Shared => format!("Shared Spotify sign-in failed: {error}"),
+                        ApiSource::Personal => {
+                            format!("Personal app authorization failed: {error}")
+                        }
+                    };
+                    let other_ready = match source {
+                        ApiSource::Shared => gateway.personal_ready(),
+                        ApiSource::Personal => {
+                            matches!(gateway.state(ApiSource::Shared), SessionState::Ready { .. })
+                        }
+                    };
+                    if source == ApiSource::Shared || !other_ready {
+                        let _ = events.send(Event::Auth(AuthStatus::Failed(message.clone())));
+                    }
+                    let _ = events.send(Event::Error(message));
+                    let _ = commands.send(Command::SignInEnded);
+                    waker.wake();
+                }
+            }
+        });
     }
 
-    fn on_web_signed_in(&mut self, token: crate::auth::StoredToken) {
-        self.cancel_signin = None;
-        if let Err(error) = token.save(&self.dirs.web_token_file()) {
+    fn on_web_verified(&mut self, source: ApiSource, token: crate::auth::StoredToken, user: User) {
+        if !matches!(self.api.state(source), SessionState::Authorizing)
+            || source == ApiSource::Personal
+                && self.web_client_id.as_deref() != Some(token.client_id.as_str())
+        {
+            return;
+        }
+        let provider = TokenProvider::Web(WebTokens::new(
+            self.http.clone(),
+            token.clone(),
+            self.token_path(source),
+            source,
+        ));
+        if let Err(error) = self
+            .api
+            .install(source, provider, AccountId::new(user.id.clone()))
+        {
+            self.api.clear(source);
+            self.emit(Event::Error(error.to_string()));
+            self.finish_authorization(source);
+            return;
+        }
+        if let Err(error) = token.save(&self.token_path(source)) {
             log::warn!("unable to save the Spotify sign-in: {error}");
         }
-        self.activate_web_token(token);
-        self.signed_in = true;
-        self.emit(Event::Auth(AuthStatus::Connected {
-            username: String::new(),
-        }));
-        self.dispatch(ApiRequest::Me);
+        match source {
+            ApiSource::Shared => {
+                self.signed_in = true;
+                self.emit(Event::Auth(AuthStatus::Connected {
+                    username: user.name().to_string(),
+                }));
+                self.emit(Event::Api(Box::new(ApiResponse::Me(Ok(user.clone())))));
+                let premium = user.product.as_deref().map(|product| product == "premium");
+                self.on_account_checked(premium);
+            }
+            ApiSource::Personal => {
+                self.emit(Event::WebApp {
+                    client_id: Some(token.client_id),
+                });
+            }
+        }
+        self.finish_authorization(source);
+    }
+
+    fn finish_authorization(&mut self, source: ApiSource) {
+        if self.authorizing_source != Some(source) {
+            return;
+        }
+        self.cancel_signin = None;
+        self.authorizing_source = None;
+        if let Some(pending) = self.pending_authorization.take() {
+            self.sign_in_source(pending);
+        }
     }
 
     fn sign_in(&mut self) {
+        self.sign_in_source(ApiSource::Shared);
+    }
+
+    fn sign_in_source(&mut self, source: ApiSource) {
         if self.cancel_signin.is_some() {
             return;
         }
-        let grant = crate::auth::Grant::web_api(self.web_client_id.as_deref());
+        let grant = match source {
+            ApiSource::Shared => crate::auth::Grant::shared_web_api(),
+            ApiSource::Personal => {
+                let Some(client_id) = self.web_client_id.as_deref() else {
+                    return;
+                };
+                match crate::auth::Grant::personal_web_api(client_id) {
+                    Ok(grant) => grant,
+                    Err(error) => {
+                        self.emit(Event::Error(error.to_string()));
+                        return;
+                    }
+                }
+            }
+        };
         let flow = crate::auth::begin(grant.clone());
         let (cancel_tx, cancel_rx) = watch::channel(false);
         self.cancel_signin = Some(cancel_tx);
-        self.emit(Event::Auth(AuthStatus::WaitingForBrowser {
-            url: flow.url.clone(),
-        }));
+        self.authorizing_source = Some(source);
+        self.api.set_state(source, SessionState::Authorizing);
+        if source == ApiSource::Shared {
+            self.emit(Event::Auth(AuthStatus::WaitingForBrowser {
+                url: flow.url.clone(),
+            }));
+        }
         if let Err(error) = open::that_detached(&flow.url) {
             log::warn!("unable to open a browser: {error}");
         }
@@ -793,10 +1109,15 @@ impl Worker {
             .await;
             match result {
                 Ok(token) => {
-                    let _ = commands.send(Command::WebSignedIn(Box::new(token)));
+                    let _ = commands.send(Command::WebSignedIn {
+                        source,
+                        token: Box::new(token),
+                    });
                 }
                 Err(error) => {
-                    let _ = events.send(Event::Auth(AuthStatus::SignedOut));
+                    if source == ApiSource::Shared {
+                        let _ = events.send(Event::Auth(AuthStatus::SignedOut));
+                    }
                     let message = error.to_string();
                     if !message.contains("cancelled") {
                         let _ = events.send(Event::Error(format!("Sign-in failed: {message}")));
@@ -808,19 +1129,28 @@ impl Worker {
         });
     }
 
-    /// Signs in again with another Web API application, without a restart.
-    /// Only the Web API grant changes hands: the browser opens once for the
-    /// new application, and local playback keeps its own credential.
-    fn switch_web_app(&mut self, client_id: Option<String>) {
-        if let Some(cancel) = self.cancel_signin.take() {
+    fn configure_personal_web_app(&mut self, client_id: Option<String>) {
+        let authorization_in_flight = if let Some(cancel) = self.cancel_signin.as_ref() {
             let _ = cancel.send(true);
-        }
+            true
+        } else {
+            false
+        };
         self.web_client_id = client_id;
-        self.api.set_token_provider(None);
-        crate::auth::StoredToken::remove(&self.dirs.web_token_file());
-        self.signed_in = false;
-        self.emit(Event::Auth(AuthStatus::SignedOut));
-        self.sign_in();
+        self.api.clear(ApiSource::Personal);
+        if self.web_client_id.is_none() {
+            crate::auth::StoredToken::remove(&self.dirs.personal_web_token_file());
+        }
+        self.emit(Event::WebApp { client_id: None });
+        if self.web_client_id.is_some() {
+            if authorization_in_flight {
+                self.pending_authorization = Some(ApiSource::Personal);
+            } else {
+                self.sign_in_source(ApiSource::Personal);
+            }
+        } else {
+            self.pending_authorization = None;
+        }
     }
 
     fn sign_out(&mut self) {
@@ -831,8 +1161,12 @@ impl Worker {
         if let Some(cancel) = self.cancel_signin.take() {
             let _ = cancel.send(true);
         }
-        self.api.set_token_provider(None);
-        crate::auth::StoredToken::remove(&self.dirs.web_token_file());
+        self.authorizing_source = None;
+        self.pending_authorization = None;
+        self.api.clear_all();
+        crate::auth::StoredToken::remove(&self.dirs.shared_web_token_file());
+        crate::auth::StoredToken::remove(&self.dirs.personal_web_token_file());
+        crate::auth::StoredToken::remove(&self.dirs.legacy_web_token_file());
         let _ = std::fs::remove_file(self.dirs.credentials_dir().join("credentials.json"));
         self.emit(Event::Playback(LocalPlayback::Unavailable));
         self.emit(Event::Auth(AuthStatus::SignedOut));
@@ -1145,9 +1479,16 @@ impl Worker {
     /// Whether they are still true is the interface's call: it compares
     /// the snapshot against the live playlist before adopting them.
     fn load_playlist_cache(&self, id: String) {
+        let Some(account) = self.api.account() else {
+            return;
+        };
         let events = self.events.clone();
         let waker = self.waker.clone();
-        let path = self.dirs.playlist_cache_dir().join(format!("{id}.json"));
+        let path = self
+            .dirs
+            .account_playlist_cache_dir(account.as_str())
+            .join(format!("{id}.json"));
+        let account_id = account.as_str().to_string();
         tokio::spawn(async move {
             let Ok(text) = tokio::fs::read_to_string(&path).await else {
                 return;
@@ -1156,6 +1497,7 @@ impl Worker {
                 return;
             };
             let _ = events.send(Event::PlaylistCache {
+                account_id,
                 id,
                 snapshot: cached.snapshot,
                 items: cached.items,
@@ -1165,13 +1507,22 @@ impl Worker {
     }
 
     fn store_playlist_cache(&self, id: String, snapshot: String, items: Vec<PlaylistItem>) {
-        let path = self.dirs.playlist_cache_dir().join(format!("{id}.json"));
+        let Some(account) = self.api.account() else {
+            return;
+        };
+        let path = self
+            .dirs
+            .account_playlist_cache_dir(account.as_str())
+            .join(format!("{id}.json"));
         tokio::spawn(async move {
             if let Some(parent) = path.parent() {
                 let _ = tokio::fs::create_dir_all(parent).await;
             }
             if let Ok(text) = serde_json::to_string(&CachedPlaylist { snapshot, items }) {
-                let _ = tokio::fs::write(&path, text).await;
+                let temporary = path.with_extension("json.tmp");
+                if tokio::fs::write(&temporary, text).await.is_ok() {
+                    let _ = tokio::fs::rename(temporary, path).await;
+                }
             }
         });
     }
@@ -1197,11 +1548,28 @@ impl Worker {
 
     fn dispatch(&self, request: ApiRequest) {
         let api = Arc::clone(&self.api);
+        let background_api = Arc::clone(&self.background_api);
+        let background = request.background();
         let events = self.events.clone();
         let waker = self.waker.clone();
         let commands = self.commands.clone();
         tokio::spawn(async move {
+            let _background_permit = if background {
+                background_api.acquire_owned().await.ok()
+            } else {
+                None
+            };
             let response = handle(&api, request).await;
+            if let Some(ApiError::SignInExpired { api_source, .. }) = response.error() {
+                api.fail(*api_source);
+                if *api_source == ApiSource::Personal {
+                    let _ = events.send(Event::WebApp { client_id: None });
+                } else {
+                    let _ = events.send(Event::Auth(AuthStatus::Failed(
+                        "Your Spotify sign-in expired. Please sign in again.".into(),
+                    )));
+                }
+            }
             if let ApiResponse::Me(result) = &response {
                 let premium = result
                     .as_ref()
@@ -1248,78 +1616,197 @@ fn friendly_connect_error(error: &anyhow::Error) -> String {
     }
 }
 
-async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
+fn operation_for(api: &ApiGateway, request: &ApiRequest) -> Operation {
     match request {
-        ApiRequest::Me => ApiResponse::Me(api.me().await),
-        ApiRequest::Devices => ApiResponse::Devices(api.devices().await),
+        ApiRequest::Me => Operation::CanonicalAccount,
+        ApiRequest::Devices
+        | ApiRequest::PlaybackState { .. }
+        | ApiRequest::Queue
+        | ApiRequest::Remote { .. }
+        | ApiRequest::Transfer { .. }
+        | ApiRequest::ShufflePlay { .. }
+        | ApiRequest::AddToQueue { .. } => Operation::Playback,
+        ApiRequest::RecentlyPlayed { .. }
+        | ApiRequest::TopTracks { .. }
+        | ApiRequest::TopArtists { .. }
+        | ApiRequest::SavedTracks { .. }
+        | ApiRequest::SavedAlbums { .. }
+        | ApiRequest::FollowedArtists { .. }
+        | ApiRequest::SavedShows { .. }
+        | ApiRequest::SavedEpisodes { .. }
+        | ApiRequest::SetSaved { .. }
+        | ApiRequest::Contains { .. }
+        | ApiRequest::FollowPlaylist { .. } => Operation::UserData,
+        ApiRequest::MyPlaylists { .. } => Operation::PlaylistLibrary,
+        ApiRequest::CreatePlaylist { .. } => Operation::PlaylistCreation,
+        ApiRequest::Discover { .. } | ApiRequest::Search { .. } => Operation::PlaylistSearch,
+        ApiRequest::Playlist { id, .. } => {
+            Operation::PlaylistMetadata(api.playlist_access(&PlaylistId::new(id.clone())))
+        }
+        ApiRequest::PlaylistItems { id, .. } | ApiRequest::PlaylistSample { id, .. } => {
+            Operation::PlaylistItems(api.playlist_access(&PlaylistId::new(id.clone())))
+        }
+        ApiRequest::UpdatePlaylist { id, .. } => {
+            Operation::PlaylistMutation(api.playlist_access(&PlaylistId::new(id.clone())))
+        }
+        ApiRequest::AddToPlaylist { playlist_id, .. }
+        | ApiRequest::RemoveFromPlaylist { playlist_id, .. }
+        | ApiRequest::ReorderPlaylist { playlist_id, .. } => {
+            Operation::PlaylistMutation(api.playlist_access(&PlaylistId::new(playlist_id.clone())))
+        }
+        ApiRequest::Recommendations { .. }
+        | ApiRequest::ArtistTopTracks { .. }
+        | ApiRequest::RelatedArtists { .. } => Operation::UnsupportedDevelopmentMode,
+        ApiRequest::Artist { .. }
+        | ApiRequest::ArtistAlbums { .. }
+        | ApiRequest::Album { .. }
+        | ApiRequest::AlbumTracks { .. }
+        | ApiRequest::Show { .. }
+        | ApiRequest::ShowEpisodes { .. }
+        | ApiRequest::Track { .. } => Operation::Catalog,
+    }
+}
+
+fn observe_playlists(api: &ApiGateway, response: &ApiResponse) {
+    match response {
+        ApiResponse::Discover {
+            result: Ok(playlists),
+            ..
+        } => api.observe_playlists(playlists),
+        ApiResponse::MyPlaylists {
+            result: Ok(page), ..
+        } => api.observe_playlists(&page.items),
+        ApiResponse::Playlist {
+            result: Ok(playlist),
+            ..
+        }
+        | ApiResponse::PlaylistCreated(Ok(playlist)) => api.observe_playlist(playlist),
+        ApiResponse::Search {
+            result: Ok(results),
+            ..
+        } => {
+            if let Some(playlists) = &results.playlists {
+                api.observe_playlists(&playlists.items);
+            }
+        }
+        ApiResponse::PlaylistUpdated {
+            id,
+            result: Err(error),
+        }
+        | ApiResponse::PlaylistItemsChanged {
+            id,
+            result: Err(error),
+            ..
+        } if error.status() == Some(403) => {
+            api.invalidate_playlist_access(&PlaylistId::new(id.clone()));
+        }
+        _ => {}
+    }
+}
+
+async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
+    let selected = api
+        .client_for(operation_for(api, &request))
+        .map(|(_, client)| client);
+    macro_rules! routed {
+        ($method:ident($($argument:expr),* $(,)?)) => {
+            match &selected {
+                Ok(client) => client.$method($($argument),*).await,
+                Err(error) => Err(error.clone()),
+            }
+        };
+    }
+
+    let response = match request {
+        ApiRequest::Me => ApiResponse::Me(routed!(me())),
+        ApiRequest::Devices => ApiResponse::Devices(routed!(devices())),
         ApiRequest::PlaybackState { seq } => ApiResponse::PlaybackState {
             seq,
-            result: api.playback_state().await,
+            result: routed!(playback_state()),
         },
-        ApiRequest::Queue => ApiResponse::Queue(api.queue().await),
-        ApiRequest::RecentlyPlayed => {
-            ApiResponse::RecentlyPlayed(api.recently_played(50).await.map(|page| page.items))
-        }
-        ApiRequest::TopTracks { offset, full } => ApiResponse::TopTracks {
-            result: api
-                .top_tracks("short_term", if full { 50 } else { 20 }, offset)
-                .await,
+        ApiRequest::Queue => ApiResponse::Queue(routed!(queue())),
+        ApiRequest::RecentlyPlayed { generation } => ApiResponse::RecentlyPlayed {
+            generation,
+            result: routed!(recently_played(50)).map(|page| page.items),
+        },
+        ApiRequest::TopTracks {
             offset,
             full,
+            generation,
+        } => ApiResponse::TopTracks {
+            result: routed!(top_tracks("short_term", if full { 50 } else { 20 }, offset)),
+            offset,
+            full,
+            generation,
         },
-        ApiRequest::TopArtists => ApiResponse::TopArtists(
-            api.top_artists("medium_term", 20)
-                .await
-                .map(|page| page.items),
-        ),
+        ApiRequest::TopArtists { generation } => ApiResponse::TopArtists {
+            generation,
+            result: routed!(top_artists("medium_term", 20)).map(|page| page.items),
+        },
         ApiRequest::Recommendations {
             seed_tracks,
             seed_artists,
-        } => {
-            ApiResponse::Recommendations(api.recommendations(&seed_tracks, &seed_artists, 20).await)
-        }
-        ApiRequest::Discover { term } => {
-            let result = api
-                .search(&term, &["playlist"])
-                .await
+            generation,
+        } => ApiResponse::Recommendations {
+            generation,
+            result: routed!(recommendations(&seed_tracks, &seed_artists, 20)),
+        },
+        ApiRequest::Discover { term, generation } => {
+            let result = routed!(search(&term, &["playlist"]))
                 .map(|results| results.playlists.map(|page| page.items).unwrap_or_default());
-            ApiResponse::Discover { term, result }
+            ApiResponse::Discover {
+                term,
+                generation,
+                result,
+            }
         }
         ApiRequest::MyPlaylists { offset } => ApiResponse::MyPlaylists {
             offset,
-            result: api.my_playlists(offset, 50).await,
+            result: routed!(my_playlists(offset, 50)),
         },
-        ApiRequest::Playlist { id } => ApiResponse::Playlist {
-            result: api.playlist(&id).await,
+        ApiRequest::Playlist { id, generation } => ApiResponse::Playlist {
+            result: routed!(playlist(&id)),
             id,
+            generation,
         },
-        ApiRequest::PlaylistItems { id, offset } => ApiResponse::PlaylistItems {
-            result: api.playlist_items(&id, offset, 100).await,
+        ApiRequest::PlaylistItems {
             id,
             offset,
-        },
-        ApiRequest::PlaylistSample { id, offset } => ApiResponse::PlaylistSample {
-            result: api.playlist_items(&id, offset, 100).await,
+            generation,
+        } => ApiResponse::PlaylistItems {
+            result: api.playlist_items(&id, offset, PLAYLIST_PAGE_SIZE).await,
             id,
+            offset,
+            generation,
+        },
+        ApiRequest::PlaylistSample {
+            id,
+            offset,
+            generation,
+        } => ApiResponse::PlaylistSample {
+            result: api.playlist_items(&id, offset, PLAYLIST_PAGE_SIZE).await,
+            id,
+            generation,
         },
         ApiRequest::CreatePlaylist {
-            user_id,
             name,
             public,
             description,
-        } => ApiResponse::PlaylistCreated(
-            api.create_playlist(&user_id, &name, public, &description)
-                .await,
-        ),
+        } => ApiResponse::PlaylistCreated(routed!(create_playlist(&name, public, &description))),
         ApiRequest::UpdatePlaylist {
             id,
             name,
             description,
             public,
         } => ApiResponse::PlaylistUpdated {
-            result: api
-                .update_playlist(&id, name.as_deref(), description.as_deref(), public)
-                .await,
+            result: match api.playlist_mutation_client(&id).await {
+                Ok((_, client)) => {
+                    client
+                        .update_playlist(&id, name.as_deref(), description.as_deref(), public)
+                        .await
+                }
+                Err(error) => Err(error),
+            },
             id,
         },
         ApiRequest::AddToPlaylist {
@@ -1327,7 +1814,10 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
             playlist_name,
             uris,
         } => ApiResponse::PlaylistItemsChanged {
-            result: api.add_playlist_items(&playlist_id, &uris, None).await,
+            result: match api.playlist_mutation_client(&playlist_id).await {
+                Ok((_, client)) => client.add_playlist_items(&playlist_id, &uris, None).await,
+                Err(error) => Err(error),
+            },
             id: playlist_id,
             message: format!("Added to {playlist_name}"),
         },
@@ -1336,9 +1826,14 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
             uris,
             snapshot_id,
         } => ApiResponse::PlaylistItemsChanged {
-            result: api
-                .remove_playlist_items(&playlist_id, &uris, snapshot_id.as_deref())
-                .await,
+            result: match api.playlist_mutation_client(&playlist_id).await {
+                Ok((_, client)) => {
+                    client
+                        .remove_playlist_items(&playlist_id, &uris, snapshot_id.as_deref())
+                        .await
+                }
+                Err(error) => Err(error),
+            },
             id: playlist_id,
             message: "Removed from playlist".to_string(),
         },
@@ -1348,107 +1843,110 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
             insert_before,
             snapshot_id,
         } => ApiResponse::PlaylistItemsChanged {
-            result: api
-                .reorder_playlist(
-                    &playlist_id,
-                    range_start,
-                    insert_before,
-                    snapshot_id.as_deref(),
-                )
-                .await,
+            result: match api.playlist_mutation_client(&playlist_id).await {
+                Ok((_, client)) => {
+                    client
+                        .reorder_playlist(
+                            &playlist_id,
+                            range_start,
+                            insert_before,
+                            snapshot_id.as_deref(),
+                        )
+                        .await
+                }
+                Err(error) => Err(error),
+            },
             id: playlist_id,
             message: String::new(),
         },
         ApiRequest::FollowPlaylist { id, follow } => ApiResponse::PlaylistFollowChanged {
             result: if follow {
-                api.follow_playlist(&id).await
+                routed!(follow_playlist(&id))
             } else {
-                api.unfollow_playlist(&id).await
+                routed!(unfollow_playlist(&id))
             },
             id,
             followed: follow,
         },
         ApiRequest::SavedTracks { offset } => ApiResponse::SavedTracks {
             offset,
-            result: api.saved_tracks(offset, 50).await,
+            result: routed!(saved_tracks(offset, 50)),
         },
         ApiRequest::SavedAlbums { offset } => ApiResponse::SavedAlbums {
             offset,
-            result: api.saved_albums(offset, 50).await,
+            result: routed!(saved_albums(offset, 50)),
         },
         ApiRequest::FollowedArtists { after } => ApiResponse::FollowedArtists {
-            result: api.followed_artists(after.as_deref(), 50).await,
+            result: routed!(followed_artists(after.as_deref(), 50)),
             after,
         },
         ApiRequest::SavedShows { offset } => ApiResponse::SavedShows {
             offset,
-            result: api.saved_shows(offset, 50).await,
+            result: routed!(saved_shows(offset, 50)),
         },
         ApiRequest::SavedEpisodes { offset } => ApiResponse::SavedEpisodes {
             offset,
-            result: api.saved_episodes(offset, 50).await,
+            result: routed!(saved_episodes(offset, 50)),
         },
         ApiRequest::SetSaved { uris, saved } => ApiResponse::SavedChanged {
             result: if saved {
-                api.save(&uris).await
+                routed!(save(&uris))
             } else {
-                api.unsave(&uris).await
+                routed!(unsave(&uris))
             },
             uris,
             saved,
         },
-        ApiRequest::Contains { uris, user_id } => ApiResponse::Contains {
-            result: api.contains(&uris, &user_id).await,
+        ApiRequest::Contains { uris } => ApiResponse::Contains {
+            result: routed!(contains(&uris)),
             uris,
         },
         ApiRequest::Search { query, serial } => ApiResponse::Search {
-            result: api
-                .search(
-                    &query,
-                    &["track", "artist", "album", "playlist", "show", "episode"],
-                )
-                .await,
+            result: routed!(search(
+                &query,
+                &["track", "artist", "album", "playlist", "show", "episode"]
+            )),
             query,
             serial,
         },
         ApiRequest::Artist { id } => ApiResponse::Artist {
-            result: api.artist(&id).await,
+            result: routed!(artist(&id)),
             id,
         },
-        ApiRequest::ArtistTopTracks { id, name } => ApiResponse::ArtistTopTracks {
-            result: api.artist_top_tracks(&id, &name).await,
+        ApiRequest::ArtistTopTracks { id } => ApiResponse::ArtistTopTracks {
+            result: routed!(artist_top_tracks(&id)),
             id,
         },
         ApiRequest::ArtistAlbums { id, groups, offset } => ApiResponse::ArtistAlbums {
-            result: api.artist_albums(&id, &groups, offset, 50).await,
+            result: routed!(artist_albums(&id, &groups, offset, 50)),
             id,
             groups,
             offset,
         },
         ApiRequest::RelatedArtists { id } => ApiResponse::RelatedArtists {
-            result: api.related_artists(&id).await,
+            result: routed!(related_artists(&id)),
             id,
         },
         ApiRequest::Album { id } => ApiResponse::Album {
-            result: api.album(&id).await,
+            result: routed!(album(&id)),
             id,
         },
         ApiRequest::AlbumTracks { id, offset } => ApiResponse::AlbumTracks {
-            result: api.album_tracks(&id, offset, 50).await,
+            result: routed!(album_tracks(&id, offset, 50)),
             id,
             offset,
         },
         ApiRequest::Show { id } => ApiResponse::Show {
-            result: api.show(&id).await,
+            result: routed!(show(&id)),
             id,
         },
         ApiRequest::ShowEpisodes { id, offset } => ApiResponse::ShowEpisodes {
-            result: api.show_episodes(&id, offset, 50).await,
+            result: routed!(show_episodes(&id, offset, 50)),
             id,
             offset,
         },
         ApiRequest::Track { id } => ApiResponse::Track {
-            result: api.track(&id).await,
+            result: routed!(track(&id)),
             id,
         },
         ApiRequest::Remote {
@@ -1462,21 +1960,21 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
         } => {
             let device = device_id.as_deref();
             let result = match action {
-                RemoteAction::Play => api.play(device, play.as_ref()).await,
-                RemoteAction::Pause => api.pause(device).await,
-                RemoteAction::Next => api.next(device).await,
-                RemoteAction::Previous => api.previous(device).await,
-                RemoteAction::Seek => api.seek(position_ms, device).await,
-                RemoteAction::Volume => api.set_volume(percent, device).await,
-                RemoteAction::Shuffle => api.set_shuffle(flag, device).await,
-                RemoteAction::Repeat => api.set_repeat(&repeat, device).await,
+                RemoteAction::Play => routed!(play(device, play.as_ref())),
+                RemoteAction::Pause => routed!(pause(device)),
+                RemoteAction::Next => routed!(next(device)),
+                RemoteAction::Previous => routed!(previous(device)),
+                RemoteAction::Seek => routed!(seek(position_ms, device)),
+                RemoteAction::Volume => routed!(set_volume(percent, device)),
+                RemoteAction::Shuffle => routed!(set_shuffle(flag, device)),
+                RemoteAction::Repeat => routed!(set_repeat(&repeat, device)),
             };
             ApiResponse::Remote { action, result }
         }
         ApiRequest::ShufflePlay { device_id, play } => {
             let device = device_id.as_deref();
-            let result = match api.set_shuffle(true, device).await {
-                Ok(()) => api.play(device, Some(&play)).await,
+            let result = match routed!(set_shuffle(true, device)) {
+                Ok(()) => routed!(play(device, Some(&play))),
                 Err(error) => Err(error),
             };
             ApiResponse::Remote {
@@ -1485,7 +1983,7 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
             }
         }
         ApiRequest::Transfer { device_id, play } => ApiResponse::Transferred {
-            result: api.transfer(&device_id, play).await,
+            result: routed!(transfer(&device_id, play)),
             device_id,
         },
         ApiRequest::AddToQueue {
@@ -1493,10 +1991,12 @@ async fn handle(api: &ApiClient, request: ApiRequest) -> ApiResponse {
             device_id,
             label,
         } => ApiResponse::QueueAdded {
-            result: api.add_to_queue(&uri, device_id.as_deref()).await,
+            result: routed!(add_to_queue(&uri, device_id.as_deref())),
             label,
         },
-    }
+    };
+    observe_playlists(api, &response);
+    response
 }
 
 /// Spotify's transcription of the track, when the local session can ask for

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -381,117 +381,6 @@ pub enum ApiResponse {
     },
 }
 
-impl ApiResponse {
-    fn error(&self) -> Option<&ApiError> {
-        match self {
-            Self::Me(Err(error))
-            | Self::Devices(Err(error))
-            | Self::Queue(Err(error))
-            | Self::PlaylistCreated(Err(error))
-            | Self::TopArtists {
-                result: Err(error), ..
-            }
-            | Self::RecentlyPlayed {
-                result: Err(error), ..
-            }
-            | Self::Recommendations {
-                result: Err(error), ..
-            }
-            | Self::PlaybackState {
-                result: Err(error), ..
-            }
-            | Self::TopTracks {
-                result: Err(error), ..
-            }
-            | Self::Discover {
-                result: Err(error), ..
-            }
-            | Self::MyPlaylists {
-                result: Err(error), ..
-            }
-            | Self::Playlist {
-                result: Err(error), ..
-            }
-            | Self::PlaylistItems {
-                result: Err(error), ..
-            }
-            | Self::PlaylistSample {
-                result: Err(error), ..
-            }
-            | Self::PlaylistUpdated {
-                result: Err(error), ..
-            }
-            | Self::PlaylistItemsChanged {
-                result: Err(error), ..
-            }
-            | Self::PlaylistFollowChanged {
-                result: Err(error), ..
-            }
-            | Self::SavedTracks {
-                result: Err(error), ..
-            }
-            | Self::SavedAlbums {
-                result: Err(error), ..
-            }
-            | Self::FollowedArtists {
-                result: Err(error), ..
-            }
-            | Self::SavedShows {
-                result: Err(error), ..
-            }
-            | Self::SavedEpisodes {
-                result: Err(error), ..
-            }
-            | Self::SavedChanged {
-                result: Err(error), ..
-            }
-            | Self::Contains {
-                result: Err(error), ..
-            }
-            | Self::Search {
-                result: Err(error), ..
-            }
-            | Self::Artist {
-                result: Err(error), ..
-            }
-            | Self::ArtistTopTracks {
-                result: Err(error), ..
-            }
-            | Self::ArtistAlbums {
-                result: Err(error), ..
-            }
-            | Self::RelatedArtists {
-                result: Err(error), ..
-            }
-            | Self::Album {
-                result: Err(error), ..
-            }
-            | Self::AlbumTracks {
-                result: Err(error), ..
-            }
-            | Self::Show {
-                result: Err(error), ..
-            }
-            | Self::ShowEpisodes {
-                result: Err(error), ..
-            }
-            | Self::Track {
-                result: Err(error), ..
-            }
-            | Self::Remote {
-                result: Err(error), ..
-            }
-            | Self::Transferred {
-                result: Err(error), ..
-            }
-            | Self::QueueAdded {
-                result: Err(error), ..
-            } => Some(error),
-            _ => None,
-        }
-    }
-}
-
 pub enum Command {
     /// Start (or restart) the Web API sign-in in the browser.
     SignIn,
@@ -517,8 +406,12 @@ pub enum Command {
         token: Box<crate::auth::StoredToken>,
         user: Box<User>,
     },
-    /// Internal: a browser flow ended (success or not).
-    SignInEnded,
+    /// Internal: a Web API browser flow or verification ended (success or not).
+    SignInEnded {
+        source: ApiSource,
+    },
+    /// Internal: the playback browser flow ended without a credential.
+    PlaybackAuthEnded,
     /// Internal: the Web API said which plan the account is on (`None` when
     /// it could not tell).
     AccountChecked {
@@ -835,7 +728,12 @@ impl Worker {
                     if let Some(cancel) = self.cancel_signin.take() {
                         let _ = cancel.send(true);
                     }
-                    self.authorizing_source = None;
+                    if let Some(source) = self.authorizing_source.take()
+                        && matches!(self.api.state(source), SessionState::Authorizing)
+                    {
+                        self.api.clear(source);
+                    }
+                    self.pending_authorization = None;
                 }
                 Command::SignOut => self.sign_out(),
                 Command::AuthorizePlayback => self.authorize_playback(),
@@ -857,6 +755,9 @@ impl Worker {
                 Command::Accent { url } => self.accent(url),
                 Command::WebSignedIn { source, token } => {
                     if self.authorizing_source == Some(source) {
+                        if let Err(error) = token.save(&self.token_path(source)) {
+                            log::warn!("unable to save the Spotify sign-in: {error}");
+                        }
                         self.on_web_signed_in(source, *token);
                     }
                 }
@@ -871,15 +772,22 @@ impl Worker {
                 Command::EngineConnected { engine, error } => {
                     self.on_engine_connected(*engine, error)
                 }
-                Command::SignInEnded => {
-                    self.cancel_signin = None;
-                    if let Some(source) = self.authorizing_source.take()
-                        && matches!(self.api.state(source), SessionState::Authorizing)
-                    {
-                        self.api.clear(source);
+                Command::SignInEnded { source } => {
+                    if self.authorizing_source == Some(source) {
+                        self.cancel_signin = None;
+                        self.authorizing_source = None;
+                        if matches!(self.api.state(source), SessionState::Authorizing) {
+                            self.api.clear(source);
+                        }
+                        if let Some(pending) = self.pending_authorization.take() {
+                            self.sign_in_source(pending);
+                        }
                     }
-                    if let Some(source) = self.pending_authorization.take() {
-                        self.sign_in_source(source);
+                }
+                Command::PlaybackAuthEnded => {
+                    self.cancel_signin = None;
+                    if let Some(pending) = self.pending_authorization.take() {
+                        self.sign_in_source(pending);
                     }
                 }
                 Command::AccountChecked { premium } => self.on_account_checked(premium),
@@ -909,23 +817,9 @@ impl Worker {
 
     fn restore_session(&mut self) {
         self.migrate_legacy_token();
-        let shared = crate::auth::StoredToken::load(&self.dirs.shared_web_token_file());
-        let personal = self.web_client_id.as_deref().and_then(|client_id| {
-            crate::auth::StoredToken::load(&self.dirs.personal_web_token_file())
-                .filter(|token| token.client_id == client_id)
-        });
-        let shared_ready = shared
-            .as_ref()
-            .is_some_and(|token| token.has_scopes(crate::auth::WEB_SCOPES));
-        let personal_ready = personal
-            .as_ref()
-            .is_some_and(|token| token.has_scopes(crate::auth::WEB_SCOPES));
-
-        if shared_ready {
-            self.emit(Event::Auth(AuthStatus::Connecting));
-        }
-        match shared {
+        match crate::auth::StoredToken::load(&self.dirs.shared_web_token_file()) {
             Some(token) if token.has_scopes(crate::auth::WEB_SCOPES) => {
+                self.emit(Event::Auth(AuthStatus::Connecting));
                 self.on_web_signed_in(ApiSource::Shared, token);
             }
             Some(_) => self.emit(Event::Auth(AuthStatus::Failed(
@@ -933,7 +827,12 @@ impl Worker {
             ))),
             None => self.emit(Event::Auth(AuthStatus::SignedOut)),
         }
-        if let Some(token) = personal.filter(|_| personal_ready) {
+        let personal = self.web_client_id.as_deref().and_then(|client_id| {
+            crate::auth::StoredToken::load(&self.dirs.personal_web_token_file())
+                .filter(|token| token.client_id == client_id)
+                .filter(|token| token.has_scopes(crate::auth::WEB_SCOPES))
+        });
+        if let Some(token) = personal {
             self.on_web_signed_in(ApiSource::Personal, token);
         }
     }
@@ -970,36 +869,48 @@ impl Worker {
         let events = self.events.clone();
         let waker = self.waker.clone();
         tokio::spawn(async move {
-            match client.me().await {
-                Ok(user) => {
-                    let _ = commands.send(Command::WebVerified {
-                        source,
-                        token: Box::new(token),
-                        user: Box::new(user),
-                    });
-                }
-                Err(error) => {
-                    gateway.set_state(source, SessionState::Failed);
-                    let message = match source {
-                        ApiSource::Shared => format!("Shared Spotify sign-in failed: {error}"),
-                        ApiSource::Personal => {
-                            format!("Personal app authorization failed: {error}")
-                        }
-                    };
-                    let other_ready = match source {
-                        ApiSource::Shared => gateway.personal_ready(),
-                        ApiSource::Personal => {
-                            matches!(gateway.state(ApiSource::Shared), SessionState::Ready { .. })
-                        }
-                    };
-                    if source == ApiSource::Shared || !other_ready {
-                        let _ = events.send(Event::Auth(AuthStatus::Failed(message.clone())));
+            let mut wait = Duration::from_secs(2);
+            let error = loop {
+                match client.me().await {
+                    Ok(user) => {
+                        let _ = commands.send(Command::WebVerified {
+                            source,
+                            token: Box::new(token),
+                            user: Box::new(user),
+                        });
+                        return;
                     }
-                    let _ = events.send(Event::Error(message));
-                    let _ = commands.send(Command::SignInEnded);
-                    waker.wake();
+                    Err(error @ ApiError::SignInExpired { .. }) => break error,
+                    Err(error) if error.status().is_some_and(|status| status < 500) => break error,
+                    Err(error) => {
+                        log::warn!("Spotify sign-in verification will retry: {error}");
+                        tokio::time::sleep(wait).await;
+                        wait = (wait * 2).min(Duration::from_secs(60));
+                        if !matches!(gateway.state(source), SessionState::Authorizing) {
+                            return;
+                        }
+                    }
                 }
+            };
+            gateway.clear(source);
+            let message = match source {
+                ApiSource::Shared => format!("Shared Spotify sign-in failed: {error}"),
+                ApiSource::Personal => {
+                    format!("Personal app authorization failed: {error}")
+                }
+            };
+            let other_ready = match source {
+                ApiSource::Shared => gateway.personal_ready(),
+                ApiSource::Personal => {
+                    matches!(gateway.state(ApiSource::Shared), SessionState::Ready { .. })
+                }
+            };
+            if source == ApiSource::Shared || !other_ready {
+                let _ = events.send(Event::Auth(AuthStatus::Failed(message.clone())));
             }
+            let _ = events.send(Event::Error(message));
+            let _ = commands.send(Command::SignInEnded { source });
+            waker.wake();
         });
     }
 
@@ -1010,23 +921,14 @@ impl Worker {
         {
             return;
         }
-        let provider = TokenProvider::Web(WebTokens::new(
-            self.http.clone(),
-            token.clone(),
-            self.token_path(source),
-            source,
-        ));
-        if let Err(error) = self
-            .api
-            .install(source, provider, AccountId::new(user.id.clone()))
-        {
+        if let Err(error) = self.api.install(source, AccountId::new(user.id.clone())) {
             self.api.clear(source);
+            if source == ApiSource::Shared {
+                self.emit(Event::Auth(AuthStatus::Failed(error.to_string())));
+            }
             self.emit(Event::Error(error.to_string()));
             self.finish_authorization(source);
             return;
-        }
-        if let Err(error) = token.save(&self.token_path(source)) {
-            log::warn!("unable to save the Spotify sign-in: {error}");
         }
         match source {
             ApiSource::Shared => {
@@ -1123,7 +1025,7 @@ impl Worker {
                         let _ = events.send(Event::Error(format!("Sign-in failed: {message}")));
                     }
                     waker.wake();
-                    let _ = commands.send(Command::SignInEnded);
+                    let _ = commands.send(Command::SignInEnded { source });
                 }
             }
         });
@@ -1276,7 +1178,7 @@ impl Worker {
                         let _ = events.send(Event::Playback(LocalPlayback::Failed(message)));
                     }
                     waker.wake();
-                    let _ = commands.send(Command::SignInEnded);
+                    let _ = commands.send(Command::PlaybackAuthEnded);
                 }
             }
         });
@@ -1559,10 +1461,10 @@ impl Worker {
             } else {
                 None
             };
-            let response = handle(&api, request).await;
-            if let Some(ApiError::SignInExpired { api_source, .. }) = response.error() {
-                api.fail(*api_source);
-                if *api_source == ApiSource::Personal {
+            let (response, expired) = handle(&api, request).await;
+            if let Some(api_source) = expired {
+                api.clear(api_source);
+                if api_source == ApiSource::Personal {
                     let _ = events.send(Event::WebApp { client_id: None });
                 } else {
                     let _ = events.send(Event::Auth(AuthStatus::Failed(
@@ -1634,25 +1536,29 @@ fn operation_for(api: &ApiGateway, request: &ApiRequest) -> Operation {
         | ApiRequest::FollowedArtists { .. }
         | ApiRequest::SavedShows { .. }
         | ApiRequest::SavedEpisodes { .. }
-        | ApiRequest::SetSaved { .. }
-        | ApiRequest::Contains { .. }
-        | ApiRequest::FollowPlaylist { .. } => Operation::UserData,
+        | ApiRequest::SetSaved { .. } => Operation::UserData,
+        // Development Mode cannot answer membership for playlists it omits.
+        ApiRequest::Contains { uris } => {
+            if uris.iter().any(|uri| uri.starts_with("spotify:playlist:")) {
+                Operation::UnsupportedDevelopmentMode
+            } else {
+                Operation::UserData
+            }
+        }
         ApiRequest::MyPlaylists { .. } => Operation::PlaylistLibrary,
         ApiRequest::CreatePlaylist { .. } => Operation::PlaylistCreation,
         ApiRequest::Discover { .. } | ApiRequest::Search { .. } => Operation::PlaylistSearch,
-        ApiRequest::Playlist { id, .. } => {
-            Operation::PlaylistMetadata(api.playlist_access(&PlaylistId::new(id.clone())))
-        }
+        ApiRequest::Playlist { id, .. } => Operation::PlaylistMetadata(api.playlist_access(id)),
         ApiRequest::PlaylistItems { id, .. } | ApiRequest::PlaylistSample { id, .. } => {
-            Operation::PlaylistItems(api.playlist_access(&PlaylistId::new(id.clone())))
+            Operation::PlaylistItems(api.playlist_access(id))
         }
-        ApiRequest::UpdatePlaylist { id, .. } => {
-            Operation::PlaylistMutation(api.playlist_access(&PlaylistId::new(id.clone())))
+        ApiRequest::UpdatePlaylist { id, .. } | ApiRequest::FollowPlaylist { id, .. } => {
+            Operation::PlaylistMutation(api.playlist_access(id))
         }
         ApiRequest::AddToPlaylist { playlist_id, .. }
         | ApiRequest::RemoveFromPlaylist { playlist_id, .. }
         | ApiRequest::ReorderPlaylist { playlist_id, .. } => {
-            Operation::PlaylistMutation(api.playlist_access(&PlaylistId::new(playlist_id.clone())))
+            Operation::PlaylistMutation(api.playlist_access(playlist_id))
         }
         ApiRequest::Recommendations { .. }
         | ApiRequest::ArtistTopTracks { .. }
@@ -1697,6 +1603,21 @@ fn observe_playlists(api: &ApiGateway, response: &ApiResponse) {
             id,
             result: Err(error),
             ..
+        }
+        | ApiResponse::PlaylistItems {
+            id,
+            result: Err(error),
+            ..
+        }
+        | ApiResponse::PlaylistSample {
+            id,
+            result: Err(error),
+            ..
+        }
+        | ApiResponse::PlaylistFollowChanged {
+            id,
+            result: Err(error),
+            ..
         } if error.status() == Some(403) => {
             api.invalidate_playlist_access(&PlaylistId::new(id.clone()));
         }
@@ -1704,17 +1625,20 @@ fn observe_playlists(api: &ApiGateway, response: &ApiResponse) {
     }
 }
 
-async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
-    let selected = api
-        .client_for(operation_for(api, &request))
-        .map(|(_, client)| client);
+async fn handle(api: &ApiGateway, request: ApiRequest) -> (ApiResponse, Option<ApiSource>) {
+    let selected = api.client_for(operation_for(api, &request));
+    let expired = std::cell::Cell::new(None);
     macro_rules! routed {
-        ($method:ident($($argument:expr),* $(,)?)) => {
-            match &selected {
+        ($method:ident($($argument:expr),* $(,)?)) => {{
+            let result = match &selected {
                 Ok(client) => client.$method($($argument),*).await,
                 Err(error) => Err(error.clone()),
+            };
+            if let Err(ApiError::SignInExpired { api_source }) = &result {
+                expired.set(Some(*api_source));
             }
-        };
+            result
+        }};
     }
 
     let response = match request {
@@ -1774,7 +1698,7 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
             offset,
             generation,
         } => ApiResponse::PlaylistItems {
-            result: api.playlist_items(&id, offset, PLAYLIST_PAGE_SIZE).await,
+            result: routed!(playlist_items(&id, offset, PLAYLIST_PAGE_SIZE)),
             id,
             offset,
             generation,
@@ -1784,7 +1708,7 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
             offset,
             generation,
         } => ApiResponse::PlaylistSample {
-            result: api.playlist_items(&id, offset, PLAYLIST_PAGE_SIZE).await,
+            result: routed!(playlist_items(&id, offset, PLAYLIST_PAGE_SIZE)),
             id,
             generation,
         },
@@ -1799,14 +1723,12 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
             description,
             public,
         } => ApiResponse::PlaylistUpdated {
-            result: match api.playlist_mutation_client(&id).await {
-                Ok((_, client)) => {
-                    client
-                        .update_playlist(&id, name.as_deref(), description.as_deref(), public)
-                        .await
-                }
-                Err(error) => Err(error),
-            },
+            result: routed!(update_playlist(
+                &id,
+                name.as_deref(),
+                description.as_deref(),
+                public
+            )),
             id,
         },
         ApiRequest::AddToPlaylist {
@@ -1814,10 +1736,7 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
             playlist_name,
             uris,
         } => ApiResponse::PlaylistItemsChanged {
-            result: match api.playlist_mutation_client(&playlist_id).await {
-                Ok((_, client)) => client.add_playlist_items(&playlist_id, &uris, None).await,
-                Err(error) => Err(error),
-            },
+            result: routed!(add_playlist_items(&playlist_id, &uris, None)),
             id: playlist_id,
             message: format!("Added to {playlist_name}"),
         },
@@ -1826,14 +1745,11 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
             uris,
             snapshot_id,
         } => ApiResponse::PlaylistItemsChanged {
-            result: match api.playlist_mutation_client(&playlist_id).await {
-                Ok((_, client)) => {
-                    client
-                        .remove_playlist_items(&playlist_id, &uris, snapshot_id.as_deref())
-                        .await
-                }
-                Err(error) => Err(error),
-            },
+            result: routed!(remove_playlist_items(
+                &playlist_id,
+                &uris,
+                snapshot_id.as_deref()
+            )),
             id: playlist_id,
             message: "Removed from playlist".to_string(),
         },
@@ -1843,19 +1759,12 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
             insert_before,
             snapshot_id,
         } => ApiResponse::PlaylistItemsChanged {
-            result: match api.playlist_mutation_client(&playlist_id).await {
-                Ok((_, client)) => {
-                    client
-                        .reorder_playlist(
-                            &playlist_id,
-                            range_start,
-                            insert_before,
-                            snapshot_id.as_deref(),
-                        )
-                        .await
-                }
-                Err(error) => Err(error),
-            },
+            result: routed!(reorder_playlist(
+                &playlist_id,
+                range_start,
+                insert_before,
+                snapshot_id.as_deref()
+            )),
             id: playlist_id,
             message: String::new(),
         },
@@ -1996,7 +1905,7 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> ApiResponse {
         },
     };
     observe_playlists(api, &response);
-    response
+    (response, expired.get())
 }
 
 /// Spotify's transcription of the track, when the local session can ask for

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -525,6 +525,7 @@ pub fn populate(app: &mut App) {
 
 /// Words to go with the sample track, timed so that the one being sung
 /// sits mid-panel at the demo's playback position.
+#[cfg(feature = "demo")]
 fn sample_lyrics() -> crate::lyrics::Lyrics {
     let lines = [
         (40_000, "Streetlights blinking down the river road"),

--- a/src/model.rs
+++ b/src/model.rs
@@ -123,6 +123,13 @@ impl<T> Loadable<T> {
             Err(error) => Loadable::Failed(error.to_string()),
         }
     }
+
+    /// Keeps an already loaded value when a refresh fails.
+    pub fn refresh<E: std::fmt::Display>(&mut self, result: Result<T, E>) {
+        if result.is_ok() || self.get().is_none() {
+            *self = Self::from_result(result);
+        }
+    }
 }
 
 /// An offset-paginated list that loads on demand as the user scrolls.
@@ -296,7 +303,6 @@ pub struct SearchState {
     pub committed: String,
     pub serial: u64,
     pub results: Loadable<SearchResults>,
-    pub refreshing: bool,
     pub filter: SearchFilter,
     pub typed_at: Option<Instant>,
     pub focus_requested: bool,

--- a/src/model.rs
+++ b/src/model.rs
@@ -169,11 +169,10 @@ impl<T> PagedList<T> {
         if (offset as usize) < self.items.len() {
             self.items.truncate(offset as usize);
         }
-        let received = page.items.len() as u32;
+        let next_offset = page.next_offset();
         self.items.extend(page.items);
         self.total = Some(page.total);
-        let more = page.next.is_some() && received > 0;
-        self.next_offset = more.then_some(offset + received);
+        self.next_offset = next_offset;
         self.loading = false;
         self.error = None;
         self.loaded_once = true;
@@ -246,6 +245,9 @@ pub struct HomeData {
     pub top_songs_complete: bool,
     pub recommendations: Loadable<Vec<Track>>,
     pub discover: HashMap<String, Loadable<Vec<Playlist>>>,
+    pub discover_pending: HashMap<String, Loadable<Vec<Playlist>>>,
+    pub generation: u64,
+    pub top_songs_generation: u64,
     pub requested: bool,
     pub loaded_at: Option<Instant>,
 }
@@ -294,6 +296,7 @@ pub struct SearchState {
     pub committed: String,
     pub serial: u64,
     pub results: Loadable<SearchResults>,
+    pub refreshing: bool,
     pub filter: SearchFilter,
     pub typed_at: Option<Instant>,
     pub focus_requested: bool,
@@ -301,6 +304,7 @@ pub struct SearchState {
 
 #[derive(Default)]
 pub struct PlaylistPage {
+    pub generation: u64,
     pub playlist: Loadable<Playlist>,
     pub items: PagedList<PlaylistItem>,
     pub filter: String,
@@ -526,8 +530,8 @@ pub enum Action {
     SignIn,
     CancelSignIn,
     SignOut,
-    /// Sign in again with the Web API application named in Settings.
-    SwitchWebApp,
+    /// Add, replace, or remove the optional personal Web API app.
+    ConfigurePersonalWebApp,
     ToggleQueuePanel,
     ToggleLyricsPanel,
     ToggleDevicesPopup,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -47,8 +47,15 @@ impl AppDirs {
         self.state.join("session.json")
     }
 
-    /// The Web API OAuth grant (access + refresh token).
-    pub fn web_token_file(&self) -> PathBuf {
+    pub fn shared_web_token_file(&self) -> PathBuf {
+        self.state.join("shared_web_api_token.json")
+    }
+
+    pub fn personal_web_token_file(&self) -> PathBuf {
+        self.state.join("personal_web_api_token.json")
+    }
+
+    pub fn legacy_web_token_file(&self) -> PathBuf {
         self.state.join("web_api_token.json")
     }
 
@@ -84,6 +91,10 @@ impl AppDirs {
 
     pub fn playlist_cache_dir(&self) -> PathBuf {
         self.cache.join("playlists")
+    }
+
+    pub fn account_playlist_cache_dir(&self, account_id: &str) -> PathBuf {
+        self.playlist_cache_dir().join(account_id)
     }
 
     pub fn ensure(&self) -> std::io::Result<()> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -48,8 +48,8 @@ pub struct Settings {
     pub sidebar_width: f32,
     pub search_history: Vec<String>,
     pub show_shortcut_hints: bool,
-    /// A personal Spotify Web API application id, if the user registered one.
-    /// `None` uses the shared public application.
+    /// An optional personal Spotify Web API application id. The shared
+    /// application remains active for coverage when this is present.
     pub web_client_id: Option<String>,
     /// Local playback has been authorized at least once on this machine, so
     /// the app can resume it silently instead of prompting.

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -531,9 +531,8 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 &app.user_names,
             );
             let count = playlist.track_total().max(items.len() as u32);
-            // The legacy collaborative flag covers only old-style secret
-            // collaborations; a playlist made together today is recognised
-            // by who added its songs.
+            // Spotify's collaborative flag covers secret collaborations; a
+            // playlist made together today is recognised by who added songs.
             let owner_id = playlist.owner.id.as_deref();
             let others = page
                 .contributors

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -152,6 +152,7 @@ fn made_for_you(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
     let mut playlists: Vec<Playlist> = Vec::new();
     let mut loading = false;
+    let mut failed = false;
     for term in DISCOVER_TERMS {
         match app.home.discover.get(*term) {
             Some(Loadable::Loaded(list)) => {
@@ -166,15 +167,18 @@ fn made_for_you(app: &mut App, ui: &mut egui::Ui) {
                 }
             }
             Some(Loadable::Loading) => loading = true,
+            Some(Loadable::Failed(_)) => failed = true,
             _ => {}
         }
     }
-    if playlists.is_empty() && !loading {
+    if playlists.is_empty() && !loading && !failed {
         return;
     }
     widgets::shelf(ui, &palette, "made-for-you", "Made for you", |ui| {
-        if playlists.is_empty() {
+        if playlists.is_empty() && loading {
             widgets::loading_row(ui, &palette);
+        } else if playlists.is_empty() && failed {
+            widgets::error_row(ui, app, "Couldn't load this shelf", Some(Page::Home));
         }
         for playlist in &playlists {
             let subtitle = playlist
@@ -209,15 +213,20 @@ fn made_for_you(app: &mut App, ui: &mut egui::Ui) {
 
 fn recently_played(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let history = match &app.home.recently_played {
-        Loadable::Loaded(history) => history.clone(),
+    let history = match app.home.recently_played.clone() {
+        Loadable::Loaded(history) => history,
         Loadable::Loading | Loadable::NotLoaded => {
             widgets::shelf(ui, &palette, "recent", "Recently played", |ui| {
                 widgets::loading_row(ui, &palette)
             });
             return;
         }
-        Loadable::Failed(_) => return,
+        Loadable::Failed(message) => {
+            widgets::shelf(ui, &palette, "recent", "Recently played", |ui| {
+                widgets::error_row(ui, app, &message, Some(Page::Home));
+            });
+            return;
+        }
     };
     let mut seen = std::collections::HashSet::new();
     let tracks: Vec<_> = history
@@ -265,15 +274,20 @@ fn recently_played(app: &mut App, ui: &mut egui::Ui) {
 
 fn top_artists(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let artists = match &app.home.top_artists {
-        Loadable::Loaded(artists) => artists.clone(),
+    let artists = match app.home.top_artists.clone() {
+        Loadable::Loaded(artists) => artists,
         Loadable::Loading | Loadable::NotLoaded => {
             widgets::shelf(ui, &palette, "top-artists", "Your top artists", |ui| {
                 widgets::loading_row(ui, &palette)
             });
             return;
         }
-        Loadable::Failed(_) => return,
+        Loadable::Failed(message) => {
+            widgets::shelf(ui, &palette, "top-artists", "Your top artists", |ui| {
+                widgets::error_row(ui, app, &message, Some(Page::Home));
+            });
+            return;
+        }
     };
     if artists.is_empty() {
         return;
@@ -328,7 +342,12 @@ fn track_list(
             ui.add_space(12.0);
             return;
         }
-        Loadable::Failed(_) => return,
+        Loadable::Failed(message) => {
+            theme::section_title(ui, &palette, title);
+            widgets::error_row(ui, app, &message, Some(title_page.unwrap_or(Page::Home)));
+            ui.add_space(12.0);
+            return;
+        }
     };
     if tracks.is_empty() {
         return;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -97,7 +97,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui,
             &palette,
             "Make it even faster",
-            "Spotify limits each app, and everyone shares this one. An app of your own has its own limit, but opens only playlists you own. Paste its Client ID here.",
+            "Add your own Spotify Development Mode app as optional acceleration. Fastpotify keeps the shared app for catalog coverage and external playlists.",
             |ui| {
                 let response = Frame::new()
                     .fill(palette.surface)
@@ -133,46 +133,53 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 }
             },
         );
-        // Whether the app named above is the one signed in with. Switching
-        // means one more trip through the browser, so it is a button, not a
-        // side effect of typing.
         let wanted = app
             .settings
             .web_client_id
             .as_deref()
             .map(str::trim)
             .filter(|id| !id.is_empty())
-            .unwrap_or(crate::auth::DEFAULT_WEB_CLIENT_ID)
-            .to_string();
-        let own = wanted != crate::auth::DEFAULT_WEB_CLIENT_ID;
-        let in_use = app.web_app.as_deref() == Some(wanted.as_str());
-        if in_use && own {
+            .map(str::to_string);
+        let in_use = wanted
+            .as_deref()
+            .is_some_and(|wanted| app.web_app.as_deref() == Some(wanted));
+        if in_use {
             widgets::setting_row(
                 ui,
                 &palette,
-                "Your app is in use",
-                "Requests go through your own limit.",
+                "Personal acceleration is ready",
+                "Supported requests use your app. Shared catalog coverage stays available.",
                 |ui| {
-                    theme::text(ui, "In use", theme::medium(13.0), palette.accent);
+                    if theme::pill_button(ui, &palette, "Remove", false).clicked() {
+                        app.settings.web_client_id = None;
+                        app.actions.push(Action::ConfigurePersonalWebApp);
+                    }
                 },
             );
-        } else if !in_use && app.web_app.is_some() {
-            let (title, detail) = if own {
-                (
-                    "Ready to switch to your app",
-                    "Fastpotify signs in again with it; your browser opens once.",
-                )
-            } else {
-                (
-                    "Back to the shared app?",
-                    "Fastpotify signs in again with it; your browser opens once.",
-                )
-            };
-            widgets::setting_row(ui, &palette, title, detail, |ui| {
-                if theme::pill_button(ui, &palette, "Switch now", true).clicked() {
-                    app.actions.push(Action::SwitchWebApp);
-                }
-            });
+        } else if wanted.is_some() {
+            widgets::setting_row(
+                ui,
+                &palette,
+                "Authorize your personal app",
+                "Spotify opens once to verify that both sessions belong to this account.",
+                |ui| {
+                    if theme::pill_button(ui, &palette, "Authorize", true).clicked() {
+                        app.actions.push(Action::ConfigurePersonalWebApp);
+                    }
+                },
+            );
+        } else if app.web_app.is_some() {
+            widgets::setting_row(
+                ui,
+                &palette,
+                "Remove personal app",
+                "Shared access remains signed in.",
+                |ui| {
+                    if theme::pill_button(ui, &palette, "Remove", false).clicked() {
+                        app.actions.push(Action::ConfigurePersonalWebApp);
+                    }
+                },
+            );
         }
     });
 


### PR DESCRIPTION
## Why

Fastpotify normally uses a shared Web API app. Users can also configure a personal Spotify Development Mode app to get a separate API quota.

Previously, configuring a personal app meant relying on it for every request. That caused Spotify-owned playlists and some catalog data to disappear because Spotify restricts those endpoints in Development Mode.

This change uses both Web API apps together. Fastpotify keeps the shared app for complete Spotify coverage and sends supported requests through the personal app when one is configured.

## What changed

A new API gateway routes each Spotify Web API request to either the shared app or the optional personal app.

The shared Web API app handles:

- Complete playlist library and search results
- Spotify-owned and external playlists
- Recommendations, artist top tracks, and related artists
- Saved-state checks and follows that name a playlist
- Account data unavailable through Development Mode

The personal Web API app handles supported requests such as:

- Playback, devices, and queue
- Library reads and writes
- Playlist creation
- Owned or collaborative playlist changes
- Supported catalog requests

When Fastpotify does not yet know who owns a playlist, its requests go through the shared app, which can serve any playlist. Once a response reveals the owner, later requests for that playlist move to the personal app. No extra request is spent on classification.

Each app has its own token, concurrency limit, cooldown, and rate-limit state. A `429` response from one app does not pause requests through the other, and `Retry-After` waits are capped at 30 seconds.

## Resilience

- A transient network failure during token refresh keeps the current session; only Spotify rejecting the grant signs a session out.
- Launching offline shows "Connecting" and retries verification with backoff until the network returns — no forced re-authorization.
- A fresh browser grant is saved to disk immediately, so a failed or rate-limited verification never discards it.
- The playlist disk cache is only shown after Spotify's snapshot confirms it is current; a stale cache is discarded, never shown.
- If the two grants belong to different Spotify accounts, the sign-in fails with a visible error instead of hanging.

## User-visible behavior

Adding a personal Spotify app now improves API capacity without removing content available through the shared app.

Spotify-owned playlists remain visible and can be opened. Playlist search remains complete, and artist discographies load within Spotify's current endpoint limits.

Late responses from older page requests can no longer replace newer content. Playlist caches are also scoped to the signed-in Spotify account.

## Upgrades

Existing Web API tokens migrate automatically:

- Tokens created with Fastpotify's shared app become the shared Web API session.
- Tokens created with a custom Client ID become the personal Web API session.
- Users upgrading from a custom-app-only setup keep their personal authorization and are prompted once to authorize the shared app.
- Signing out removes both Web API grants.

The separate local playback credential is unchanged.

## Code guide

- `src/api/gateway.rs` contains the routing rules, session states, and the playlist-ownership map.
- `src/auth.rs` handles authorization and migration of existing tokens.
- `src/backend.rs` manages both sessions and their lifecycle.
- `src/api/client.rs` contains per-session limits, cooldowns, and Spotify endpoint handling.
- `src/app.rs` handles request generations and account-scoped playlist caching.

## Verification

- `cargo test --features demo`
- `cargo clippy --all-targets --features demo -- -D warnings`
- `cargo fmt --all --check`
- Production documentation build
- Fresh shared and personal app authorization
- Spotify-owned playlist discovery, opening, and playback
- Artist discography loading