### PR TITLE
Show platform-correct keyboard shortcut labels

### DIFF
--- a/src/ui/keys.rs
+++ b/src/ui/keys.rs
@@ -5,6 +5,15 @@ use egui::{Key, Modifiers};
 use crate::app::App;
 use crate::model::{Action, Dialog, Page};
 
+pub(super) const fn platform_shortcut(ctrl: &'static str, cmd: &'static str) -> &'static str {
+    if cfg!(target_os = "macos") { cmd } else { ctrl }
+}
+
+pub(super) const SIDEBAR_SHORTCUT: &str = platform_shortcut("Ctrl+B", "Cmd+B");
+pub(super) const QUIT_SHORTCUT: &str = platform_shortcut("Ctrl+Q", "Cmd+Q");
+pub(super) const WINAMP_SHORTCUT: &str = platform_shortcut("Ctrl+M", "Cmd+Shift+M");
+pub(super) const MILKDROP_SHORTCUT: &str = platform_shortcut("Ctrl+Shift+K", "Cmd+Shift+K");
+
 pub fn handle(app: &mut App, ctx: &egui::Context) {
     let typing = ctx.memory(|memory| memory.focused().is_some());
     let mut actions = Vec::new();
@@ -150,44 +159,98 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
 
 pub const SHORTCUTS: &[(&str, &str)] = &[
     ("Space", "Play or pause"),
-    ("Ctrl+←  /  Ctrl+→", "Previous or next"),
+    (
+        platform_shortcut("Ctrl+←  /  Ctrl+→", "Cmd+←  /  Cmd+→"),
+        "Previous or next",
+    ),
     ("Shift+←  /  Shift+→", "Seek 10 seconds"),
-    ("Ctrl+↑  /  Ctrl+↓", "Volume up or down"),
+    (
+        platform_shortcut("Ctrl+↑  /  Ctrl+↓", "Cmd+↑  /  Cmd+↓"),
+        "Volume up or down",
+    ),
     ("M", "Mute or unmute"),
     ("S", "Toggle shuffle"),
     ("R", "Cycle repeat"),
     ("Q", "Show the queue"),
     ("L", "Show the lyrics"),
-    ("Ctrl+F  or  /", "Search"),
-    ("Ctrl+B", "Show or hide the sidebar"),
+    (platform_shortcut("Ctrl+F  or  /", "Cmd+F  or  /"), "Search"),
+    (SIDEBAR_SHORTCUT, "Show or hide the sidebar"),
     ("Alt+←  /  Alt+→", "Back or forward"),
+    (platform_shortcut("Ctrl+H", "Cmd+Shift+H"), "Home"),
+    (platform_shortcut("Ctrl+L", "Cmd+L"), "Liked Songs"),
     (
-        if cfg!(target_os = "macos") {
-            "Ctrl+Shift+H"
-        } else {
-            "Ctrl+H"
-        },
-        "Home",
+        platform_shortcut("Ctrl+Shift+A", "Cmd+Shift+A"),
+        "Go to the playing artist",
     ),
-    ("Ctrl+L", "Liked Songs"),
-    ("Ctrl+Shift+A", "Go to the playing artist"),
-    ("Ctrl+Shift+B", "Go to the playing album"),
     (
-        if cfg!(target_os = "macos") {
-            "Ctrl+Shift+M"
-        } else {
-            "Ctrl+M"
-        },
-        "Winamp mini player",
+        platform_shortcut("Ctrl+Shift+B", "Cmd+Shift+B"),
+        "Go to the playing album",
     ),
-    ("Ctrl+Shift+K", "MilkDrop, under the mini player"),
+    (WINAMP_SHORTCUT, "Winamp mini player"),
+    (MILKDROP_SHORTCUT, "MilkDrop, under the mini player"),
     ("F  or  double-click", "MilkDrop: fill the screen"),
     ("→  /  N", "MilkDrop: next preset"),
     ("←  /  P", "MilkDrop: previous preset"),
     ("L", "MilkDrop: keep this preset"),
     ("Esc", "MilkDrop: leave full screen, or close"),
-    ("Ctrl+,", "Settings"),
-    ("Ctrl+/ or ?", "Keyboard shortcuts"),
-    ("Ctrl+W", "Close the window"),
-    ("Ctrl+Q", "Quit"),
+    (platform_shortcut("Ctrl+,", "Cmd+,"), "Settings"),
+    (
+        platform_shortcut("Ctrl+/ or ?", "Cmd+/ or ?"),
+        "Keyboard shortcuts",
+    ),
+    (platform_shortcut("Ctrl+W", "Cmd+W"), "Close the window"),
+    (QUIT_SHORTCUT, "Quit"),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shortcut_constants_name_the_platform_modifier() {
+        let expected = if cfg!(target_os = "macos") {
+            ["Cmd+B", "Cmd+Q", "Cmd+Shift+M", "Cmd+Shift+K"]
+        } else {
+            ["Ctrl+B", "Ctrl+Q", "Ctrl+M", "Ctrl+Shift+K"]
+        };
+        assert_eq!(
+            [
+                SIDEBAR_SHORTCUT,
+                QUIT_SHORTCUT,
+                WINAMP_SHORTCUT,
+                MILKDROP_SHORTCUT,
+            ],
+            expected
+        );
+    }
+
+    #[test]
+    fn shortcut_dialog_never_names_the_other_command_modifier() {
+        let other = if cfg!(target_os = "macos") {
+            "Ctrl+"
+        } else {
+            "Cmd+"
+        };
+        for (keys, _) in SHORTCUTS {
+            assert!(!keys.contains(other), "wrong modifier in {keys}");
+        }
+    }
+
+    #[test]
+    fn shortcut_dialog_names_platform_reserved_alternatives() {
+        let label = |description| {
+            SHORTCUTS
+                .iter()
+                .find(|(_, candidate)| *candidate == description)
+                .map(|(keys, _)| *keys)
+                .unwrap()
+        };
+        if cfg!(target_os = "macos") {
+            assert_eq!(label("Home"), "Cmd+Shift+H");
+            assert_eq!(label("Winamp mini player"), "Cmd+Shift+M");
+        } else {
+            assert_eq!(label("Home"), "Ctrl+H");
+            assert_eq!(label("Winamp mini player"), "Ctrl+M");
+        }
+    }
+}

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -316,7 +316,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui,
             &palette,
             "Keep music playing when the window closes",
-            "Fastpotify hides to the system tray. Quit from the tray menu or with Ctrl+Q.",
+            super::keys::platform_shortcut(
+                "Fastpotify hides to the system tray. Quit from the tray menu or with Ctrl+Q.",
+                "Fastpotify hides to the system tray. Quit from the tray menu or with Cmd+Q.",
+            ),
             |ui| {
                 if widgets::switch(ui, &palette, &mut app.settings.keep_playing_in_background)
                     .changed()
@@ -479,7 +482,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui,
             &palette,
             "Interface zoom",
-            "Ctrl+Plus and Ctrl+Minus work anywhere; Ctrl+0 resets.",
+            super::keys::platform_shortcut(
+                "Ctrl+Plus and Ctrl+Minus work anywhere; Ctrl+0 resets.",
+                "Cmd+Plus and Cmd+Minus work anywhere; Cmd+0 resets.",
+            ),
             |ui| {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 6.0;
@@ -511,7 +517,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui,
             &palette,
             "Mini player",
-            "Fastpotify becomes a small player that wears classic Winamp skins (.wsz files); the logo in the skin, or Ctrl+M, brings this window back. Drop a skin on either window to add it.",
+            super::keys::platform_shortcut(
+                "Fastpotify becomes a small player that wears classic Winamp skins (.wsz files); the logo in the skin, or Ctrl+M, brings this window back. Drop a skin on either window to add it.",
+                "Fastpotify becomes a small player that wears classic Winamp skins (.wsz files); the logo in the skin, or Cmd+Shift+M, brings this window back. Drop a skin on either window to add it.",
+            ),
             |ui| {
                 if theme::pill_button(ui, &palette, "Switch to it", true).clicked() {
                     app.actions.push(Action::ToggleWinampWindow);
@@ -615,7 +624,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui,
             &palette,
             "MilkDrop window",
-            "Winamp's visualiser, as projectM reimplements it, in a window of its own; the vis button in the top bar, Ctrl+Shift+K, or the V on the mini player opens it too. Inside it, F or a double-click fills the screen, the arrows or N and P change the preset, L keeps one, and Esc leaves. It draws the music played on this computer.",
+            super::keys::platform_shortcut(
+                "Winamp's visualiser, as projectM reimplements it, in a window of its own; the vis button in the top bar, Ctrl+Shift+K, or the V on the mini player opens it too. Inside it, F or a double-click fills the screen, the arrows or N and P change the preset, L keeps one, and Esc leaves. It draws the music played on this computer.",
+                "Winamp's visualiser, as projectM reimplements it, in a window of its own; the vis button in the top bar, Cmd+Shift+K, or the V on the mini player opens it too. Inside it, F or a double-click fills the screen, the arrows or N and P change the preset, L keeps one, and Esc leaves. It draws the music played on this computer.",
+            ),
             |ui| {
                 let mut open = app.settings.milkdrop_open;
                 if widgets::switch(ui, &palette, &mut open).changed() {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -326,7 +326,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                 16.0,
                 palette.secondary,
                 palette.text,
-                "Hide sidebar (Cmd+B)",
+                super::keys::platform_shortcut("Hide sidebar (Ctrl+B)", "Hide sidebar (Cmd+B)"),
             )
             .clicked()
             {

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -65,7 +65,14 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui.add_space(super::widgets::PAGE_PADDING);
             ui.spacing_mut().item_spacing.x = 8.0;
             if !app.settings.sidebar_visible {
-                if nav_button(ui, &palette, Icon::PanelLeft, true, "Show sidebar (Cmd+B)").clicked()
+                if nav_button(
+                    ui,
+                    &palette,
+                    Icon::PanelLeft,
+                    true,
+                    super::keys::platform_shortcut("Show sidebar (Ctrl+B)", "Show sidebar (Cmd+B)"),
+                )
+                .clicked()
                 {
                     app.actions.push(Action::ToggleSidebar);
                 }
@@ -242,7 +249,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         palette.secondary
                     },
                     palette.text,
-                    "MilkDrop visualiser (Ctrl+Shift+K)",
+                    super::keys::platform_shortcut(
+                        "MilkDrop visualiser (Ctrl+Shift+K)",
+                        "MilkDrop visualiser (Cmd+Shift+K)",
+                    ),
                 )
                 .clicked()
                 {
@@ -254,7 +264,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     19.0,
                     palette.secondary,
                     palette.text,
-                    "Winamp mini player (Ctrl+M)",
+                    super::keys::platform_shortcut(
+                        "Winamp mini player (Ctrl+M)",
+                        "Winamp mini player (Cmd+Shift+M)",
+                    ),
                 )
                 .clicked()
                 {

--- a/src/ui/winamp/mod.rs
+++ b/src/ui/winamp/mod.rs
@@ -433,7 +433,10 @@ fn full_window(
     if view
         .interact(layout::ABOUT, "about", Sense::click())
         .on_hover_cursor(egui::CursorIcon::PointingHand)
-        .on_hover_text("Back to the big window (Ctrl+M)")
+        .on_hover_text(super::keys::platform_shortcut(
+            "Back to the big window (Ctrl+M)",
+            "Back to the big window (Cmd+Shift+M)",
+        ))
         .clicked()
     {
         app.actions.push(Action::ToggleWinampWindow);
@@ -475,7 +478,10 @@ fn shade_bar(
     menu(egui::Popup::context_menu(&title), view.skin, unit, |ui| {
         options_menu(app, ui, unit);
     });
-    let big_window = "Back to the big window (Ctrl+M)";
+    let big_window = super::keys::platform_shortcut(
+        "Back to the big window (Ctrl+M)",
+        "Back to the big window (Cmd+Shift+M)",
+    );
     if view
         .button(
             layout::OPTIONS_BUTTON,
@@ -640,8 +646,11 @@ fn title_bar(app: &mut App, view: &mut View, ctx: &egui::Context, focused: bool)
     });
     // The logo and the close button lead back to the big window: the mini
     // player is a way of looking at the same app, not a second one to
-    // close. Quitting is in the menu and Ctrl+Q.
-    let big_window = "Back to the big window (Ctrl+M)";
+    // close. Quitting is in the menu and through the platform shortcut.
+    let big_window = super::keys::platform_shortcut(
+        "Back to the big window (Ctrl+M)",
+        "Back to the big window (Cmd+Shift+M)",
+    );
     if view
         .button(
             layout::OPTIONS_BUTTON,
@@ -715,7 +724,7 @@ fn options_menu(app: &mut App, ui: &mut Ui, unit: f32) {
     let mut milkdrop = app.settings.milkdrop_open;
     if ui
         .checkbox(&mut milkdrop, "MilkDrop")
-        .on_hover_text("Ctrl+Shift+K")
+        .on_hover_text(super::keys::MILKDROP_SHORTCUT)
         .clicked()
     {
         app.actions.push(Action::ToggleWinampMilkdrop);
@@ -904,7 +913,7 @@ fn clutter_bar(app: &mut App, view: &mut View, now: Option<&NowPlaying>) {
         let mut milkdrop = app.settings.milkdrop_open;
         if ui
             .checkbox(&mut milkdrop, "MilkDrop")
-            .on_hover_text("Ctrl+Shift+K")
+            .on_hover_text(super::keys::MILKDROP_SHORTCUT)
             .clicked()
         {
             app.actions.push(Action::ToggleWinampMilkdrop);


### PR DESCRIPTION
## Summary
- show Ctrl-based shortcut labels on Windows/Linux and Cmd-based labels on macOS
- keep labels aligned with reserved macOS alternatives for Home and the Winamp mini player
- use the same platform-aware copy in the shortcut dialog, settings, top-bar/sidebar tooltips, and Winamp controls
- add regression tests for modifier labels and reserved macOS variants

`egui::Modifiers::COMMAND` maps to Ctrl off macOS and Cmd on macOS. The bindings already behaved correctly, but several discovery surfaces hard-coded the other platform's label. This follows the shortcut-label cleanup left for a separate change in #18.

## Screenshots
| Before (Windows) | After (Windows) |
| --- | --- |
| ![Before: sidebar tooltip says Cmd+B](https://raw.githubusercontent.com/BraydenPB/fastpotify/screenshots-platform-shortcuts/before.png) | ![After: sidebar tooltip says Ctrl+B](https://raw.githubusercontent.com/BraydenPB/fastpotify/screenshots-platform-shortcuts/after.png) |

## Testing
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --no-default-features -- -D warnings`
- `cargo test --locked --all-targets --no-default-features` (184 passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings` *(blocked locally in `projectm-sys`: `VCPKG_INSTALLATION_ROOT` is not set)*