### PR TITLE
Widen the control channel to what a button needs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,10 @@ librespot-protocol = { version = "0.8", default-features = false }
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
 cpal = "0.16"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "gzip", "http2", "blocking"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
+# `fs` is used by the playlist cache in `backend.rs`. On Linux the
+# mpris-server dependency happens to turn it on, which is why leaving it out
+# built there and nowhere else.
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "fs"] }
 sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -167,19 +167,40 @@ fastpotify play-pause          fastpotify volume 40
 fastpotify play                fastpotify volume-up [percent]
 fastpotify pause               fastpotify volume-down [percent]
 fastpotify next                fastpotify mute
-fastpotify previous            fastpotify shuffle
-fastpotify seek 15             fastpotify repeat
-fastpotify seek -- -15         fastpotify show
-fastpotify now-playing [--raw]
+fastpotify previous            fastpotify shuffle [on|off]
+fastpotify seek 15             fastpotify repeat [off|context|track]
+fastpotify seek -- -15         fastpotify like
+fastpotify seek-to 90          fastpotify play-uri spotify:playlist:37i9…
+fastpotify show                fastpotify transfer <device-id>
+fastpotify now-playing [--raw] fastpotify devices [--raw]
 ```
+
+`shuffle` and `repeat` toggle when asked for nothing in particular and set
+the state outright when given one, which is what a button that draws the
+current state wants: a missed update otherwise leaves the two disagreeing
+until the next press. `like` saves the playing track to your library, or
+takes it back out.
 
 `now-playing` prints one readable line; `--raw` prints the fields
 tab-separated — state, title, artists, album, position_ms, duration_ms,
-volume, shuffle, repeat — for a script that wants one of them. A verb exits
-non-zero when Fastpotify is not running.
+volume, shuffle, repeat, art_url, saved, device — for a script that wants
+one of them. `saved` is `yes`, `no`, or `unknown` while the answer is still
+on its way. The last three fields were added after the first nine, and
+appended rather than woven in, so a script written against the older shape
+still reads correctly.
+
+`devices` lists the Spotify Connect devices, id first, the active one
+marked with `*`; `--raw` prints them as JSON. The app only refreshes that
+list while its own picker is open, so asking for it also asks it to look
+again: on a cold list the first call can come back empty and the next one
+has it.
+
+A verb exits non-zero when Fastpotify is not running.
 
 That is enough for a launcher such as Raycast or Alfred to drive playback
-through its own script commands.
+through its own script commands — and it is the same channel the Stream
+Deck plugin speaks, which is why the verbs cover more than a media key can
+ask for.
 
 ## Settings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -131,6 +131,13 @@ pub struct App {
     /// Where the now-playing snapshot goes for the control channel's
     /// `nowplaying` verb to answer from.
     control_now_playing: Option<std::sync::Arc<std::sync::Mutex<String>>>,
+    /// The same, for its `devices` verb.
+    control_devices: Option<std::sync::Arc<std::sync::Mutex<String>>>,
+    /// Whether that device slot still matches [`Self::devices`]. The
+    /// now-playing snapshot is rebuilt every frame because its position
+    /// moves every frame; a device list changes when Spotify answers, which
+    /// is seconds apart, so it is written when it changes instead.
+    control_devices_stale: bool,
     /// Sample data is loaded and nothing is asked of Spotify.
     pub offline: bool,
     pub palette: Palette,
@@ -318,6 +325,8 @@ impl App {
             wants_show: false,
             control_commands: None,
             control_now_playing: None,
+            control_devices: None,
+            control_devices_stale: true,
             offline: false,
             palette: Palette::dark(),
             applied_dark: None,
@@ -402,11 +411,12 @@ impl App {
         app
     }
 
-    /// Watches the queue control clients fill and keeps their now-playing
-    /// snapshot fresh.
+    /// Watches the queue control clients fill and keeps the snapshots they
+    /// read -- now playing, and the device list -- fresh.
     pub fn set_remote_control(&mut self, guard: &crate::single_instance::Guard) {
         self.control_commands = Some(guard.commands());
         self.control_now_playing = Some(guard.now_playing_slot());
+        self.control_devices = Some(guard.devices_slot());
     }
 
     /// Per-window setup: fonts, icons, loaders, theme. Called every time a
@@ -849,6 +859,7 @@ impl App {
         self.saved_pending.clear();
         self.queue = Loadable::NotLoaded;
         self.devices.clear();
+        self.control_devices_stale = true;
         self.devices_fetched_at = None;
         self.search.results = Loadable::NotLoaded;
         self.search.committed.clear();
@@ -1087,6 +1098,21 @@ impl App {
                 ControlCommand::ToggleMute => Some(Action::ToggleMute),
                 ControlCommand::ToggleShuffle => Some(Action::ToggleShuffle),
                 ControlCommand::CycleRepeat => Some(Action::CycleRepeat),
+                ControlCommand::SetShuffle(shuffle) => Some(Action::SetShuffle(shuffle)),
+                ControlCommand::SetRepeat(mode) => Some(Action::SetRepeat(mode)),
+                ControlCommand::SeekTo(position) => Some(Action::Seek(position)),
+                // Nothing playing is nothing to save, so the verb is a
+                // no-op rather than an error the client has to handle.
+                ControlCommand::ToggleSaved => {
+                    self.now_playing().map(|now| Action::ToggleSaved(now.uri))
+                }
+                ControlCommand::PlayUri(uri) => Some(Action::PlayContext {
+                    uri,
+                    offset_uri: None,
+                    offset_index: None,
+                }),
+                ControlCommand::Transfer(device_id) => Some(Action::Transfer(device_id)),
+                ControlCommand::RefreshDevices => Some(Action::RefreshDevices),
             };
             if let Some(action) = action {
                 self.actions.push(action);
@@ -1178,25 +1204,55 @@ impl App {
             let snapshot = self.control_snapshot();
             *slot.lock().unwrap_or_else(|p| p.into_inner()) = snapshot;
         }
+        if self.control_devices_stale
+            && let Some(slot) = self.control_devices.clone()
+        {
+            let snapshot = self.control_devices_snapshot();
+            *slot.lock().unwrap_or_else(|p| p.into_inner()) = snapshot;
+            self.control_devices_stale = false;
+        }
     }
 
     /// One line for the control channel's `nowplaying` verb: tab-separated
     /// `state, title, artists, album, position_ms, duration_ms, volume,
