### PR TITLE
Add middle-button autoscroll (fixes #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ Settings live in one readable JSON file (`~/.config/fastpotify/settings.json`
 on Linux). They include the Connect device name, bitrate, normalisation,
 autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
-from artwork, and the mini player's skin and size.
+from artwork, autoscroll with the middle mouse button, and the mini player's
+skin and size.
 Playback settings apply when you press **Apply and restart playback**.
 
 Caches (audio, artwork) live under the cache directory and can be deleted at

--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -174,7 +174,18 @@ On macOS, `Cmd` replaces `Ctrl`.
 Settings (Ctrl+,) includes the Connect device name, audio quality up to
 320 kbps, volume normalisation, autoplay, gapless playback, the audio backend
 on Linux, the audio cache size, the equalizer, themes, album-art tinting,
-compact views of the sidebar and of track lists (Spotify's compact views:
-names only, one line a row, no covers),
+autoscroll, compact views of the sidebar and of track lists (Spotify's
+compact views: names only, one line a row, no covers),
 the mini player's skin and size, and close-to-tray behaviour. Applying playback settings restarts the local player. Other
 settings take effect immediately.
+
+### Autoscroll
+
+Click the middle mouse button in any scrollable list, then move the mouse —
+the page follows, faster the further the cursor sits from where you
+clicked. Move down to read further down, right to reveal the rest of a
+wide row. A small dead zone around the click keeps a plain middle-click
+from nudging the page. Click again (any button) or press Esc to stop. It
+is on by default on Windows and macOS, and off by default on Linux, where
+the middle button instead pastes selected text — turn it on there with the
+**Autoscroll** switch in Settings, Appearance.

