### PR TITLE
nix: fix `xorg` deprecation warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,10 +56,10 @@
               libxkbcommon
               wayland
               libGL
-              xorg.libX11
-              xorg.libXcursor
-              xorg.libXi
-              xorg.libXrandr
+              libx11
+              libxcursor
+              libxi
+              libxrandr
             ];
           # The GUI dlopens its Wayland, X11 and GL libraries at run time.
           LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
@@ -69,10 +69,10 @@
                 libxkbcommon
                 wayland
                 libGL
-                xorg.libX11
-                xorg.libXcursor
-                xorg.libXi
-                xorg.libXrandr
+                libx11
+                libxcursor
+                libxi
+                libxrandr
               ]
             )
           );
@@ -88,19 +88,18 @@
               cargo = toolchain;
               rustc = toolchain;
             };
-            runtimeLibs =
-              pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
-                with pkgs;
-                [
-                  libxkbcommon
-                  wayland
-                  libGL
-                  xorg.libX11
-                  xorg.libXcursor
-                  xorg.libXi
-                  xorg.libXrandr
-                ]
-              );
+            runtimeLibs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
+              with pkgs;
+              [
+                libxkbcommon
+                wayland
+                libGL
+                libx11
+                libxcursor
+                libxi
+                libxrandr
+              ]
+            );
           in
           rustPlatform.buildRustPackage {
             pname = "fastpotify";


### PR DESCRIPTION
## Why

Fixes deprecation warnings from `xorg.*` packages in nix.

```
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXrandr' has been renamed to 'libxrandr'
```

## What changed

Updates to the new location of each of the packages.

## Verification

`nix build`/`nix run`

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
