### PR TITLE
Keep the macOS window reachable after Cmd+W

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,8 @@ tray-icon = { version = "0.24", default-features = false }
 souvlaki = { version = "0.8", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# Serving AppKit while no window exists (the status item lives on the main
-# thread), and leaving the Dock while hidden.
+# Serving AppKit while no window exists: the status item and Dock reopen
+# callback live on the main thread.
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSEvent", "NSMenu", "NSMenuItem", "NSResponder", "NSRunningApplication"] }
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSDate", "NSObjCRuntime", "NSRunLoop", "NSString"] }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ application rather than a shell plugin.
   and clicking the tray, or your desktop's media controls, brings a window
   back. No compositor-specific tricks, so it behaves the same on any
   desktop. Quit from the tray menu or `Ctrl+Q`; turn the behaviour off in
-  Settings if you prefer close-to-quit.
+  Settings if you prefer close-to-quit. On macOS the Dock icon stays present,
+  and clicking it opens the window again.
 - **Visible network activity.** Pages show spinners while they load. An
   indicator appears in the top bar when a Spotify request takes more than a
   moment or is waiting for a rate limit.

--- a/docs/_guide/getting-started.md
+++ b/docs/_guide/getting-started.md
@@ -68,7 +68,8 @@ speaker.
 
 - **Closing the window does not stop the music.** Fastpotify keeps playing
   from the system tray; reopen it from the tray icon and quit from the tray
-  menu or Ctrl+Q. Settings can turn this off.
+  menu or Ctrl+Q. On macOS you can also reopen it from the Dock. Settings can
+  turn this off.
 - **Play requests show their progress.** A pressed play button spins until
   Spotify responds.
 - **Common actions have shortcuts.** Space plays and pauses, Ctrl+F or `/`

--- a/src/app.rs
+++ b/src/app.rs
@@ -1244,6 +1244,7 @@ impl App {
         };
         for command in commands {
             match command {
+                TrayCommand::Show => self.actions.push(Action::ShowWindow),
                 TrayCommand::ShowHide => self.actions.push(if self.window_hidden {
                     Action::ShowWindow
                 } else {

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -14,6 +14,7 @@ use ksni::blocking::TrayMethods;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TrayCommand {
+    Show,
     ShowHide,
     PlayPause,
     Next,

--- a/src/tray_native.rs
+++ b/src/tray_native.rs
@@ -5,9 +5,8 @@
 //! Linux one. macOS allows status items on the main thread only, and only
 //! while its event loop runs, so there the item is created with the first
 //! window and, while no window exists, the headless loop in `main` pumps
-//! the application's events itself. The app also leaves the Dock while it
-//! is hidden: a Dock icon with no window behind it has nothing to offer, and
-//! the status item is the way back.
+//! the application's events itself. Its Dock icon remains available and a
+//! Dock activation recreates the window.
 
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, Sender};
@@ -18,6 +17,7 @@ use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TrayCommand {
+    Show,
     ShowHide,
     PlayPause,
     Next,
@@ -229,9 +229,11 @@ pub fn idle(duration: Duration) {
 #[cfg(target_os = "macos")]
 mod host {
     use std::cell::RefCell;
+    use std::ffi::CString;
 
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSEventMask};
+    use objc2::runtime::{AnyClass, AnyObject, Bool, MethodImplementation, Sel};
+    use objc2::{Encode, MainThreadMarker, sel};
+    use objc2_app_kit::{NSApplication, NSEventMask};
     use objc2_foundation::{NSDate, NSDefaultRunLoopMode};
 
     use super::*;
@@ -239,14 +241,69 @@ mod host {
     thread_local! {
         /// The status item, which only the main thread may touch.
         pub static ITEM: RefCell<Option<Item>> = const { RefCell::new(None) };
+        pub(super) static REOPEN: RefCell<Option<Sender<TrayCommand>>> = const { RefCell::new(None) };
+    }
+
+    pub(super) fn request_reopen(has_visible_windows: bool) -> Bool {
+        if !has_visible_windows {
+            REOPEN.with(|slot| {
+                if let Some(sender) = slot.borrow().as_ref() {
+                    let _ = sender.send(TrayCommand::Show);
+                }
+            });
+        }
+        Bool::YES
+    }
+
+    extern "C-unwind" fn application_should_handle_reopen(
+        _delegate: *mut AnyObject,
+        _selector: Sel,
+        _application: *mut NSApplication,
+        has_visible_windows: Bool,
+    ) -> Bool {
+        request_reopen(has_visible_windows.as_bool())
+    }
+
+    fn install_reopen_handler(app: &NSApplication) {
+        let Some(delegate) = app.delegate() else {
+            log::warn!("the macOS application delegate is unavailable");
+            return;
+        };
+        let delegate: &AnyObject = AsRef::<AnyObject>::as_ref(&*delegate);
+        let class = delegate.class();
+        let selector = sel!(applicationShouldHandleReopen:hasVisibleWindows:);
+        if class.responds_to(selector) {
+            return;
+        }
+        let implementation: extern "C-unwind" fn(
+            *mut AnyObject,
+            Sel,
+            *mut NSApplication,
+            Bool,
+        ) -> Bool = application_should_handle_reopen;
+        let types = CString::new(format!("{}@:@{}", Bool::ENCODING, Bool::ENCODING))
+            .expect("valid Objective-C type encoding");
+        let installed = unsafe {
+            objc2::ffi::class_addMethod(
+                class as *const AnyClass as *mut AnyClass,
+                selector,
+                implementation.__imp(),
+                types.as_ptr(),
+            )
+        };
+        if !installed.as_bool() {
+            log::warn!("the macOS Dock reopen handler could not be installed");
+        }
     }
 
     /// Creates the item, once, on the main thread.
     pub fn create(sender: Sender<TrayCommand>, wake: Wake, playing: bool) {
-        if MainThreadMarker::new().is_none() {
+        let Some(mtm) = MainThreadMarker::new() else {
             log::warn!("the status item can only be made on the main thread");
             return;
-        }
+        };
+        REOPEN.with(|slot| *slot.borrow_mut() = Some(sender.clone()));
+        install_reopen_handler(&NSApplication::sharedApplication(mtm));
         match build(sender, wake) {
             Ok(item) => {
                 item.play_pause.set_text(play_pause_label(playing));
@@ -268,18 +325,13 @@ mod host {
         });
     }
 
-    /// Regular apps have a Dock icon and a menu bar; accessories have
-    /// neither, which suits an app whose only presence is a status item.
-    pub fn set_activation_policy(policy: NSApplicationActivationPolicy, activate: bool) {
+    pub fn activate() {
         let Some(mtm) = MainThreadMarker::new() else {
             return;
         };
         let app = NSApplication::sharedApplication(mtm);
-        let _ = app.setActivationPolicy(policy);
-        if activate {
-            #[allow(deprecated)]
-            app.activateIgnoringOtherApps(true);
-        }
+        #[allow(deprecated)]
+        app.activateIgnoringOtherApps(true);
     }
 
     /// Runs the application's event loop for `duration`, so the status
@@ -341,29 +393,19 @@ impl TrayService {
         }
     }
 
-    /// A window exists: make the item if this is the first one, and take
-    /// the app's place in the Dock again.
+    /// A window exists: make the item if this is the first one and bring the
+    /// application forward.
     pub fn attach(&mut self) {
         if let Some((sender, wake)) = self.pending.take() {
             host::create(sender, wake, self.playing);
         }
         if host::exists() {
-            host::set_activation_policy(
-                objc2_app_kit::NSApplicationActivationPolicy::Regular,
-                true,
-            );
+            host::activate();
         }
     }
 
-    /// No window: leave the Dock. The status item is the way back.
-    pub fn hidden(&mut self) {
-        if host::exists() {
-            host::set_activation_policy(
-                objc2_app_kit::NSApplicationActivationPolicy::Accessory,
-                false,
-            );
-        }
-    }
+    /// No window: the status item and Dock icon both remain available.
+    pub fn hidden(&mut self) {}
 }
 
 /// Waits while the app lives in the tray without a window, keeping AppKit
@@ -371,4 +413,22 @@ impl TrayService {
 #[cfg(target_os = "macos")]
 pub fn idle(duration: Duration) {
     host::pump(duration);
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dock_reopen_requests_a_window_only_when_none_is_visible() {
+        let (sender, commands) = std::sync::mpsc::channel();
+        host::REOPEN.with(|slot| *slot.borrow_mut() = Some(sender));
+
+        assert!(host::request_reopen(true).as_bool());
+        assert!(commands.try_recv().is_err());
+
+        assert!(host::request_reopen(false).as_bool());
+        assert_eq!(commands.try_recv(), Ok(TrayCommand::Show));
+        host::REOPEN.with(|slot| *slot.borrow_mut() = None);
+    }
 }


### PR DESCRIPTION
## The problem

On macOS I expect Cmd+W to close Fastpotify’s window without making the running app unreachable. Playback already continued as intended, but Fastpotify also changed itself into an accessory app. That removed its Dock icon.

The process was still alive and playing, but clicking Fastpotify in the Dock or opening it again through Raycast could not bring the window back.

## The fix

Fastpotify now remains a regular Dock app after its window closes.

When macOS activates an app with no visible windows, AppKit calls `applicationShouldHandleReopen:hasVisibleWindows:`. Winit does not expose that callback, and replacing its application delegate would interfere with the existing window lifecycle. This change therefore adds only that optional callback to the existing delegate.

The callback sends a dedicated `Show` command into Fastpotify’s existing action queue. The current outer loop still owns window recreation, so background playback, state preservation, the menu-bar item, and close-to-quit remain unchanged.

Using `Show` instead of the existing show/hide toggle also means an activation can never hide a window that is already visible.

## Result

Cmd+W closes the window while Fastpotify keeps playing. The Dock icon remains, and activating Fastpotify from the Dock or an app launcher recreates the window.

## Verification

- Manually verified on macOS
- `cargo fmt --all --check`
- Both required clippy configurations
- Standard and all-feature test suites: 66 tests passed
- Documentation tests and Rust documentation build
- Jekyll documentation build