### PR TITLE
Compact the account menu

### DIFF
--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -161,7 +161,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     .frame(super::widgets::menu_frame(&palette))
                     .align(egui::RectAlign::BOTTOM_END)
                     .show(|ui| {
-                        ui.set_min_width(200.0);
+                        ui.set_width(200.0);
                         ui.add_space(4.0);
                         ui.horizontal(|ui| {
                             ui.add_space(10.0);

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -163,7 +163,7 @@ pub fn menu_item_enabled(
     label: &str,
     enabled: bool,
 ) -> bool {
-    let width = ui.available_width().max(200.0);
+    let width = ui.available_width();
     let (rect, response) = ui.allocate_exact_size(
         vec2(width, 28.0),
         if enabled {


### PR DESCRIPTION
## Summary
- constrain the account popup to its intended width
- let menu items fill the popup instead of forcing a 200px minimum

## Testing
- `cargo check`
- `cargo test` (51 tests)
- `cargo clippy --lib -- -D warnings`