### PR TITLE
Add a recents tab in the queue sidebar (fixes #106)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -502,12 +502,20 @@ impl ApiClient {
         self.get("/me/player/queue", &[]).await
     }
 
-    pub async fn recently_played(&self, limit: u32) -> Result<CursorPage<PlayHistory>> {
-        self.get(
-            "/me/player/recently-played",
-            &[("limit", limit.to_string())],
-        )
-        .await
+    pub async fn recently_played(
+        &self,
+        limit: u32,
+        after: Option<&str>,
+        before: Option<&str>,
+    ) -> Result<CursorPage<PlayHistory>> {
+        let mut query = vec![("limit", limit.to_string())];
+        if let Some(after) = after {
+            query.push(("after", after.to_string()));
+        }
+        if let Some(before) = before {
+            query.push(("before", before.to_string()));
+        }
+        self.get("/me/player/recently-played", &query).await
     }
 
     fn device_query(device_id: Option<&str>) -> Vec<(&'static str, String)> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use crate::backend::{
 };
 use crate::media::{MediaCommand, MediaState, MediaTrack};
 use crate::media_controls::MediaService;
+use crate::model::QueueTab;
 use crate::model::*;
 use crate::paths::AppDirs;
 use crate::player::{EngineConfig, LoadSpec, LocalState, Playback, PlayerCommand, RepeatMode};
@@ -206,6 +207,9 @@ pub struct App {
 
     pub library: Library,
     pub home: HomeData,
+    pub recents: crate::model::CursorList<crate::api::models::PlayHistory>,
+    pub recents_generation: u64,
+    pub queue_tab: QueueTab,
     pub search: SearchState,
     pub playlist_pages: HashMap<String, PlaylistPage>,
     load_generation: u64,
@@ -462,6 +466,13 @@ impl App {
             window_title: String::new(),
             library: Library::default(),
             home: HomeData::default(),
+            recents: crate::model::CursorList::default(),
+            recents_generation: 0,
+            queue_tab: session
+                .queue_tab
+                .as_deref()
+                .and_then(QueueTab::decode)
+                .unwrap_or_default(),
             search: SearchState::default(),
             playlist_pages: HashMap::new(),
             load_generation: 0,
@@ -2165,7 +2176,11 @@ impl App {
         if self.home.top_tracks.get().is_none() {
             self.home.top_tracks = Loadable::Loading;
         }
-        self.backend.api(ApiRequest::RecentlyPlayed { generation });
+        self.backend.api(ApiRequest::RecentlyPlayed {
+            generation,
+            after: None,
+            before: None,
+        });
         self.backend.api(ApiRequest::TopArtists { generation });
         self.backend.api(ApiRequest::TopTracks {
             offset: 0,
@@ -2202,6 +2217,39 @@ impl App {
             full: true,
             generation: self.home.top_songs_generation,
         });
+    }
+
+    pub fn load_recents(&mut self, force: bool) {
+        if self.recents.loading {
+            return;
+        }
+        if self.recents.complete && !force {
+            return;
+        }
+        if force {
+            self.recents.reset();
+        }
+        self.recents.loading = true;
+        self.recents.error = None;
+        self.recents_generation = self.recents_generation.wrapping_add(1);
+        let generation = self.recents_generation;
+        let before = self.recents.after.clone();
+        self.backend.api(ApiRequest::RecentlyPlayed {
+            generation,
+            after: None,
+            before,
+        });
+    }
+
+    pub fn load_more_recents(&mut self) {
+        if !self.recents.can_load_more() {
+            return;
+        }
+        self.load_recents(false);
+    }
+
+    pub fn reload_recents(&mut self) {
+        self.load_recents(true);
     }
 
     pub fn load_more(&mut self, page: Page) {
@@ -2861,22 +2909,109 @@ impl App {
                     self.request_contains(uris);
                 }
             }
-            ApiResponse::RecentlyPlayed { generation, result } => {
-                if generation != self.home.generation {
+            ApiResponse::RecentlyPlayed {
+                generation,
+                after: _,
+                before: _,
+                result,
+            } => {
+                let is_home = generation == self.home.generation;
+                let is_recents = generation == self.recents_generation;
+                if !is_home && !is_recents {
                     return;
                 }
-                if let Ok(history) = &result {
-                    // Oldest first, so the newest ends up at the front.
-                    let contexts: Vec<String> = history
-                        .iter()
-                        .rev()
-                        .filter_map(|play| play.context.as_ref().map(|context| context.uri.clone()))
-                        .collect();
-                    for context in contexts {
-                        self.note_recent_context(&context);
+                if is_home {
+                    if let Ok(page) = &result {
+                        let contexts: Vec<String> = page
+                            .items
+                            .iter()
+                            .rev()
+                            .filter_map(|play| {
+                                play.context.as_ref().map(|context| context.uri.clone())
+                            })
+                            .collect();
+                        for context in contexts {
+                            self.note_recent_context(&context);
+                        }
+                    }
+                    let mapped = result
+                        .as_ref()
+                        .map(|page| page.items.clone())
+                        .map_err(|e| e.to_string());
+                    self.home.recently_played.refresh(mapped);
+                    if !is_recents {
+                        return;
+                    }
+                    // Generation collision: also handle recents below, contexts already noted.
+                }
+                // Recents handling
+                if is_recents {
+                    match result {
+                        Ok(page) => {
+                            if !is_home {
+                                let contexts: Vec<String> = page
+                                    .items
+                                    .iter()
+                                    .rev()
+                                    .filter_map(|play| {
+                                        play.context.as_ref().map(|context| context.uri.clone())
+                                    })
+                                    .collect();
+                                for context in contexts {
+                                    self.note_recent_context(&context);
+                                }
+                            }
+                            let cursors = page.cursors.clone();
+                            let items_len = page.items.len();
+                            let next_before = cursors.as_ref().and_then(|c| c.before.clone());
+                            let fallback_after = cursors.as_ref().and_then(|c| c.after.clone());
+                            let mut seen: std::collections::HashSet<String> = self
+                                .recents
+                                .items
+                                .iter()
+                                .filter_map(|p| p.track.id.clone())
+                                .collect();
+                            let mut new_items = Vec::new();
+                            for entry in page.items {
+                                if let Some(id) = entry.track.id.clone()
+                                    && !seen.insert(id)
+                                {
+                                    continue;
+                                }
+                                new_items.push(entry);
+                            }
+                            let new_len = new_items.len();
+                            self.recents.items.extend(new_items);
+                            let cursor = next_before.or(fallback_after);
+                            if cursor.is_none() || items_len == 0 || items_len < 50 {
+                                self.recents.complete = true;
+                                self.recents.after = None;
+                            } else {
+                                self.recents.after = cursor;
+                                // If deduplication consumed everything, still keep cursor but not complete.
+                                if new_len == 0 && self.recents.after.is_some() {
+                                    // keep trying, not complete
+                                    self.recents.complete = false;
+                                }
+                            }
+                            self.recents.loading = false;
+                            self.recents.loaded_once = true;
+                            self.recents.error = None;
+                            let uris: Vec<String> = self
+                                .recents
+                                .items
+                                .iter()
+                                .map(|h| h.track.uri.clone())
+                                .collect();
+                            self.request_contains(uris);
+                        }
+                        Err(error) => {
+                            self.recents.loading = false;
+                            self.recents.error = Some(error.to_string());
+                            self.recents.loaded_once = true;
+                        }
                     }
                 }
-                self.home.recently_played.refresh(result);
             }
             ApiResponse::TopTracks {
                 offset,
@@ -4637,6 +4772,18 @@ impl App {
                 }
             }
             Action::LoadMore(page) => self.load_more(page),
+            Action::LoadMoreRecents => self.load_more_recents(),
+            Action::ReloadRecents => self.reload_recents(),
+            Action::SetQueueTab(tab) => {
+                self.queue_tab = tab;
+                self.session_dirty = true;
+                if tab == QueueTab::Recents
+                    && self.recents.items.is_empty()
+                    && !self.recents.loading
+                {
+                    self.load_recents(false);
+                }
+            }
             Action::LoadMoreArtistAlbums(id) => {
                 let Some(page) = self.artist_pages.get_mut(&id) else {
                     return;
@@ -5204,6 +5351,7 @@ impl App {
                 window_size: self.last_window_size.or(self.session_window_size),
                 window_pos: self.last_window_pos.or(self.session_window_pos),
                 queue_open: Some(self.show_queue_panel),
+                queue_tab: Some(self.queue_tab.encode().to_string()),
                 winamp_pos: self.winamp.last_pos.or(self.winamp.restore_pos),
                 milkdrop_pos: self.milkdrop_pos,
             }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -60,6 +60,8 @@ pub enum ApiRequest {
     },
     RecentlyPlayed {
         generation: u64,
+        after: Option<String>,
+        before: Option<String>,
     },
     TopTracks {
         offset: u32,
@@ -242,7 +244,9 @@ pub enum ApiResponse {
     },
     RecentlyPlayed {
         generation: u64,
-        result: ApiResult<Vec<PlayHistory>>,
+        after: Option<String>,
+        before: Option<String>,
+        result: ApiResult<CursorPage<PlayHistory>>,
     },
     TopTracks {
         offset: u32,
@@ -1759,9 +1763,15 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> (ApiResponse, Option<A
             seq,
             result: routed!(queue()),
         },
-        ApiRequest::RecentlyPlayed { generation } => ApiResponse::RecentlyPlayed {
+        ApiRequest::RecentlyPlayed {
             generation,
-            result: routed!(recently_played(50)).map(|page| page.items),
+            after,
+            before,
+        } => ApiResponse::RecentlyPlayed {
+            generation,
+            after: after.clone(),
+            before: before.clone(),
+            result: routed!(recently_played(50, after.as_deref(), before.as_deref())),
         },
         ApiRequest::TopTracks {
             offset,

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -442,6 +442,28 @@ pub fn populate(app: &mut App) {
             })
             .collect(),
     );
+    // Recents tab (queue sidebar) – deduped, timestamped, paginated.
+    let recents_now = Timestamp::now();
+    app.recents.items = tracks
+        .iter()
+        .skip(2)
+        .take(24)
+        .enumerate()
+        .map(|(index, track)| PlayHistory {
+            track: track.clone(),
+            played_at: Some(demo_added_at(index, recents_now)),
+            context: None,
+        })
+        .collect();
+    app.recents.loaded_once = true;
+    app.recents.loading = false;
+    app.recents.error = None;
+    // Has more to load (before cursor of oldest item).
+    let oldest = recents_now - SignedDuration::from_hours(48);
+    // Cursor is unix millis; jiff Timestamp exposes seconds + nanos.
+    let millis = oldest.as_second() * 1000 + i64::from(oldest.subsec_nanosecond() / 1_000_000);
+    app.recents.after = Some(millis.to_string());
+    app.recents.complete = false;
     app.home.top_artists = Loadable::Loaded((0..8).map(artist).collect());
     app.home.top_tracks = Loadable::Loaded(tracks.iter().skip(10).take(10).cloned().collect());
     app.home.top_songs = Loadable::Loaded(tracks.iter().skip(10).cloned().collect());
@@ -589,6 +611,10 @@ pub fn apply_flags(app: &mut App, page: Option<&str>, show: Option<&str>) {
     for surface in show.unwrap_or("").split(',').map(str::trim) {
         match surface {
             "queue" => app.show_queue_panel = true,
+            "recents" => {
+                app.show_queue_panel = true;
+                app.queue_tab = QueueTab::Recents;
+            }
             "devices" => app.show_devices = true,
             "shortcuts" => app.dialog = Some(Dialog::Shortcuts),
             "premium" => app.dialog = Some(Dialog::PremiumNeeded),

--- a/src/model.rs
+++ b/src/model.rs
@@ -85,6 +85,32 @@ impl Page {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum QueueTab {
+    #[default]
+    Queue,
+    Recents,
+}
+
+impl QueueTab {
+    pub fn encode(self) -> &'static str {
+        match self {
+            Self::Queue => "queue",
+            Self::Recents => "recents",
+        }
+    }
+
+    pub fn decode(text: &str) -> Option<Self> {
+        match text {
+            "queue" => Some(Self::Queue),
+            "recents" => Some(Self::Recents),
+            // Backward compat: image label
+            "recently_played" => Some(Self::Recents),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum Loadable<T> {
     #[default]
@@ -602,6 +628,9 @@ pub enum Action {
     SetSearchFilter(SearchFilter),
     FocusSearch,
     LoadMore(Page),
+    LoadMoreRecents,
+    ReloadRecents,
+    SetQueueTab(QueueTab),
     LoadMoreArtistAlbums(String),
     SetDiscographyFilter {
         artist_id: String,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -385,6 +385,8 @@ pub struct SessionState {
     pub window_pos: Option<[f32; 2]>,
     /// Whether the queue panel was open.
     pub queue_open: Option<bool>,
+    /// Which tab the queue panel showed: `queue` or `recents`.
+    pub queue_tab: Option<String>,
     /// Last outer position of the Winamp window.
     pub winamp_pos: Option<[f32; 2]>,
     /// Last outer position of the MilkDrop window.

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,10 +1,10 @@
 //! The playback queue, as a page or as a side panel.
 
-use egui::{Align, Frame, Layout, Margin};
+use egui::{Align, Frame, Layout, Margin, Stroke, Vec2, pos2};
 
 use crate::api::models::PlayableItem;
 use crate::app::App;
-use crate::model::{Action, Loadable, RowContext};
+use crate::model::{Action, Loadable, QueueTab, RowContext};
 use crate::theme::{self, Icon};
 
 use super::widgets::{self, TrackRow};
@@ -39,27 +39,94 @@ pub fn side_panel(app: &mut App, ui: &mut egui::Ui) {
     let response = panel.show(ui, |ui| {
         ui.horizontal(|ui| {
             ui.add_space(4.0);
-            theme::text(ui, "Queue", theme::bold(18.0), palette.text);
+            tabs(app, ui);
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 if theme::icon_button(ui, Icon::X, 18.0, palette.secondary, palette.text, "Close")
                     .clicked()
                 {
                     app.actions.push(Action::ToggleQueuePanel);
                 }
-                save_button(app, ui);
+                if app.queue_tab == QueueTab::Queue {
+                    save_button(app, ui);
+                }
             });
         });
         ui.add_space(8.0);
+        // Lazy load recents when tab becomes visible.
+        if app.queue_tab == QueueTab::Recents
+            && !app.recents.loading
+            && !app.recents.complete
+            && app.recents.items.is_empty()
+            && app.recents.error.is_none()
+        {
+            app.actions.push(Action::LoadMoreRecents);
+        }
         egui::ScrollArea::vertical()
             .id_salt("queue-panel-scroll")
             .auto_shrink([false, false])
-            .show(ui, |ui| contents(app, ui, true));
+            .show(ui, |ui| match app.queue_tab {
+                QueueTab::Queue => contents(app, ui, true),
+                QueueTab::Recents => recents_contents(app, ui),
+            });
     });
     let width = response.response.rect.width();
     if (width - app.settings.queue_width).abs() > 1.0 {
         app.settings.queue_width = width;
         app.actions.push(Action::SettingsChanged);
     }
+}
+
+fn tabs(app: &mut App, ui: &mut egui::Ui) {
+    let palette = app.palette;
+    let current = app.queue_tab;
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 16.0;
+        for (tab, label) in [
+            (QueueTab::Queue, "Queue"),
+            (QueueTab::Recents, "Recently played"),
+        ] {
+            let active = current == tab;
+            let color = if active {
+                palette.text
+            } else {
+                palette.secondary
+            };
+            let font = if active {
+                theme::semibold(14.0)
+            } else {
+                theme::regular(14.0)
+            };
+            let galley = ui
+                .painter()
+                .layout_no_wrap(label.to_string(), font.clone(), color);
+            let size = galley.size() + Vec2::new(4.0, 6.0);
+            let (rect, response) = ui.allocate_exact_size(size, egui::Sense::click());
+            if ui.is_rect_visible(rect) {
+                let pos = pos2(
+                    rect.center().x - galley.size().x / 2.0,
+                    rect.center().y - galley.size().y / 2.0,
+                );
+                ui.painter().galley(pos, galley, color);
+                if active {
+                    let y = rect.bottom() + 2.0;
+                    ui.painter()
+                        .hline(rect.x_range(), y, Stroke::new(2.0, palette.accent));
+                }
+                if response.hovered() && !active {
+                    let y = rect.bottom() + 2.0;
+                    ui.painter()
+                        .hline(rect.x_range(), y, Stroke::new(1.0, palette.outline));
+                }
+            }
+            if response
+                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                .clicked()
+                && !active
+            {
+                app.actions.push(Action::SetQueueTab(tab));
+            }
+        }
+    });
 }
 
 /// The queue, made permanent: a new playlist of the playing song and
@@ -195,6 +262,104 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
         widgets::virtual_rows(ui, items.len() - queued_len, row_height, |ui, index| {
             queue_row(app, ui, &items, queued_len + index, compact);
         });
+    }
+}
+
+fn recents_contents(app: &mut App, ui: &mut egui::Ui) {
+    let palette = app.palette;
+    // Snapshot to avoid borrow issues while drawing.
+    let items = app.recents.items.clone();
+    let loading = app.recents.loading;
+    let error = app.recents.error.clone();
+    let complete = app.recents.complete;
+    let loaded_once = app.recents.loaded_once;
+
+    if items.is_empty() {
+        if loading {
+            widgets::loading_row(ui, &palette);
+            return;
+        }
+        if let Some(err) = error {
+            ui.horizontal(|ui| {
+                ui.add_space(8.0);
+                theme::icon(ui, Icon::CircleAlert, 16.0, palette.danger);
+                theme::text(ui, &err, theme::regular(13.0), palette.secondary);
+                if theme::soft_button(ui, &palette, Some(Icon::Refresh), "Retry", false).clicked() {
+                    app.actions.push(Action::ReloadRecents);
+                }
+            });
+            return;
+        }
+        if loaded_once {
+            widgets::empty_state(
+                ui,
+                &palette,
+                Icon::Clock,
+                "No recent plays",
+                "Play something and it will show up here.",
+            );
+        } else {
+            widgets::loading_row(ui, &palette);
+        }
+        return;
+    }
+
+    // Show error inline if we have items but also an error on next page.
+    if let Some(err) = error {
+        ui.horizontal(|ui| {
+            theme::icon(ui, Icon::CircleAlert, 14.0, palette.danger);
+            theme::text(ui, &err, theme::regular(12.0), palette.secondary);
+            if theme::soft_button(ui, &palette, Some(Icon::Refresh), "Retry", false).clicked() {
+                app.actions.push(Action::LoadMoreRecents);
+            }
+        });
+        ui.add_space(6.0);
+    }
+
+    let row_height = theme::COMPACT_ROW_HEIGHT;
+    // Build PlayableItems on the fly; virtual_rows needs stable index.
+    widgets::virtual_rows(ui, items.len(), row_height, |ui, index| {
+        let entry = &items[index];
+        // Need owned PlayableItem for track_row; clone track.
+        let item = PlayableItem::Track(entry.track.clone());
+        let context = RowContext::Uris(vec![entry.track.uri.clone()]);
+        widgets::track_row(
+            ui,
+            app,
+            TrackRow {
+                index,
+                number: None,
+                item: &item,
+                context: &context,
+                show_cover: true,
+                show_album: false,
+                added_at: entry.played_at.as_deref(),
+                added_by: None,
+                show_added_by: false,
+                compact: true,
+                thin: false,
+                shift: 0.0,
+            },
+        );
+    });
+
+    // Footer: loading more or load more trigger
+    if loading {
+        ui.add_space(8.0);
+        widgets::loading_row(ui, &palette);
+    } else if !complete {
+        ui.add_space(8.0);
+        // Auto-load when near end, plus manual button as fallback.
+        let can_load = app.recents.can_load_more();
+        // Check if scroll is near end (same heuristic as widgets::load_more_when_near_end)
+        let clip = ui.clip_rect();
+        let cursor = ui.cursor().top();
+        if can_load && cursor - clip.bottom() < 900.0 {
+            app.actions.push(Action::LoadMoreRecents);
+        }
+        if theme::soft_button(ui, &palette, Some(Icon::Refresh), "Load more", false).clicked() {
+            app.actions.push(Action::LoadMoreRecents);
+        }
     }
 }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -751,6 +751,22 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                     theme::regular(13.0),
                     subtitle_color,
                 );
+                if let Some(added) = row.added_at.filter(|a| !a.starts_with("1970-01-01"))
+                    && cols.added == 0.0
+                {
+                    let label = util::format_relative_date(added, jiff::Timestamp::now());
+                    theme::text(
+                        &mut child,
+                        "•",
+                        theme::regular(12.0),
+                        palette.secondary.gamma_multiply(0.6),
+                    );
+                    theme::text(&mut child, &label, theme::regular(12.0), palette.secondary);
+                    if label.ends_with(" ago") {
+                        ui.ctx()
+                            .request_repaint_after(std::time::Duration::from_secs(1));
+                    }
+                }
             }
             PlayableItem::Episode(episode) => {
                 let subtitle = episode
@@ -772,6 +788,22 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                         && let Some(id) = show_id
                     {
                         app.actions.push(Action::Open(Page::Show(id)));
+                    }
+                }
+                if let Some(added) = row.added_at.filter(|a| !a.starts_with("1970-01-01"))
+                    && cols.added == 0.0
+                {
+                    theme::text(
+                        &mut child,
+                        "•",
+                        theme::regular(12.0),
+                        palette.secondary.gamma_multiply(0.6),
+                    );
+                    let label = util::format_relative_date(added, jiff::Timestamp::now());
+                    theme::text(&mut child, &label, theme::regular(12.0), palette.secondary);
+                    if label.ends_with(" ago") {
+                        ui.ctx()
+                            .request_repaint_after(std::time::Duration::from_secs(1));
                     }
                 }
             }
@@ -805,6 +837,22 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                         theme::regular(12.5),
                         subtitle_color,
                     );
+                    if let Some(added) = row.added_at.filter(|a| !a.starts_with("1970-01-01"))
+                        && cols.added == 0.0
+                    {
+                        theme::text(
+                            ui,
+                            "•",
+                            theme::regular(12.0),
+                            palette.secondary.gamma_multiply(0.6),
+                        );
+                        let label = util::format_relative_date(added, jiff::Timestamp::now());
+                        theme::text(ui, &label, theme::regular(12.0), palette.secondary);
+                        if label.ends_with(" ago") {
+                            ui.ctx()
+                                .request_repaint_after(std::time::Duration::from_secs(1));
+                        }
+                    }
                 }
                 PlayableItem::Episode(episode) => {
                     let subtitle = episode
@@ -818,6 +866,22 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) {
                         && let Some(id) = show_id
                     {
                         app.actions.push(Action::Open(Page::Show(id)));
+                    }
+                    if let Some(added) = row.added_at.filter(|a| !a.starts_with("1970-01-01"))
+                        && cols.added == 0.0
+                    {
+                        theme::text(
+                            ui,
+                            "•",
+                            theme::regular(12.0),
+                            palette.secondary.gamma_multiply(0.6),
+                        );
+                        let label = util::format_relative_date(added, jiff::Timestamp::now());
+                        theme::text(ui, &label, theme::regular(12.0), palette.secondary);
+                        if label.ends_with(" ago") {
+                            ui.ctx()
+                                .request_repaint_after(std::time::Duration::from_secs(1));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #106

## What problem this solves

Fastpotify had no way to check recently played songs. The Home page shows a 16-card "Recently played" shelf, but there was no dedicated view with the full history and when it was played. The issue asks for a separate tab in the queue sidebar.

## What changed

The queue side panel now has two tabs, `Queue` and `Recently played` (accent-underline style matching the mockup in the issue). The Recents tab:

- shows the account's recently played songs, newest first, from `GET /me/player/recently-played` (the `user-read-recently-played` scope was already requested)
- deduplicates by track id while preserving each row's `played_at` timestamp, shown as a relative time ("5 minutes ago", "2 hours ago", then an absolute date after 30 days via the existing `util::format_relative_date`)
- loads 50 songs on first open and paginates older history with the endpoint's `before` cursor — scroll to the end or press "Load more", and the next 50 append without duplicates; the list marks itself complete when Spotify returns fewer than a page
- persists which tab was open in `SessionState` (`queue_tab`), so the choice survives a restart; older session files default to `Queue`
- shows a loading row while fetching, an inline error with Retry when the request fails, and an empty state when there is no history

## Files

- `src/api/client.rs` — `recently_played(limit, after, before)` passes the cursor parameters
- `src/backend.rs` — `ApiRequest::RecentlyPlayed { after, before }` and `ApiResponse::RecentlyPlayed` carry the `CursorPage<PlayHistory>` through
- `src/app.rs` — new `recents: CursorList<PlayHistory>` state with generation guard, `load_recents`/`load_more_recents`/`reload_recents`, dedup-by-id on absorb, and the new actions
- `src/model.rs` — `QueueTab` (encode/decode) and `Action::{LoadMoreRecents, ReloadRecents, SetQueueTab}`
- `src/ui/queue.rs` — tab bar and `recents_contents` (virtualized compact rows, relative timestamps, load-more footer)
- `src/ui/widgets.rs` — `track_row` appends "• 2 hours ago" inline when the added column is hidden (narrow panels), so timestamps are visible in the 360px drawer
- `src/settings.rs` — `SessionState.queue_tab`
- `src/demo.rs` — sample recents with varied `demo_added_at` and a `--demo-show recents` flag

## How it was verified

- `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings` (with and without `--all-features`/demo), `cargo test --locked --all-targets` (202 tests) and `--all-features --doc` pass
- The queue panel's own behaviour is untouched: the Queue tab still follows the rules in `docs/_reference/queue.md`, and the recents list is read-only (no `Clear queue`, no queue mutation)
- Tested locally on Windows (debug build): tabs switch without flicker, dedup + relative timestamps render, load-more appends older pages, error/Retry and empty states work, and the tab choice persists across restarts
- No new dependencies
