### PR TITLE
fix(backend): reap browser opener child processes on Linux

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -997,9 +997,12 @@ impl Worker {
                 url: flow.url.clone(),
             }));
         }
-        if let Err(error) = open::that_detached(&flow.url) {
-            log::warn!("unable to open a browser: {error}");
-        }
+        let browser_url = flow.url.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(error) = open::that(&browser_url) {
+                log::warn!("unable to open a browser: {error}");
+            }
+        });
         let http = self.http.clone();
         let events = self.events.clone();
         let waker = self.waker.clone();
@@ -1164,9 +1167,12 @@ impl Worker {
         let (cancel_tx, cancel_rx) = watch::channel(false);
         self.cancel_signin = Some(cancel_tx);
         self.emit(Event::Playback(LocalPlayback::Authorizing));
-        if let Err(error) = open::that_detached(&flow.url) {
-            log::warn!("unable to open a browser: {error}");
-        }
+        let browser_url = flow.url.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(error) = open::that(&browser_url) {
+                log::warn!("unable to open a browser: {error}");
+            }
+        });
         let http = self.http.clone();
         let events = self.events.clone();
         let waker = self.waker.clone();


### PR DESCRIPTION
### Summary

Closes #74.

Fixes an issue on Linux where browser authorization left unreaped zombie child processes (`[fastpotify-back] <defunct>`) in the process table.

### Root Cause

`src/backend.rs` called `open::that_detached(&flow.url)` during Web API and streaming playback authorizations. On Linux/POSIX, `open::that_detached` spawns a launcher (`xdg-open`) and immediately drops the `std::process::Child` handle without waiting. When the launcher terminates, the absence of a `wait()` / `waitpid()` call leaves a zombie (`<defunct>`) process in the kernel process table under the calling thread's truncated name (`fastpotify-backend` -> `[fastpotify-back]`).

### Changes

- Replaced `open::that_detached` with `open::that` executed inside `tokio::task::spawn_blocking`.
- `spawn_blocking` prevents blocking the async backend event loop while `open::that` waits on the child process, allowing the OS kernel to reap the exit status cleanly when the launcher exits.

### Validation

- Verified full test suite across all configurations:
  ```powershell
  cargo fmt --all --check
  cargo clippy --all-targets --features demo -- -D warnings
  cargo test --release --features demo