-    /// shuffle, repeat`, or [`crate::single_instance::NOTHING_PLAYING`].
+    /// shuffle, repeat, art_url, saved, device`, or
+    /// [`crate::single_instance::NOTHING_PLAYING`].
+    ///
+    /// The last three are what a Stream Deck key needs and a media key does
+    /// not: something to draw, whether the heart is filled, and where the
+    /// sound is coming out. They are appended rather than woven in, so a
+    /// script written against the older nine fields still reads correctly.
     fn control_snapshot(&self) -> String {
         let Some(now) = self.now_playing() else {
             return crate::single_instance::NOTHING_PLAYING.to_owned();
         };
         let state = if now.playing { "playing" } else { "paused" };
-        let repeat = match now.repeat {
-            RepeatMode::Off => "off",
-            RepeatMode::Context => "context",
-            RepeatMode::Track => "track",
+        // Not every track has been looked up yet; say so rather than
+        // claiming an unsaved track the client would draw as a hollow heart
+        // and then watch fill in a moment later.
+        let saved = match self.is_saved(&now.uri) {
+            Some(true) => "yes",
+            Some(false) => "no",
+            None => "unknown",
+        };
+        // Local playback is this computer, which Spotify has not named in
+        // the snapshot because it is not a remote device.
+        let device = match (&now.device_name, now.local) {
+            (Some(name), _) => name.as_str(),
+            (None, true) => self.settings.device_name.as_str(),
+            (None, false) => "",
         };
         // Tabs separate the fields, so a tab inside one would shift the rest.
-        let clean = |text: &str| text.replace('\t', " ");
+        // This runs every frame, and titles almost never contain one, so the
+        // usual answer borrows rather than allocating a copy per field.
+        fn clean(text: &str) -> std::borrow::Cow<'_, str> {
+            match text.contains('\t') {
+                true => std::borrow::Cow::Owned(text.replace('\t', " ")),
+                false => std::borrow::Cow::Borrowed(text),
+            }
+        }
         format!(
-            "{state}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{repeat}",
+            "{state}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{saved}\t{}",
             clean(&now.title),
             clean(&now.subtitle),
             clean(&now.album_name),
@@ -1204,7 +1260,34 @@ impl App {
             now.duration_ms,
             now.volume_percent,
             if now.shuffle { "on" } else { "off" },
+            now.repeat.api_name(),
+            clean(now.art_url.as_deref().unwrap_or_default()),
+            clean(device),
         )
+    }
+
+    /// One line for the control channel's `devices` verb: the Spotify
+    /// Connect devices the app last saw, as JSON.
+    ///
+    /// JSON rather than the tab-separated shape `nowplaying` uses because
+    /// there are several of them and a device carries a name its owner
+    /// chose, which is exactly the kind of free text a hand-rolled
+    /// separator gets wrong.
+    fn control_devices_snapshot(&self) -> String {
+        let devices: Vec<_> = self
+            .devices
+            .iter()
+            .filter_map(|device| {
+                Some(serde_json::json!({
+                    "id": device.id.as_deref()?,
+                    "name": device.name,
+                    "kind": device.kind,
+                    "active": device.is_active,
+                }))
+            })
+            .collect();
+        serde_json::to_string(&devices)
+            .unwrap_or_else(|_| crate::single_instance::NO_DEVICES.to_owned())
     }
 
     // ---- loading ---------------------------------------------------------------
@@ -1598,6 +1681,7 @@ impl App {
                 match result {
                     Ok(devices) => {
                         self.devices = devices;
+                        self.control_devices_stale = true;
                         if let Some((name, since)) = self.pending_transfer_to.clone() {
                             let matching = self
                                 .devices
@@ -3613,6 +3697,148 @@ mod tests {
             app.actions
         );
         assert!(queue.lock().expect("the queue").is_empty());
+    }
+
+    /// The verbs a Stream Deck key needs and a media key never asked for:
+    /// a state said outright rather than toggled, an absolute position, a
+    /// URI, and moving the sound to another device.
+    #[test]
+    fn a_key_can_ask_for_a_state_rather_than_a_toggle() {
+        // #given
+        let mut app = headless_app();
+        let queue: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> = Default::default();
+        app.control_commands = Some(std::sync::Arc::clone(&queue));
+
+        // #when
+        queue.lock().expect("the queue").extend([
+            ControlCommand::SetShuffle(true),
+            ControlCommand::SetRepeat(RepeatMode::Track),
+            ControlCommand::SeekTo(90_000),
+            ControlCommand::PlayUri("spotify:playlist:pl1".to_owned()),
+            ControlCommand::Transfer("abc123".to_owned()),
+            ControlCommand::RefreshDevices,
+            // Nothing is playing in a headless app, so there is no track to
+            // save and this one falls away rather than erroring.
+            ControlCommand::ToggleSaved,
+        ]);
+        app.handle_control_commands();
+
+        // #then
+        assert!(
+            matches!(
+                app.actions.as_slice(),
+                [
+                    Action::SetShuffle(true),
+                    Action::SetRepeat(RepeatMode::Track),
+                    Action::Seek(90_000),
+                    Action::PlayContext {
+                        offset_uri: None,
+                        offset_index: None,
+                        ..
+                    },
+                    Action::Transfer(_),
+                    Action::RefreshDevices,
+                ]
+            ),
+            "{:?}",
+            app.actions
+        );
+        assert!(queue.lock().expect("the queue").is_empty());
+    }
+
+    /// The snapshot a client polls keeps its first nine fields where they
+    /// were, so a script written against the older shape still reads them,
+    /// and says "unknown" rather than guessing at a saved flag nobody has
+    /// told it yet.
+    #[test]
+    fn the_snapshot_appends_what_a_key_needs_without_moving_what_was_there() {
+        // #given
+        let mut app = headless_app();
+        app.handle_local(LocalState {
+            playback: Playback::Playing,
+            track: Some(crate::player::LocalTrack {
+                uri: "spotify:track:t1".to_owned(),
+                title: "Go".to_owned(),
+                artists: vec!["The Band".to_owned()],
+                album: "First".to_owned(),
+                art_url: Some("https://i.scdn.co/image/abc".to_owned()),
+                duration_ms: 200_000,
+                ..Default::default()
+            }),
+            position_ms: 20_000,
+            volume: percent_to_volume(35),
+            shuffle: true,
+            repeat: RepeatMode::Track,
+            ..LocalState::default()
+        });
+
+        // #when
+        let snapshot = app.control_snapshot();
+        let fields: Vec<&str> = snapshot.split('\t').collect();
+
+        // #then
+        assert_eq!(
+            fields,
+            [
+                // The nine a media key or a Raycast script already read.
+                "playing",
+                "Go",
+                "The Band",
+                "First",
+                "20000",
+                "200000",
+                "35",
+                "on",
+                "track",
+                // The three a Stream Deck key needs, appended.
+                "https://i.scdn.co/image/abc",
+                // Not signed in, so nobody has said whether this is saved.
+                "unknown",
+                // Local playback is this computer, which Spotify has not
+                // named because it is not a remote device.
+                "Fastpotify",
+            ]
+        );
+        // No devices seen yet is an empty array, not an empty string, so a
+        // client never special-cases the answer.
+        assert_eq!(
+            app.control_devices_snapshot(),
+            crate::single_instance::NO_DEVICES
+        );
+    }
+
+    /// The device slot is written when Spotify answers rather than every
+    /// frame, so the thing to check is that an answer still reaches it.
+    #[test]
+    fn a_device_list_reaches_the_slot_when_spotify_answers() {
+        // #given
+        let mut app = headless_app();
+        let slot = std::sync::Arc::new(std::sync::Mutex::new(
+            crate::single_instance::NO_DEVICES.to_owned(),
+        ));
+        app.control_devices = Some(std::sync::Arc::clone(&slot));
+        app.control_devices_stale = false;
+
+        // #when
+        app.handle_api(ApiResponse::Devices(Ok(vec![Device {
+            id: Some("abc123".to_owned()),
+            name: "Kitchen\tspeaker".to_owned(),
+            kind: "Speaker".to_owned(),
+            is_active: true,
+            ..Device::default()
+        }])));
+        app.sync_media_controls();
+
+        // #then
+        let written = slot.lock().expect("the slot").clone();
+        assert_eq!(
+            written,
+            r#"[{"active":true,"id":"abc123","kind":"Speaker","name":"Kitchen\tspeaker"}]"#,
+            "a name is carried whole, tab and all, because JSON escapes it \
+             where the tab-separated snapshot could not"
+        );
+        // Written once and not again until the next answer.
+        assert!(!app.control_devices_stale);
     }
 
     /// `play` and `pause` say what state to end in, so the one that would

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,8 @@ enum Control {
         #[arg(allow_negative_numbers = true)]
         seconds: i64,
     },
+    /// Seek to a position, in seconds from the start
+    SeekTo { seconds: u32 },
     /// Set the volume to a percentage
     Volume {
         #[arg(value_parser = clap::value_parser!(u8).range(0..=100))]
@@ -89,14 +91,27 @@ enum Control {
     },
     /// Toggle mute
     Mute,
-    /// Toggle shuffle
-    Shuffle,
-    /// Cycle the repeat mode
-    Repeat,
+    /// Toggle shuffle, or set it outright
+    Shuffle { state: Option<OnOff> },
+    /// Cycle the repeat mode, or set it outright
+    Repeat { mode: Option<Repeat> },
+    /// Save the playing track to your library, or take it back out
+    Like,
+    /// Play a Spotify URI: a track, album, playlist, artist, or show
+    PlayUri { uri: String },
+    /// List the Spotify Connect devices
+    Devices {
+        /// Print the JSON the running instance sent instead.
+        #[arg(long)]
+        raw: bool,
+    },
+    /// Move playback to a device, by the id `devices` prints
+    Transfer { device_id: String },
     /// Print the playing track
     NowPlaying {
         /// Print the fields tab-separated instead: state, title, artists,
-        /// album, position_ms, duration_ms, volume, shuffle, repeat.
+        /// album, position_ms, duration_ms, volume, shuffle, repeat,
+        /// art_url, saved, device.
         #[arg(long)]
         raw: bool,
     },
@@ -104,11 +119,30 @@ enum Control {
     Show,
 }
 
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum OnOff {
+    On,
+    Off,
+}
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum Repeat {
+    /// Play through and stop
+    Off,
+    /// Repeat the album, playlist, or queue
+    Context,
+    /// Repeat this track
+    Track,
+}
+
 /// Sends one control verb to the running instance. Speaks over the
 /// single-instance loopback socket, which Linux does not have.
 #[cfg(not(target_os = "linux"))]
 fn run_control(control: Control) -> i32 {
-    let raw = matches!(control, Control::NowPlaying { raw: true });
+    let raw = matches!(
+        control,
+        Control::NowPlaying { raw: true } | Control::Devices { raw: true }
+    );
     let verb = match control {
         Control::PlayPause => "playpause".to_owned(),
         Control::Play => "play".to_owned(),
@@ -116,12 +150,32 @@ fn run_control(control: Control) -> i32 {
         Control::Next => "next".to_owned(),
         Control::Previous => "previous".to_owned(),
         Control::Seek { seconds } => format!("seek-by {}", seconds.saturating_mul(1000)),
+        Control::SeekTo { seconds } => format!("seek-to {}", u64::from(seconds) * 1000),
         Control::Volume { percent } => format!("volume-set {percent}"),
         Control::VolumeUp { percent } => format!("volume-by {percent}"),
         Control::VolumeDown { percent } => format!("volume-by -{percent}"),
         Control::Mute => "mute".to_owned(),
-        Control::Shuffle => "shuffle".to_owned(),
-        Control::Repeat => "repeat".to_owned(),
+        Control::Shuffle { state: None } => "shuffle".to_owned(),
+        Control::Shuffle { state: Some(state) } => {
+            let state = match state {
+                OnOff::On => "on",
+                OnOff::Off => "off",
+            };
+            format!("shuffle-set {state}")
+        }
+        Control::Repeat { mode: None } => "repeat".to_owned(),
+        Control::Repeat { mode: Some(mode) } => {
+            let mode = match mode {
+                Repeat::Off => "off",
+                Repeat::Context => "context",
+                Repeat::Track => "track",
+            };
+            format!("repeat-set {mode}")
+        }
+        Control::Like => "save-toggle".to_owned(),
+        Control::PlayUri { uri } => format!("play-uri {uri}"),
+        Control::Devices { .. } => "devices".to_owned(),
+        Control::Transfer { device_id } => format!("transfer {device_id}"),
         Control::NowPlaying { .. } => "nowplaying".to_owned(),
         Control::Show => "show".to_owned(),
     };
@@ -132,6 +186,14 @@ fn run_control(control: Control) -> i32 {
                 println!("{snapshot}");
             } else {
                 println!("{}", format_now_playing(&snapshot));
+            }
+            0
+        }
+        Ok(single_instance::Reply::Devices(snapshot)) => {
+            if raw {
+                println!("{snapshot}");
+            } else {
+                print!("{}", format_devices(&snapshot));
             }
             0
         }
@@ -173,6 +235,33 @@ fn format_now_playing(snapshot: &str) -> String {
         }
         _ => "Nothing playing".to_owned(),
     }
+}
+
+/// The `devices` snapshot as one line per device, the active one marked.
+/// The id comes first because `fastpotify transfer` is what it is for.
+#[cfg(not(target_os = "linux"))]
+fn format_devices(snapshot: &str) -> String {
+    let Ok(devices) = serde_json::from_str::<Vec<serde_json::Value>>(snapshot) else {
+        return String::new();
+    };
+    let field =
+        |device: &serde_json::Value, key: &str| device[key].as_str().unwrap_or_default().to_owned();
+    devices
+        .iter()
+        .map(|device| {
+            format!(
+                "{}{}\t{}\t{}\n",
+                if device["active"].as_bool().unwrap_or(false) {
+                    "* "
+                } else {
+                    "  "
+                },
+                field(device, "id"),
+                field(device, "name"),
+                field(device, "kind"),
+            )
+        })
+        .collect()
 }
 
 fn main() -> eframe::Result<()> {

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -29,10 +29,22 @@
 //! `fastpotify next` (or a Raycast script running it) connects, sends one
 //! `fastpotify:<verb>` line, and reads one reply line. Playback verbs are
 //! acknowledged with `fastpotify:ok` and land in the same action queue the
-//! tray and the media keys feed; `nowplaying` is answered from a snapshot
-//! the app keeps fresh, so the listener thread never touches app state.
+//! tray and the media keys feed; the two read verbs, `nowplaying` and
+//! `devices`, are answered from snapshots the app keeps fresh, so the
+//! listener thread never touches app state.
 //! Linux needs none of this: MPRIS already gives `playerctl` the same verbs,
 //! so the D-Bus name stays a pure instance guard there.
+//!
+//! The same channel is what the Stream Deck plugin speaks. That is why the
+//! verbs cover more than a media key can ask for -- an explicit shuffle or
+//! repeat state rather than only a toggle, saving the playing track, playing
+//! a URI, listing devices and moving playback to one -- and why the
+//! now-playing snapshot carries the artwork URL and the saved flag a key
+//! needs to draw itself. A client polls; nothing is pushed.
+//!
+//! Anything on the machine can reach the port, so the two verbs that carry
+//! free text (`play-uri`, `transfer`) validate their argument here rather
+//! than handing the app an arbitrary string.
 
 /// The name held for the lifetime of the running instance.
 #[cfg(target_os = "linux")]
@@ -68,6 +80,23 @@ pub enum ControlCommand {
     ToggleMute,
     ToggleShuffle,
     CycleRepeat,
+    /// Shuffle set outright. A key that draws the current state wants to say
+    /// which state it is asking for, or a missed update leaves the two
+    /// disagreeing until the next press.
+    SetShuffle(bool),
+    /// Repeat set outright, for the same reason.
+    SetRepeat(crate::player::RepeatMode),
+    /// Absolute position, in milliseconds.
+    SeekTo(u32),
+    /// Save the playing track to the library, or take it back out.
+    ToggleSaved,
+    /// Play a `spotify:` URI: a track, album, playlist, artist, or show.
+    PlayUri(String),
+    /// Move playback to a Spotify Connect device, by id.
+    Transfer(String),
+    /// Refresh the device list. Sent by the `devices` read, which answers
+    /// from a snapshot that is only as fresh as the app's last look.
+    RefreshDevices,
 }
 
 /// Holds whatever marks this process as the running instance. Dropping it
@@ -81,6 +110,9 @@ pub struct Guard {
     /// One line about the current track, kept fresh by the app so the
     /// listener can answer `nowplaying` without touching app state.
     now_playing: std::sync::Arc<std::sync::Mutex<String>>,
+    /// The Spotify Connect devices the app last saw, as one line of JSON,
+    /// kept fresh the same way and for the same reason.
+    devices: std::sync::Arc<std::sync::Mutex<String>>,
 }
 
 impl Guard {
@@ -93,11 +125,21 @@ impl Guard {
     pub fn now_playing_slot(&self) -> std::sync::Arc<std::sync::Mutex<String>> {
         std::sync::Arc::clone(&self.now_playing)
     }
+
+    /// The slot the app writes the device list into.
+    pub fn devices_slot(&self) -> std::sync::Arc<std::sync::Mutex<String>> {
+        std::sync::Arc::clone(&self.devices)
+    }
 }
 
 /// What the app writes into the snapshot slot before anything plays, and
 /// what `nowplaying` reports when nothing does.
 pub const NOTHING_PLAYING: &str = "stopped";
+
+/// What the device slot holds before the app has looked, and what `devices`
+/// reports when Spotify lists none. A JSON array either way, so a client
+/// never has to special-case the empty answer.
+pub const NO_DEVICES: &str = "[]";
 
 /// Loopback port that marks a running instance on platforms without a bus.
 /// Registered to nothing; chosen high and out of the ephemeral range.
@@ -112,6 +154,8 @@ const PREFIX: &str = "fastpotify:";
 const OK_REPLY: &str = "fastpotify:ok";
 #[cfg(not(target_os = "linux"))]
 const NOW_REPLY: &str = "fastpotify:now ";
+#[cfg(not(target_os = "linux"))]
+const DEVICES_REPLY: &str = "fastpotify:devices ";
 
 /// What the running instance said back.
 #[cfg(not(target_os = "linux"))]
@@ -120,8 +164,12 @@ pub enum Reply {
     Ok,
     /// The `nowplaying` snapshot: [`NOTHING_PLAYING`], or tab-separated
     /// `state, title, artists, album, position_ms, duration_ms, volume,
-    /// shuffle, repeat`.
+    /// shuffle, repeat, art_url, saved, device`.
     NowPlaying(String),
+    /// The `devices` snapshot: a JSON array of objects with `id`, `name`,
+    /// `kind`, and `active`, or [`NO_DEVICES`]. Free text (a speaker someone
+    /// named) makes tab-separated fields a poor fit here.
+    Devices(String),
 }
 
 /// Sends one verb to the running instance and reads its reply.
@@ -149,6 +197,8 @@ fn send_to(port: u16, verb: &str) -> std::io::Result<Reply> {
         Ok(Reply::Ok)
     } else if let Some(snapshot) = line.strip_prefix(NOW_REPLY) {
         Ok(Reply::NowPlaying(snapshot.to_owned()))
+    } else if let Some(snapshot) = line.strip_prefix(DEVICES_REPLY) {
+        Ok(Reply::Devices(snapshot.to_owned()))
     } else {
         Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -165,6 +215,7 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
     let unguarded = || Guard {
         commands: Default::default(),
         now_playing: Arc::new(Mutex::new(NOTHING_PLAYING.to_owned())),
+        devices: Arc::new(Mutex::new(NO_DEVICES.to_owned())),
     };
 
     let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, INSTANCE_PORT)) {
@@ -184,10 +235,11 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
     let guard = unguarded();
     let commands = Arc::clone(&guard.commands);
     let now_playing = Arc::clone(&guard.now_playing);
+    let devices = Arc::clone(&guard.devices);
     let waker = waker.clone();
     let spawned = std::thread::Builder::new()
         .name("fastpotify-instance".to_owned())
-        .spawn(move || serve(listener, &commands, &now_playing, &waker));
+        .spawn(move || serve(listener, &commands, &now_playing, &devices, &waker));
     if let Err(error) = spawned {
         log::warn!("cannot listen for other launches: {error}");
     }
@@ -201,10 +253,19 @@ fn serve(
     listener: std::net::TcpListener,
     commands: &std::sync::Mutex<Vec<ControlCommand>>,
     now_playing: &std::sync::Mutex<String>,
+    devices: &std::sync::Mutex<String>,
     waker: &crate::backend::Waker,
 ) {
     use std::io::Write;
     use std::time::Duration;
+
+    let queue = |command| {
+        commands
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(command);
+        waker.wake();
+    };
 
     for mut stream in listener.incoming().flatten() {
         let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
@@ -214,11 +275,7 @@ fn serve(
         match parse(&line) {
             Some(Request::Command(command)) => {
                 let _ = stream.write_all(format!("{OK_REPLY}\n").as_bytes());
-                commands
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push(command);
-                waker.wake();
+                queue(command);
             }
             Some(Request::NowPlaying) => {
                 let snapshot = now_playing
@@ -226,6 +283,17 @@ fn serve(
                     .unwrap_or_else(|p| p.into_inner())
                     .clone();
                 let _ = stream.write_all(format!("{NOW_REPLY}{snapshot}\n").as_bytes());
+            }
+            Some(Request::Devices) => {
+                let snapshot = devices.lock().unwrap_or_else(|p| p.into_inner()).clone();
+                let _ = stream.write_all(format!("{DEVICES_REPLY}{snapshot}\n").as_bytes());
+                // The app only refreshes the list while its own picker is
+                // open, so a client asking is reason enough to look again.
+                // The answer above is whatever was known a moment ago; the
+                // next read has the fresh one.
+                // ponytail: one read behind on a cold list. Push updates
+                // only if a client ever needs it sooner than that.
+                queue(ControlCommand::RefreshDevices);
             }
             // Not our client; say nothing and hang up.
             None => {}
@@ -239,6 +307,7 @@ fn serve(
 enum Request {
     Command(ControlCommand),
     NowPlaying,
+    Devices,
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -256,15 +325,58 @@ fn parse(line: &str) -> Option<Request> {
         ("next", None) => ControlCommand::Next,
         ("previous", None) => ControlCommand::Previous,
         ("seek-by", Some(ms)) => ControlCommand::SeekBy(ms.parse().ok()?),
+        ("seek-to", Some(ms)) => ControlCommand::SeekTo(ms.parse().ok()?),
         ("volume-by", Some(delta)) => ControlCommand::VolumeBy(delta.parse().ok()?),
         ("volume-set", Some(volume)) => ControlCommand::SetVolume(volume.parse().ok()?),
         ("mute", None) => ControlCommand::ToggleMute,
         ("shuffle", None) => ControlCommand::ToggleShuffle,
+        ("shuffle-set", Some("on")) => ControlCommand::SetShuffle(true),
+        ("shuffle-set", Some("off")) => ControlCommand::SetShuffle(false),
         ("repeat", None) => ControlCommand::CycleRepeat,
+        // Spelled out rather than through `RepeatMode::from_api`, which
+        // reads an unknown word as `off`. A verb nobody meant to send
+        // should be refused, not obeyed as something else.
+        ("repeat-set", Some("off")) => ControlCommand::SetRepeat(crate::player::RepeatMode::Off),
+        ("repeat-set", Some("context")) => {
+            ControlCommand::SetRepeat(crate::player::RepeatMode::Context)
+        }
+        ("repeat-set", Some("track")) => {
+            ControlCommand::SetRepeat(crate::player::RepeatMode::Track)
+        }
+        ("save-toggle", None) => ControlCommand::ToggleSaved,
+        ("play-uri", Some(uri)) => ControlCommand::PlayUri(spotify_uri(uri)?),
+        ("transfer", Some(id)) => ControlCommand::Transfer(device_id(id)?),
         ("nowplaying", None) => return Some(Request::NowPlaying),
+        ("devices", None) => return Some(Request::Devices),
         _ => return None,
     };
     Some(Request::Command(command))
+}
+
+/// A `spotify:` URI, as far as this side can tell. Anything on the machine
+/// can reach the port, so what goes on to become a Web API play request is
+/// checked here rather than taken on trust: the scheme, and only the
+/// characters Spotify's own URIs and their percent-escapes are made of.
+#[cfg(not(target_os = "linux"))]
+fn spotify_uri(text: &str) -> Option<String> {
+    let shaped = text.starts_with("spotify:")
+        && text.len() <= 128
+        && text
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '-' | '_' | '.' | '%' | '+'));
+    shaped.then(|| text.to_owned())
+}
+
+/// A Spotify Connect device id: the opaque hex-ish string the Web API hands
+/// out. Checked for the same reason as [`spotify_uri`].
+#[cfg(not(target_os = "linux"))]
+fn device_id(text: &str) -> Option<String> {
+    let shaped = !text.is_empty()
+        && text.len() <= 64
+        && text
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'));
+    shaped.then(|| text.to_owned())
 }
 
 /// Reads up to the first newline. A line too long to be one of ours, or any
@@ -302,6 +414,7 @@ pub fn acquire(_waker: &crate::backend::Waker) -> Outcome {
         _connection: connection,
         commands: Default::default(),
         now_playing: std::sync::Arc::new(std::sync::Mutex::new(NOTHING_PLAYING.to_owned())),
+        devices: std::sync::Arc::new(std::sync::Mutex::new(NO_DEVICES.to_owned())),
     };
 
     let connection = match Connection::session() {
@@ -360,6 +473,7 @@ fn raise_running_instance(connection: &mpris_server::zbus::blocking::Connection)
 #[cfg(all(test, not(target_os = "linux")))]
 mod tests {
     use super::*;
+    use crate::player::RepeatMode;
 
     fn command(line: &str) -> Option<ControlCommand> {
         match parse(line) {
@@ -404,9 +518,51 @@ mod tests {
             command("fastpotify:repeat"),
             Some(ControlCommand::CycleRepeat)
         );
+        assert_eq!(
+            command("fastpotify:shuffle-set on"),
+            Some(ControlCommand::SetShuffle(true))
+        );
+        assert_eq!(
+            command("fastpotify:shuffle-set off"),
+            Some(ControlCommand::SetShuffle(false))
+        );
+        assert_eq!(
+            command("fastpotify:repeat-set track"),
+            Some(ControlCommand::SetRepeat(RepeatMode::Track))
+        );
+        assert_eq!(
+            command("fastpotify:repeat-set context"),
+            Some(ControlCommand::SetRepeat(RepeatMode::Context))
+        );
+        assert_eq!(
+            command("fastpotify:repeat-set off"),
+            Some(ControlCommand::SetRepeat(RepeatMode::Off))
+        );
+        assert_eq!(
+            command("fastpotify:seek-to 90000"),
+            Some(ControlCommand::SeekTo(90_000))
+        );
+        assert_eq!(
+            command("fastpotify:save-toggle"),
+            Some(ControlCommand::ToggleSaved)
+        );
+        assert_eq!(
+            command("fastpotify:play-uri spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
+            Some(ControlCommand::PlayUri(
+                "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M".to_owned()
+            ))
+        );
+        assert_eq!(
+            command("fastpotify:transfer a1b2c3d4e5"),
+            Some(ControlCommand::Transfer("a1b2c3d4e5".to_owned()))
+        );
         assert!(matches!(
             parse("fastpotify:nowplaying"),
             Some(Request::NowPlaying)
+        ));
+        assert!(matches!(
+            parse("fastpotify:devices"),
+            Some(Request::Devices)
         ));
     }
 
@@ -420,9 +576,29 @@ mod tests {
         assert!(parse("").is_none());
     }
 
+    /// The two verbs that carry free text are the ones a hostile local
+    /// process would reach for, so neither hands the app a string it has
+    /// not looked at.
+    #[test]
+    fn refuses_arguments_that_are_not_shaped_like_spotifys_own() {
+        // #given / #when / #then
+        assert!(command("fastpotify:play-uri http://example.com/pwn").is_none());
+        assert!(command("fastpotify:play-uri spotify:track:a b").is_none());
+        assert!(command("fastpotify:play-uri ../../etc/passwd").is_none());
+        assert!(command("fastpotify:play-uri").is_none());
+        assert!(command(&format!("fastpotify:play-uri spotify:{}", "x".repeat(200))).is_none());
+        assert!(command("fastpotify:transfer ../secrets").is_none());
+        assert!(command("fastpotify:transfer").is_none());
+        // A word that is not one of the three is refused rather than read
+        // as `off`, which is what `RepeatMode::from_api` would have done.
+        assert!(command("fastpotify:repeat-set sometimes").is_none());
+        assert!(command("fastpotify:shuffle-set maybe").is_none());
+        assert!(command("fastpotify:seek-to -1").is_none());
+    }
+
     /// The whole channel over a real socket: what `fastpotify next` sends is
-    /// what the app finds in its queue, and `nowplaying` reads back the
-    /// snapshot the app published.
+    /// what the app finds in its queue, and the two reads come back from the
+    /// snapshots the app published.
     #[test]
     fn a_client_reaches_the_command_queue_and_the_snapshot() {
         use std::net::{Ipv4Addr, TcpListener};
@@ -433,32 +609,50 @@ mod tests {
         let port = listener.local_addr().expect("a bound address").port();
         let commands: Arc<Mutex<Vec<ControlCommand>>> = Default::default();
         let now_playing = Arc::new(Mutex::new("playing\tGo\tThe Band".to_owned()));
+        let devices = Arc::new(Mutex::new(
+            r#"[{"id":"abc","name":"Kitchen","kind":"Speaker","active":true}]"#.to_owned(),
+        ));
         let served = {
             let commands = Arc::clone(&commands);
             let now_playing = Arc::clone(&now_playing);
+            let devices = Arc::clone(&devices);
             let waker = crate::backend::Waker::default();
-            std::thread::spawn(move || serve(listener, &commands, &now_playing, &waker))
+            std::thread::spawn(move || serve(listener, &commands, &now_playing, &devices, &waker))
         };
 
         // #when
         let accepted = send_to(port, "next").expect("a reply");
         let volume = send_to(port, "volume-by -5").expect("a reply");
+        let liked = send_to(port, "save-toggle").expect("a reply");
         let snapshot = send_to(port, "nowplaying").expect("a reply");
+        let listed = send_to(port, "devices").expect("a reply");
         let refused = send_to(port, "frobnicate");
 
         // #then
         assert!(matches!(accepted, Reply::Ok));
         assert!(matches!(volume, Reply::Ok));
+        assert!(matches!(liked, Reply::Ok));
         match snapshot {
             Reply::NowPlaying(line) => assert_eq!(line, "playing\tGo\tThe Band"),
-            Reply::Ok => panic!("nowplaying answered with an acknowledgement"),
+            _ => panic!("nowplaying answered with something else"),
+        }
+        match listed {
+            Reply::Devices(json) => assert!(json.contains("Kitchen")),
+            _ => panic!("devices answered with something else"),
         }
         // An unknown verb gets no reply at all, so the client sees a closed
         // connection rather than a command it never sent being obeyed.
         assert!(refused.is_err());
+        // Reading the devices also asks the app to look again, so the next
+        // read is fresh.
         assert_eq!(
             *commands.lock().expect("the queue"),
-            vec![ControlCommand::Next, ControlCommand::VolumeBy(-5)]
+            vec![
+                ControlCommand::Next,
+                ControlCommand::VolumeBy(-5),
+                ControlCommand::ToggleSaved,
+                ControlCommand::RefreshDevices,
+            ]
         );
 
         drop(served);


### PR DESCRIPTION
Hey! Ran into this while wiring Fastpotify up to a Stream Deck, but it turned
out not to be Stream Deck specific at all. It's the same control channel the
Raycast/Alfred scripts already use.

The problem: the existing verbs all came from media keys, so they only toggle.
There's no way to say "shuffle on", only "shuffle, change". So anything drawing
the current state on a button drifts out of sync with Spotify the second it
misses an update, and the only way to fix it is to press it again.

This adds the missing half:

`shuffle-set on|off`, `repeat-set off|context|track`, `seek-to <ms>`,
`save-toggle`, `play-uri <uri>`, `transfer <device-id>`, and a `devices` read.
They all map to `Action`s that already existed, so nothing new actually happens
to playback. They're subcommands too, so `fastpotify like` and friends work
from a launcher or a hotkey.

The now-playing snapshot also picks up three fields: artwork URL, whether the
track is saved, and which device the sound is coming out of. They're appended
after the original nine, so anything reading the old shape is unaffected.
`saved` is `yes`/`no`/`unknown`, and it's free, since the playing track already
gets looked up through `request_contains`. No extra request.

`devices` answers as JSON rather than tab-separated, since people name their
speakers whatever they like and a separator won't survive that. One quirk worth
knowing about: the app only refreshes that list while its own picker is open,
so the read kicks off a refresh as well. That means a cold first call comes
back empty and the next one has it. There's a comment at the site explaining
that.

`play-uri` and `transfer` are the only verbs carrying free text, and anything
on the machine can reach the port, so both check their argument before the app
sees it.

**Heads up: the first commit is unrelated.** `fabf009` added `tokio::fs`
without declaring the feature that compiles it. Linux gets it for free from
`mpris-server`, so the build there never noticed, but Windows won't compile at
that commit and macOS doesn't have that dependency either, so I think CI is red
on both right now. It's one word in `Cargo.toml`. I put it first so every
commit on the branch builds on its own, but happy to split it into its own PR
if you'd rather take it separately.

fmt, clippy (`-D warnings`) and the 54 tests all pass, and both commits build
standalone. Tested against a real account too. The snapshot reads back
correctly and `devices` does the empty-then-populated thing described above.
