### PR TITLE
Enable tokio's fs feature for the playlist cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ librespot-protocol = { version = "0.8", default-features = false }
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
 cpal = "0.16"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "gzip", "http2", "blocking"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "fs"] }
 sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"


### PR DESCRIPTION
Main does not compile on macOS or Windows any more. Since fabf009
("Remember whole playlists on disk, keyed by snapshot"), the playlist
cache reads and writes with `tokio::fs`, but tokio's `fs` feature is
never enabled in Cargo.toml. On Linux the symbol resolves anyway,
through a dependency that turns the feature on for the graph, so the
Linux CI job stays green while the other two fail:

```
error[E0433]: cannot find `fs` in `tokio`
   --> src/backend.rs:1171:35
```

This turns the feature on. One line; `cargo test --features demo`
passes again on all three platforms.

Verified on macOS: `main` fails `cargo check` with 7 errors, all of
them this; with the line, `cargo test --features demo` is green.
