### PR TITLE
macOS: hide the titlebar and run the UI to the top edge

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -546,6 +546,13 @@ fn native_options(fullscreen: bool, mini: Option<MiniWindow>) -> eframe::NativeO
             }
         }
         None => viewport
+            // macOS: no title bar strip above the app. The content runs to
+            // the top edge and the traffic lights float over it, the way
+            // every other music player on the platform looks; the interface
+            // leaves room for them with `theme::titlebar_inset`.
+            .with_fullsize_content_view(true)
+            .with_titlebar_shown(false)
+            .with_title_shown(false)
             .with_inner_size([1240.0, 800.0])
             .with_min_inner_size([760.0, 520.0])
             .with_fullscreen(fullscreen),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -102,6 +102,19 @@ pub const COMPACT_ROW_HEIGHT: f32 = 48.0;
 pub const PLAYER_BAR_HEIGHT: f32 = 88.0;
 pub const TOP_BAR_HEIGHT: f32 = 56.0;
 
+/// macOS hides the titlebar and draws the window content all the way to the
+/// top edge, so whatever sits at the top of the window has to leave room for
+/// the traffic lights. Zero everywhere else, and in fullscreen, where the
+/// buttons are gone.
+pub fn titlebar_inset(ctx: &egui::Context) -> f32 {
+    if cfg!(target_os = "macos") && !ctx.input(|input| input.viewport().fullscreen.unwrap_or(false))
+    {
+        28.0
+    } else {
+        0.0
+    }
+}
+
 const INTER_MEDIUM: &str = "inter-medium";
 const INTER_SEMIBOLD: &str = "inter-semibold";
 const INTER_BOLD: &str = "inter-bold";

