### PR TITLE
Link each track artist separately

### DIFF
--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -772,6 +772,16 @@ mod tests {
     }
 
     #[test]
+    fn track_keeps_artist_objects_when_a_name_has_a_comma() {
+        let json = r#"{"name":"Song","artists":[{"id":"tyler","name":"Tyler, the Creator"},{"id":"guest","name":"Guest"}]}"#;
+        let track: Track = serde_json::from_str(json).unwrap();
+
+        assert_eq!(track.artists.len(), 2);
+        assert_eq!(track.artists[0].name, "Tyler, the Creator");
+        assert_eq!(track.artists[1].id.as_deref(), Some("guest"));
+    }
+
+    #[test]
     fn search_playlists_skip_null_entries() {
         let json = r#"{"playlists":{"items":[null,{"id":"p","name":"P","uri":"spotify:playlist:p"}],"total":2,"limit":2,"offset":0,"next":"next page"}}"#;
         let results: SearchResults = serde_json::from_str(json).unwrap();

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -136,28 +136,27 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
             app.actions.push(Action::Open(Page::Show(id.clone())));
         }
     }
-    let subtitle_response = theme::link(
-        &mut text_ui,
-        &now.subtitle,
-        theme::regular(12.0),
-        palette.secondary,
-    );
-    if subtitle_response.clicked() {
-        if let Some(id) = now.artists.first().and_then(|artist| artist.id.clone()) {
-            app.actions.push(Action::Open(Page::Artist(id)));
-        } else if let Some(id) = &now.show_id {
-            app.actions.push(Action::Open(Page::Show(id.clone())));
+    text_ui.horizontal_top(|ui| {
+        if now.artists.is_empty() {
+            if theme::link(ui, &now.subtitle, theme::regular(12.0), palette.secondary).clicked()
+                && let Some(id) = &now.show_id
+            {
+                app.actions.push(Action::Open(Page::Show(id.clone())));
+            }
+        } else {
+            super::widgets::artist_links(
+                ui,
+                app,
+                &now.artists,
+                theme::regular(12.0),
+                palette.secondary,
+            );
         }
-    }
+    });
     // The playing thing answers the same right-click menu as a table row,
     // from the cover, the empty space around the words, or the words.
     if let Some(item) = app.now_playing_item() {
-        for response in [
-            &cover_response,
-            &info_response,
-            &title_response,
-            &subtitle_response,
-        ] {
+        for response in [&cover_response, &info_response, &title_response] {
             egui::Popup::context_menu(response)
                 .frame(super::widgets::menu_frame(&palette))
                 .show(|ui| super::widgets::item_menu(ui, app, &item, None, None));

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -474,6 +474,31 @@ pub struct TrackRow<'a> {
     pub shift: f32,
 }
 
+/// Draw each credited artist separately so its Spotify id remains clickable.
+pub(crate) fn artist_links(
+    ui: &mut Ui,
+    app: &mut App,
+    artists: &[ArtistRef],
+    font: egui::FontId,
+    color: Color32,
+) {
+    let spacing = ui.spacing().item_spacing;
+    ui.spacing_mut().item_spacing.x = 0.0;
+    for (index, artist) in artists.iter().enumerate() {
+        if index > 0 {
+            theme::text(ui, ", ", font.clone(), color);
+        }
+        if let Some(id) = &artist.id {
+            if theme::link(ui, &artist.name, font.clone(), color).clicked() {
+                app.actions.push(Action::Open(Page::Artist(id.clone())));
+            }
+        } else {
+            theme::text(ui, &artist.name, font.clone(), color);
+        }
+    }
+    ui.spacing_mut().item_spacing = spacing;
+}
+
 /// Column widths of the track table, computed from the available width.
 struct Columns {
     number: f32,
@@ -681,14 +706,13 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                     theme::regular(12.0),
                     palette.secondary.gamma_multiply(0.6),
                 );
-                let names = track.artist_names();
-                let first_artist = track.artists.iter().find_map(|artist| artist.id.clone());
-                let response = theme::link(&mut child, names, theme::regular(13.0), subtitle_color);
-                if response.clicked()
-                    && let Some(id) = first_artist
-                {
-                    app.actions.push(Action::Open(Page::Artist(id)));
-                }
+                artist_links(
+                    &mut child,
+                    app,
+                    &track.artists,
+                    theme::regular(13.0),
+                    subtitle_color,
+                );
             }
             PlayableItem::Episode(episode) => {
                 let subtitle = episode
@@ -736,14 +760,13 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                     if track.explicit {
                         explicit_badge(ui, &palette);
                     }
-                    let names = track.artist_names();
-                    let first_artist = track.artists.iter().find_map(|artist| artist.id.clone());
-                    let response = theme::link(ui, names, theme::regular(12.5), subtitle_color);
-                    if response.clicked()
-                        && let Some(id) = first_artist
-                    {
-                        app.actions.push(Action::Open(Page::Artist(id)));
-                    }
+                    artist_links(
+                        ui,
+                        app,
+                        &track.artists,
+                        theme::regular(12.5),
+                        subtitle_color,
+                    );
                 }
                 PlayableItem::Episode(episode) => {
                     let subtitle = episode


### PR DESCRIPTION
## Why

Tracks can credit multiple artists, but Fastpotify displayed their names as one
combined link that always opened the first artist. This made it impossible to
open another credited artist directly.

Artist names cannot safely be split on commas because a comma may be part of
the name, such as “Tyler, the Creator”. Spotify already provides each artist as
a separate object with its own name and id.

This belongs in Fastpotify because it fixes navigation from track rows and the
now-playing bar without changing Spotify data or adding another integration.

## What changed

Added one shared UI helper that renders every credited artist separately:

- each artist with an id is an independent link;
- separators remain plain text;
- artists without an id remain plain text;
- names containing commas remain intact.

Used the helper in regular and compact track rows and in the now-playing bar.
Episode navigation to the show page remains unchanged.

Added a regression test confirming that an artist name containing a comma is
preserved as one artist object alongside another credited artist.

## Verification

Tested on macOS (Darwin 25.5.0, arm64):

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --all-features --doc`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- `bundle exec jekyll build`
- `cargo run --locked --features demo -- --demo-page album:alb0 --demo-shot /tmp/fastpotify-artist-links-after.png --demo-shot-delay 300`

All 167 tests passed with and without all features. The documentation site
built successfully.

Result: <img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/b887537e-c35e-4c85-9826-28a255adfe06" />

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] I updated documentation for user-visible behaviour, settings, files, or network access. Not applicable: this fixes existing link behaviour and introduces no setting, file, or network change.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