--- a/src/app.rs
+++ b/src/app.rs
@@ -316,6 +316,9 @@ pub struct App {
     glide: Option<egui::Vec2>,
     /// When the last scroll event arrived, for lifts nobody announces.
     scroll_last_event: Option<Instant>,
+    /// Where the middle button was pressed to anchor autoscroll; `None`
+    /// when the Windows-style autoscroll is not active.
+    autoscroll_anchor: Option<egui::Pos2>,
     /// How each table is sorted, per page, for as long as the app runs.
     pub table_sorts: HashMap<Page, TableSort>,
     /// User ids resolved to display names; `None` while unknown, so an id
@@ -368,6 +371,14 @@ const TRACKPAD_SCALE: f32 = 1.8;
 const GLIDE_DECAY: f32 = 0.35;
 const GLIDE_START: f32 = 120.0;
 const GLIDE_STOP: f32 = 40.0;
+
+/// How far the pointer must sit from the autoscroll anchor before the
+/// page starts moving, so a plain middle-click does not nudge the page.
+const AUTOSCROLL_DEAD_ZONE: f32 = 12.0;
+/// Page speed per point of pointer distance beyond the dead zone, in
+/// points per second. Further from the anchor scrolls faster, like the
+/// native Windows autoscroll.
+const AUTOSCROLL_SPEED: f32 = 6.0;
 
 impl App {
     pub fn new(waker: &Waker, dirs: AppDirs, settings: Settings, options: AppOptions) -> Self {
@@ -525,6 +536,7 @@ impl App {
             scroll_accum: egui::Vec2::ZERO,
             glide: None,
             scroll_last_event: None,
+            autoscroll_anchor: None,
             table_sorts: session
                 .sorts
                 .iter()
@@ -5006,6 +5018,7 @@ impl App {
         let ctx = &ctx;
         self.apply_theme(ctx);
         self.lock_scroll_axis(ctx);
+        self.autoscroll(ctx);
         // The mini player has no sign-in screen; someone who needs one gets
         // the big window.
         let needs_sign_in = !(self.is_connected() && self.user.is_some())
@@ -5159,6 +5172,111 @@ impl App {
             ScrollAxis::Horizontal => input.smooth_scroll_delta.y = 0.0,
             ScrollAxis::Vertical => input.smooth_scroll_delta.x = 0.0,
         });
+    }
+
+    /// Windows-style autoscroll: middle-click to anchor, then move the
+    /// mouse and the page follows. This replicates what Windows does in any
+    /// scrollable view — no new interaction to learn.
+    ///
+    /// Click the middle button once to anchor; moving the mouse away from
+    /// the anchor scrolls in that direction, faster the further it sits.
+    /// Inside a small dead zone around the anchor the page stays put so a
+    /// plain click does not nudge it. Click again (any button) or press Esc
+    /// to stop. The wheel still works while autoscroll is idle.
+    ///
+    /// On Linux the middle button pastes the X11 selection, so the feature
+    /// is off there by default (the toggle still turns it on).
+    fn autoscroll(&mut self, ctx: &egui::Context) {
+        if !self.settings.autoscroll {
+            self.autoscroll_anchor = None;
+            return;
+        }
+
+        // Toggle on middle press, stop on any other press or Esc.
+        let (middle_pressed, any_pressed, esc_pressed, pointer_pos) = ctx.input(|input| {
+            (
+                input.pointer.button_pressed(egui::PointerButton::Middle),
+                input.pointer.any_pressed(),
+                input.key_pressed(egui::Key::Escape),
+                input.pointer.hover_pos().or(input.pointer.latest_pos()),
+            )
+        });
+
+        if esc_pressed {
+            self.autoscroll_anchor = None;
+            return;
+        }
+
+        if middle_pressed {
+            if let Some(pos) = pointer_pos {
+                if self.autoscroll_anchor.is_some() {
+                    // Second middle-click — stop.
+                    self.autoscroll_anchor = None;
+                    return;
+                }
+                self.autoscroll_anchor = Some(pos);
+                // Own the gesture: cancel any trackpad glide or axis lock
+                // left over from the last wheel turn.
+                self.glide = None;
+                self.scroll_lock = None;
+            }
+            // Do not also treat the press as a stop for another button
+            // pressed in the same frame.
+            return;
+        }
+
+        if any_pressed && self.autoscroll_anchor.is_some() {
+            // Clicking anywhere else stops the anchored scroll, like Windows.
+            self.autoscroll_anchor = None;
+            return;
+        }
+
+        let Some(anchor) = self.autoscroll_anchor else {
+            return;
+        };
+        let Some(pos) = pointer_pos else {
+            return;
+        };
+
+        let offset = pos - anchor;
+        let distance = offset.length();
+        if distance <= AUTOSCROLL_DEAD_ZONE {
+            ctx.set_cursor_icon(egui::CursorIcon::AllScroll);
+            ctx.request_repaint_after(Duration::from_millis(16));
+            return;
+        }
+
+        ctx.set_cursor_icon(egui::CursorIcon::AllScroll);
+        // Own the gesture while scrolling.
+        self.glide = None;
+        self.scroll_lock = None;
+
+        let dt = ctx.input(|input| input.stable_dt).clamp(0.001, 0.05);
+        let effective = distance - AUTOSCROLL_DEAD_ZONE;
+        let speed = effective * AUTOSCROLL_SPEED;
+        let dir = offset / distance;
+        let delta = dir * speed * dt;
+        ctx.input_mut(|input| {
+            input.smooth_scroll_delta -= delta;
+        });
+        ctx.request_repaint_after(Duration::from_millis(16));
+    }
+
+    /// Helper for the unit test: what the page does for a given pointer
+    /// offset from the anchor. Extracted so the direction is testable without
+    /// driving a full frame.
+    #[allow(dead_code)]
+    fn autoscroll_delta_from_offset(offset: egui::Vec2) -> egui::Vec2 {
+        let distance = offset.length();
+        if distance <= AUTOSCROLL_DEAD_ZONE {
+            return egui::Vec2::ZERO;
+        }
+        let effective = distance - AUTOSCROLL_DEAD_ZONE;
+        let dir = offset / distance;
+        // Use a nominal 1/60s step so the helper is deterministic in tests;
+        // the real code scales by `stable_dt`.
+        let dt = 1.0 / 60.0;
+        -(dir * effective * AUTOSCROLL_SPEED * dt)
     }
 
     /// Persist state when a window closes (to the tray or for good).
@@ -6187,6 +6305,35 @@ mod tests {
             app.playing_context_uri().as_deref(),
             Some("spotify:station:track:xyz"),
             "the station is what the interface calls playing"
+        );
+    }
+
+    /// Autoscroll: moving the mouse away from the middle-click anchor
+    /// scrolls in that direction, faster the further it sits — like Windows.
+    #[test]
+    fn middle_drag_scroll_moves_the_page_with_the_mouse() {
+        // Well outside the dead zone: offset down scrolls down (negative y).
+        let down = egui::Vec2::new(0.0, 40.0);
+        let scroll = App::autoscroll_delta_from_offset(down);
+        assert!(
+            scroll.y < 0.0,
+            "moving below the anchor scrolls down: {scroll:?}"
+        );
+        let right = egui::Vec2::new(30.0, 0.0);
+        let scroll = App::autoscroll_delta_from_offset(right);
+        assert!(
+            scroll.x < 0.0,
+            "moving right of the anchor scrolls right: {scroll:?}"
+        );
+        // Inside the dead zone or not moved at all: no scroll, so a plain
+        // middle-click does not nudge the page.
+        assert_eq!(
+            App::autoscroll_delta_from_offset(egui::Vec2::ZERO),
+            egui::Vec2::ZERO
+        );
+        assert_eq!(
+            App::autoscroll_delta_from_offset(egui::Vec2::new(5.0, 0.0)),
+            egui::Vec2::ZERO
         );
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -106,6 +106,10 @@ pub struct Settings {
     pub skin_scale: Option<u8>,
     /// The Winamp window stays above other windows.
     pub winamp_on_top: bool,
+    /// Click the middle mouse button to anchor autoscroll, then move the
+    /// mouse to scroll. On by default on Windows and macOS; off on Linux,
+    /// where the middle button pastes the X11 selection instead.
+    pub autoscroll: bool,
     /// The mini player's visualiser: bars, scope, or off.
     pub vis: VisMode,
     /// The playlist window is open under the mini player.
@@ -179,6 +183,7 @@ impl Default for Settings {
             skin: None,
             skin_scale: None,
             winamp_on_top: false,
+            autoscroll: !cfg!(target_os = "linux"),
             vis: VisMode::default(),
             playlist_open: false,
             playlist_height: 174,
@@ -347,6 +352,27 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
         assert!(restored.tracklist_compact);
+    }
+
+    #[test]
+    fn autoscroll_defaults_to_off_on_linux_and_older_files() {
+        let older: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            older.autoscroll,
+            !cfg!(target_os = "linux"),
+            "the default follows the platform: on in Windows and macOS, off where middle-click pastes"
+        );
+    }
+
+    #[test]
+    fn autoscroll_round_trips() {
+        let settings = Settings {
+            autoscroll: false,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert!(!restored.autoscroll);
     }
 }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -504,6 +504,17 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 });
             },
         );
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Autoscroll",
+            "Click the middle mouse button in any scrollable list, then move the mouse — the page follows. Click again or press Esc to stop. On by default on Windows and macOS; on Linux it starts off, because the middle button pastes selected text there.",
+            |ui| {
+                if widgets::switch(ui, &palette, &mut app.settings.autoscroll).changed() {
+                    changed = true;
+                }
+            },
+        );
     });
 
     section(ui, &palette, "Winamp skins", |ui| {


### PR DESCRIPTION
Fixes #96

## Problem

Scrolling through long playlists with the wheel is tiring. Windows does autoscroll in any scrollable view: click the middle mouse button, move the mouse away from the click, and the page follows — no new interaction to learn. On Linux the middle button rarely scrolls and normally pastes the X11 primary selection, so the feature should be opt-in there.

## What this does

* **Windows-style autoscroll:** click the middle mouse button in any scrollable list to anchor, then move the mouse — the page follows in that direction, faster the further the cursor sits from the anchor. A small dead zone (~12px) around the anchor keeps a plain middle-click from nudging the page. Click again (any button) or press Esc to stop. The wheel still works while autoscroll is idle. While active the cursor shows `AllScroll` and the anchored scroll owns the gesture (cancels trackpad glide/axis lock).
* **Setting:** `Settings.autoscroll: bool` — on by default on Windows and macOS, off by default on Linux (`!cfg(target_os = "linux")`). `#[serde(default)]` so older `settings.json` files without the field get the platform default and round-trip correctly. Lives in **Settings → Appearance → Autoscroll** with a toggle.
* **Docs:** `README.md` and `docs/_guide/using-fastpotify.md` (new `### Autoscroll` subsection under `## Settings`) describe the click-to-anchor behaviour and the per-platform default.
* **Tests:** `settings` round-trip + older-file default, and `app` unit test `middle_drag_scroll_moves_the_page_with_the_mouse` (now `autoscroll_delta_from_offset`) asserting offset-down → scroll-down, dead zone → no scroll. Existing 202 lib tests still pass, including headless demo renders.
* **No new dependencies**, no platform `cfg` blocks that break the other targets — `cfg!` is compile-time and the injection runs after `lock_scroll_axis`.

## Why it fits Fastpotify

* Small, native, focused — one toggle, ~70 lines of logic, no new crates, no hosted backend. Replicates what Windows already does instead of inventing a new interaction.
* Makes switching from the official client easier, as requested in #96.
* Respects platform conventions (Windows/macOS on, Linux off where middle-click paste matters).
* Follows the existing scroll architecture (`smooth_scroll_delta` → `ScrollArea`), analogous to the wheel/trackpad path.

## Verification

* `cargo fmt --all --check` — ok
* `cargo clippy --locked --no-default-features --all-targets -- -D warnings` — ok (and `--features demo`)
* `cargo test --locked --no-default-features --lib` — 202 passed, including new autoscroll tests
* `cargo test --locked --no-default-features --features demo --all-targets` — 202 passed
* Demo rendering of all surfaces (`every_surface_renders_headless`) still passes
* Manual demo screenshot of Settings shows the new row correctly (verified locally).

## How to test in the app

1. Build: `cargo run --no-default-features` (or with default features if you have the MilkDrop deps).
2. Open **Settings** (`Ctrl+,`) → **Appearance** → verify the **Autoscroll** row is last in that section. Toggle it, close and reopen the app, verify the choice persists (`~/.config/fastpotify/settings.json` on Linux, `%APPDATA%\paolino\fastpotify\config\settings.json` on Windows).
3. On Windows/macOS the switch should be ON after a fresh install (delete/rename the settings file to test). On Linux it should be OFF.
4. Open a long playlist (e.g. in `--demo` use `cargo run --features demo -- --demo --demo-page playlist:pl1`). Click the **middle mouse button** anywhere in the list — the cursor should become the four-arrow `AllScroll`. **Move the mouse down** away from the click point — the list should start scrolling down, faster the further you move. Move up/left/right — it should follow. With the mouse still but far from the anchor, it should keep scrolling at that speed.
5. **Click again** (middle or any button) or press **Esc** — scrolling should stop and the cursor should return to normal.
6. Try a plain middle-click without moving (within the dead zone) — the page should not nudge.
7. Try with the toggle **OFF** — middle-click and moving should do nothing.
8. Try on the sidebar and queue panel — the ScrollArea under the cursor should scroll.

Let me know if you prefer a different dead zone or speed (currently `AUTOSCROLL_DEAD_ZONE = 12.0`, `AUTOSCROLL_SPEED = 6.0`).