--- a/src/ui/login.rs
+++ b/src/ui/login.rs
@@ -14,6 +14,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, connecting: bool) {
         .frame(Frame::new().fill(palette.window))
         .show(ui, |ui| {
             let rect = ui.max_rect();
+            super::titlebar_drag(ui, rect);
             let top = super::blend(palette.window, palette.accent, 0.10);
             super::widgets::paint_vertical_gradient(ui, rect, top, palette.window);
             let card_width = 440.0;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -154,6 +154,29 @@ fn central(app: &mut App, ui: &mut egui::Ui) {
         });
 }
 
+/// Makes `rect` behave like the titlebar that is no longer there: dragging it
+/// moves the window. Register it before the widgets that sit on top of it, so
+/// they keep the clicks that are theirs.
+pub fn titlebar_drag(ui: &mut egui::Ui, rect: egui::Rect) {
+    if theme::titlebar_inset(ui.ctx()) == 0.0 {
+        return;
+    }
+    let response = ui.interact(
+        rect,
+        ui.id().with("titlebar-drag"),
+        egui::Sense::click_and_drag(),
+    );
+    // AppKit begins the move from the mouse-down event that is still live, so
+    // the command has to go out on the press itself. Waiting for egui's drag
+    // threshold leaves the event stale by the time it arrives, and the window
+    // stays put ("Window move completed without beginning"). There is no
+    // double-click-to-zoom to go with it: the press hands the rest of the
+    // gesture to the native drag loop, so a second click never comes back.
+    if response.is_pointer_button_down_on() && ui.input(|input| input.pointer.primary_pressed()) {
+        ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+    }
+}
+
 pub fn blend(base: Color32, tint: Color32, amount: f32) -> Color32 {
     let a = egui::Rgba::from(base);
     let b = egui::Rgba::from(tint);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -33,6 +33,9 @@ struct Entry {
 
 pub fn show(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
+    // The traffic lights float over the top-left of the sidebar now, so the
+    // first nav row has to start below them.
+    let top = 12 + theme::titlebar_inset(ui.ctx()) as i8;
     let panel = egui::Panel::left("sidebar")
         .resizable(true)
         .default_size(app.settings.sidebar_width)
@@ -41,7 +44,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         .frame(Frame::new().fill(palette.panel).inner_margin(Margin {
             left: 12,
             right: 8,
-            top: 12,
+            top,
             bottom: 8,
         }));
     let response = panel.show(ui, |ui| {

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -50,8 +50,16 @@ fn nav_button(
 pub fn show(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
     let width = ui.available_width();
+    // Where the titlebar used to be: the bar grows upwards into that space and
+    // its empty parts drag the window.
+    let inset = theme::titlebar_inset(ui.ctx());
+    let height = theme::TOP_BAR_HEIGHT + inset;
+    super::titlebar_drag(
+        ui,
+        egui::Rect::from_min_size(ui.cursor().min, vec2(width, height)),
+    );
     ui.allocate_ui_with_layout(
-        vec2(width, theme::TOP_BAR_HEIGHT),
+        vec2(width, height),
         Layout::left_to_right(Align::Center),
         |ui| {
             ui.add_space(super::widgets::PAGE_PADDING);


### PR DESCRIPTION
## macOS: hide the titlebar and run the UI to the top edge

On macOS the app currently sits under the stock titlebar — a separate band of chrome with the window title in it, above the sidebar and the top bar. It reads as a generic window rather than as a music player: Spotify, Music, and most other players on the platform hide that strip and let their own chrome run to the top edge with the traffic lights floating over it.

This does the same.

### What changed

- **`main.rs`** — the viewport turns on `fullsize_content_view` and turns off `titlebar_shown` / `title_shown`. macOS-only options; other platforms are untouched.
- **`theme.rs`** — new `titlebar_inset(ctx)`, the vertical space the traffic lights need. It is `28.0` on macOS and `0.0` everywhere else, and also `0.0` in fullscreen, where the buttons are gone and the space would just be padding.
- **`ui/sidebar.rs`** — the panel's top margin picks up the inset, so the first nav row starts below the traffic lights instead of behind them.
- **`ui/topbar.rs`** — the bar grows upwards by the inset into the space the titlebar used to occupy. The row's own layout is unchanged.
- **`ui/mod.rs`** — new `titlebar_drag`, which gives back what the titlebar was doing: dragging the empty area moves the window. It is registered *before* the widgets that sit on top of it, so the nav arrows, the search field, and the account button keep their own clicks. It is a no-op wherever the inset is zero.
- **`ui/login.rs`** — the same drag region on the sign-in background, so the window is still movable before you are signed in.

### On the drag

The command goes out on the **press**, not on egui's drag threshold. AppKit begins the move from the mouse-down event that is still live; by the time the threshold is crossed that event is stale, the window stays put, and AppKit logs:

```
Warning: Window move completed without beginning
```

That is what the first cut of this branch did, and it is fixed here.

The consequence is that there is **no double-click-to-zoom** on the bar. Taking the press hands the rest of the gesture to AppKit's native drag loop, so a second click never comes back to egui. I tried it both ways; a reliable drag seemed clearly worth more than the zoom shortcut, but say the word if you'd rather have the trade the other way.

### Testing

Built and run on macOS (`--demo`), with synthesized input against the real window:

- Dragging the empty part of the top bar moves the window by exactly the drag delta, with no AppKit warning logged.
- A press-and-move that *starts on the search field* leaves the window where it is — widget priority holds, so the arrows, search, and account button are unaffected.
- The sidebar and top bar render correctly against the top edge with room left for the traffic lights.

### One thing to flag

`main` does not currently build for me, on a line unrelated to this PR — `src/backend.rs:1152` calls `tokio::fs`, but the `tokio` dependency in `Cargo.toml` does not enable the `fs` feature:

```
error[E0433]: cannot find `fs` in `tokio`
    --> src/backend.rs:1152:35
```

I confirmed that on a clean checkout before making any changes. I built and tested this branch with `tokio`'s `fs` feature enabled locally, then reverted that, so this PR stays scoped to the titlebar. Happy to fold the one-word `Cargo.toml` fix in here if you'd rather have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
