### PR TITLE
feat(ui): add compact queue view setting

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -71,6 +71,8 @@ pub struct Settings {
     pub sidebar_width: f32,
     pub lyrics_width: f32,
     pub queue_width: f32,
+    /// Use compact rows without cover art in the queue.
+    pub queue_compact: bool,
     pub search_history: Vec<String>,
     pub show_shortcut_hints: bool,
     /// An optional personal Spotify Web API application id. The shared
@@ -145,6 +147,7 @@ impl Default for Settings {
             sidebar_width: 250.0,
             lyrics_width: 360.0,
             queue_width: 360.0,
+            queue_compact: false,
             search_history: Vec::new(),
             show_shortcut_hints: true,
             web_client_id: None,
@@ -286,6 +289,23 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
         assert!(!restored.sidebar_visible);
+    }
+
+    #[test]
+    fn older_settings_default_to_standard_queue() {
+        let settings: Settings = serde_json::from_str("{}").unwrap();
+        assert!(!settings.queue_compact);
+    }
+
+    #[test]
+    fn compact_queue_round_trips() {
+        let settings = Settings {
+            queue_compact: true,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert!(restored.queue_compact);
     }
 }
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -104,6 +104,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
                 .and_then(|id| app.track_cache.get(id).cloned().map(PlayableItem::Track))
         })
     });
+    let show_cover = !app.settings.queue_compact;
     if let Some(current) = &current {
         theme::text(ui, "Now playing", theme::semibold(14.0), palette.text);
         ui.add_space(4.0);
@@ -116,7 +117,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
                 number: Some(1),
                 item: current,
                 context: &context,
-                show_cover: true,
+                show_cover,
                 show_album: !compact,
                 added_at: None,
                 added_by: None,
@@ -160,7 +161,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
                 number: Some(index + 1),
                 item: &items[index],
                 context: &context,
-                show_cover: true,
+                show_cover,
                 show_album: !compact,
                 added_at: None,
                 added_by: None,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -456,6 +456,17 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         widgets::setting_row(
             ui,
             &palette,
+            "Compact queue",
+            "Show track names only in the queue without cover artwork.",
+            |ui| {
+                if widgets::switch(ui, &palette, &mut app.settings.queue_compact).changed() {
+                    changed = true;
+                }
+            },
+        );
+        widgets::setting_row(
+            ui,
+            &palette,
             "Interface zoom",
             "Ctrl+Plus and Ctrl+Minus work anywhere; Ctrl+0 resets.",
             |ui| {


### PR DESCRIPTION
### Summary
Adds a setting under Appearance to toggle compact track rows without cover artwork in the queue (both the side panel and the queue page).

### Changes
- **Settings State:** Added `queue_compact: bool` to [`Settings`](file:///c:/Users/kveld/Documents/fastpotify/src/settings.rs) with backward-compatible serde defaults and round-trip unit tests.
- **Settings UI:** Added the "Compact queue" switch under the Appearance section in [`src/ui/settings.rs`](file:///c:/Users/kveld/Documents/fastpotify/src/ui/settings.rs).
- **Queue UI:** Connected `TrackRow`'s existing `show_cover` property to `!app.settings.queue_compact` in [`src/ui/queue.rs`](file:///c:/Users/kveld/Documents/fastpotify/src/ui/queue.rs) for both the *Now playing* item and *Next up* list.

### Screenshots
<img width="822" height="300" alt="image" src="https://github.com/user-attachments/assets/077d024e-a892-423e-889e-6643bca9368d" />
<img width="280" height="922" alt="image" src="https://github.com/user-attachments/assets/49c8a918-c99e-4445-a09e-d013762fbc25" />


### Testing
- `cargo test` passing (146 unit/integration tests).
- `cargo clippy --all-targets` passing with 0 warnings.