### PR TITLE
Stop pinning the access point to port 443

### DIFF
--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -76,3 +76,8 @@ Playback runs on a dedicated runtime: librespot maintains the Spotify
 Connect session, exposes this computer as a device, receives transfers, and
 reports its playback position. If the session drops, the engine reconnects
 with the stored credential. This work does not block the interface.
+
+The engine discovers access points through `apresolve.spotify.com` and
+connects over TCP in the resolver's preference order: port 4070 first,
+falling back to 443 and 80. Only outbound connections are needed; no
+inbound ports have to be open.

--- a/src/player.rs
+++ b/src/player.rs
@@ -242,7 +242,6 @@ impl Engine {
         let device_id = config.device_id();
         let session_config = SessionConfig {
             device_id: device_id.clone(),
-            ap_port: Some(443),
             autoplay: Some(config.autoplay),
             ..SessionConfig::default()
         };


### PR DESCRIPTION
## Why

Local playback ("play on this computer") could never connect: `Engine::connect` hardcoded `SessionConfig.ap_port = Some(443)`, which makes librespot's apresolver discard every access point except the 443 endpoints (`port_config()` in `apresolve.rs`). Spotify's port-443 access points no longer speak the plaintext keyexchange librespot uses — there is no TLS path in librespot's AP transport (`Transport = Framed<TcpStream, ApCodec>`). The server accepts the TCP connection and closes it as soon as the `ClientHello` bytes arrive, so every attempt fails with:

```
ERROR librespot_core::session] Tried too many access points
ERROR fastpotify::backend] engine connect failed: unable to connect to Spotify: Invalid state { early eof }
```

(`read_exact` EOF → `UnexpectedEof` → librespot maps it to `FailedPrecondition` = "Invalid state".)

Observed from my network, against three different 443 APs (`ap-gae2`, `ap-gue1`, `ap-gew1` — so not one bad edge node): plaintext bytes get an immediate clean EOF, a TLS ClientHello gets no response at all, while `api.spotify.com:443` completes a TLS 1.3 handshake through the same path. Meanwhile `ap-*.spotify.com:4070` answers the plaintext protocol normally.

This is platform-independent (it fails at the TCP application-protocol level), not Arch/Linux-specific.

## What changed

- `src/player.rs`: drop the `ap_port` override so the resolver's preference order applies (4070, then 443, then 80, as returned by `apresolve.spotify.com`).
- `docs/_reference/how-it-connects.md`: document which hosts/ports the engine contacts (network behavior was previously undocumented).

No new settings and no proxy support — librespot's `SessionConfig.proxy` remains available if a firewall-locked network ever needs it; plaintext-on-443 was the previous escape hatch and is dead server-side.

## Verification

- Before: a probe replaying `Engine::connect`'s exact `SessionConfig` with dummy credentials reproduced the reported log lines byte for byte (`Tried too many access points` / `Invalid state { early eof }`). The failure happens at the handshake, before authentication.
- After: full end-to-end run through the real `Engine::connect` path (browser playback authorization → stored credential → connect): `Connecting to AP "ap-gae2.spotify.com:4070"`, `Authenticated as …`, Spirc announced the machine as an active Connect device, clean shutdown.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --locked --all-targets` (62 passed), `cargo test --locked --all-targets --all-features`, `cargo test --locked --all-features --doc`, `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps` all pass. The docs jekyll build was not run locally (`bundle` unavailable here); the docs diff is a four-line plain-Markdown paragraph.

