### PR TITLE
Fix escaped slashes in playlist descriptions

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -186,6 +186,7 @@ pub fn strip_html(text: &str) -> String {
         .replace("&quot;", "\"")
         .replace("&#x27;", "'")
         .replace("&#39;", "'")
+        .replace("&#x2F;", "/")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
 }
@@ -228,5 +229,6 @@ mod tests {
             strip_html("Hi <a href=\"x\">there</a> &amp; you"),
             "Hi there & you"
         );
+        assert_eq!(strip_html("ONE&#x2F;TWO&#x2F;THREE"), "ONE/TWO/THREE");
     }
 }


### PR DESCRIPTION
## Why

Playlist descriptions containing `/` were displayed as `&#x2F;`, including in the edit form. Fastpotify should render Spotify playlist descriptions as readable text.

## What changed

Added decoding for Spotify’s `&#x2F;` character reference to the existing shared HTML-stripping helper. Added a regression test using `ONE&#x2F;TWO&#x2F;THREE`.

## Verification

Tested on macOS:

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked util::tests::html_is_stripped`
– `cargo clippy --locked --all-targets --all-features -- -D warnings`

Before: `ONE&#x2F;TWO&#x2F;THREE`  
After: `ONE/TWO/THREE`

No screenshot included; this is a string-decoding fix covered by the focused regression test.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] Documentation update not applicable: no settings, files, or network behaviour changed.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.