### PR TITLE
Fix: Ignore question mark shortcut while typing

### DIFF
--- a/src/ui/keys.rs
+++ b/src/ui/keys.rs
@@ -35,16 +35,6 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
             Key::Slash,
             Action::ShowDialog(Dialog::Shortcuts),
         );
-        key(
-            Modifiers::NONE,
-            Key::Questionmark,
-            Action::ShowDialog(Dialog::Shortcuts),
-        );
-        key(
-            Modifiers::SHIFT,
-            Key::Questionmark,
-            Action::ShowDialog(Dialog::Shortcuts),
-        );
         key(Modifiers::ALT, Key::ArrowLeft, Action::Back);
         key(Modifiers::ALT, Key::ArrowRight, Action::Forward);
         key(Modifiers::COMMAND, Key::ArrowLeft, Action::Previous);
@@ -72,6 +62,16 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
             );
         }
         if !typing {
+            key(
+                Modifiers::NONE,
+                Key::Questionmark,
+                Action::ShowDialog(Dialog::Shortcuts),
+            );
+            key(
+                Modifiers::SHIFT,
+                Key::Questionmark,
+                Action::ShowDialog(Dialog::Shortcuts),
+            );
             key(Modifiers::SHIFT, Key::ArrowLeft, Action::SeekBy(-10_000));
             key(Modifiers::SHIFT, Key::ArrowRight, Action::SeekBy(10_000));
             key(Modifiers::NONE, Key::Space, Action::TogglePlay);


### PR DESCRIPTION
## Why

Typing `?` into a search field or playlist form also opened the keyboard shortcuts dialog. Text input should accept the character without triggering an unrelated global shortcut.

## What changed

Moved the unmodified `?` shortcut behind the existing text-input focus check. `Ctrl+/` remains available while typing.

## Verification

Tested on macOS:

- Manually verified that `?` is entered into text fields without opening the shortcuts dialog.
- Verified that `?` still opens the dialog outside text fields.
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets` — 65 passed

Before: entering `?` inserted the character and opened the shortcuts dialog.  
After: entering `?` only inserts the character.

No screenshot attached.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [ ] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] Documentation update not applicable: no settings, files, or network access changed.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.