### PR TITLE
Add custom colour palettes with hex/alpha support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -152,6 +152,7 @@ pub struct App {
     pub offline: bool,
     pub palette: Palette,
     applied_dark: Option<bool>,
+    pub palette_manager: crate::palette::PaletteManager,
 
     pub auth: AuthStatus,
     pub user: Option<User>,
@@ -387,6 +388,15 @@ impl App {
             .filter(|page| !matches!(page, Page::Settings | Page::Queue))
             .unwrap_or(Page::Home);
 
+        // Grabbed before `settings` moves into the struct below.
+        let palette_file = settings.palette_file.clone();
+        let palette_manager = crate::palette::PaletteManager::new();
+        if let Some(path) = &palette_file
+            && let Err(error) = palette_manager.load_from_file(path)
+        {
+            log::warn!("could not load palette from {}: {error}", path.display());
+        }
+
         let mut app = Self {
             dirs,
             settings,
@@ -406,6 +416,7 @@ impl App {
             offline: false,
             palette: Palette::dark(),
             applied_dark: None,
+            palette_manager,
             auth: AuthStatus::Starting,
             user: None,
             local_device_id: None,
@@ -1685,14 +1696,59 @@ impl App {
         self.settings.save(&self.dirs.settings_file());
     }
 
+    /// Loads a custom palette from `path` and applies it immediately.
+    fn load_palette_file(&mut self, ctx: &egui::Context, path: std::path::PathBuf) {
+        match self.palette_manager.load_from_file(&path) {
+            Ok(()) => {
+                self.settings.palette_file = Some(path);
+                self.settings_dirty = true;
+                self.applied_dark = None;
+                self.apply_theme(ctx);
+                self.toast("Palette loaded");
+            }
+            Err(error) => self.toast_error(format!("Could not load palette: {error}")),
+        }
+    }
+
+    /// Makes a built-in palette active immediately. Built-in palettes have
+    /// no file, so `settings.palette_file` is cleared.
+    fn load_builtin_palette(&mut self, ctx: &egui::Context, name: String) {
+        match self.palette_manager.load_builtin(&name) {
+            Ok(()) => {
+                self.settings.palette_file = None;
+                self.settings_dirty = true;
+                self.applied_dark = None;
+                self.apply_theme(ctx);
+            }
+            Err(error) => self.toast_error(format!("Could not load palette: {error}")),
+        }
+    }
+
+    /// Drops the active palette and returns to the built-in default.
+    fn reset_palette(&mut self, ctx: &egui::Context) {
+        self.palette_manager.reset();
+        self.settings.palette_file = None;
+        self.settings_dirty = true;
+        self.applied_dark = None;
+        self.apply_theme(ctx);
+    }
+
+    /// Re-reads the active palette's file from disk, if it has one.
+    fn reload_palette(&mut self, ctx: &egui::Context) {
+        match self.palette_manager.reload() {
+            Ok(()) => {
+                self.applied_dark = None;
+                self.apply_theme(ctx);
+                self.toast("Palette reloaded");
+            }
+            Err(error) => self.toast_error(format!("Could not reload palette: {error}")),
+        }
+    }
+
     fn apply_theme(&mut self, ctx: &egui::Context) {
         let dark = ctx.theme() == egui::Theme::Dark;
         if self.applied_dark != Some(dark) {
-            self.palette = if dark {
-                Palette::dark()
-            } else {
-                Palette::light()
-            };
+            self.palette = self.palette_manager.current(dark).palette;
             theme::apply(ctx, &self.palette);
             self.applied_dark = Some(dark);
             self.accents.clear();
@@ -1756,6 +1812,9 @@ impl App {
                 }),
                 ControlCommand::Transfer(device_id) => Some(Action::Transfer(device_id)),
                 ControlCommand::RefreshDevices => Some(Action::RefreshDevices),
+                ControlCommand::SetPalette(path) => Some(Action::LoadPalette(path)),
+                ControlCommand::ReloadPalette => Some(Action::ReloadPalette),
+                ControlCommand::ResetPalette => Some(Action::ResetPalette),
             };
             if let Some(action) = action {
                 self.actions.push(action);
@@ -4286,6 +4345,10 @@ impl App {
                     ThemeChoice::System => egui::ThemePreference::System,
                 });
             }
+            Action::LoadPalette(path) => self.load_palette_file(ctx, path),
+            Action::LoadBuiltinPalette(name) => self.load_builtin_palette(ctx, name),
+            Action::ReloadPalette => self.reload_palette(ctx),
+            Action::ResetPalette => self.reset_palette(ctx),
             Action::RestartEngine => {
                 self.save_settings();
                 let config = engine_config(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod media_controls;
 pub mod media_controls;
 pub mod milkdrop;
 pub mod model;
+pub mod palette;
 pub mod paths;
 pub mod player;
 pub mod resample;

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,22 @@ enum Control {
     },
     /// Bring the window of the running instance forward
     Show,
+    /// Manage the running instance's colour palette
+    Palette {
+        #[command(subcommand)]
+        action: PaletteAction,
+    },
+}
+
+/// A colour palette command sent to the running instance.
+#[derive(Clone, Debug, clap::Subcommand)]
+enum PaletteAction {
+    /// Load a custom palette from a JSON file
+    Set { path: std::path::PathBuf },
+    /// Re-read the active palette's file from disk
+    Reload,
+    /// Drop the active palette, back to the built-in default
+    Reset,
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
@@ -178,6 +194,11 @@ fn run_control(control: Control) -> i32 {
         Control::Transfer { device_id } => format!("transfer {device_id}"),
         Control::NowPlaying { .. } => "nowplaying".to_owned(),
         Control::Show => "show".to_owned(),
+        Control::Palette { action } => match action {
+            PaletteAction::Set { path } => format!("palette-set {}", path.display()),
+            PaletteAction::Reload => "palette-reload".to_owned(),
+            PaletteAction::Reset => "palette-reset".to_owned(),
+        },
     };
     match single_instance::send(&verb) {
         Ok(single_instance::Reply::Ok) => 0,
@@ -563,6 +584,11 @@ fn native_options(fullscreen: bool, mini: Option<MiniWindow>) -> eframe::NativeO
             .with_fullsize_content_view(true)
             .with_titlebar_shown(false)
             .with_title_shown(false)
+            // Opaque by default (the built-in and built-in-name palettes
+            // never set alpha below 255 on `window`), but a custom palette
+            // can make the window translucent, so the surface itself has
+            // to allow it.
+            .with_transparent(true)
             .with_inner_size([1240.0, 800.0])
             .with_min_inner_size([760.0, 520.0])
             .with_fullscreen(fullscreen),
@@ -722,16 +748,18 @@ impl eframe::App for Shell {
     }
 
     /// The mini player's window is see-through where the skin leaves it
-    /// out; the big window paints itself over eframe's own ground.
+    /// out. The main window clears to its palette's `window` colour,
+    /// alpha included, so a custom palette with a translucent `window`
+    /// shows the desktop behind it; the built-in palettes are opaque, so
+    /// this changes nothing for them.
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
-        if self
-            .app
-            .as_ref()
-            .is_some_and(|app| app.settings.winamp_window)
-        {
+        let Some(app) = self.app.as_ref() else {
+            return egui::Color32::from_rgba_unmultiplied(12, 12, 12, 180).to_normalized_gamma_f32();
+        };
+        if app.settings.winamp_window {
             [0.0; 4]
         } else {
-            egui::Color32::from_rgba_unmultiplied(12, 12, 12, 180).to_normalized_gamma_f32()
+            app.palette.window.to_normalized_gamma_f32()
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -611,6 +611,14 @@ pub enum Action {
     ToggleDevicesPopup,
     SettingsChanged,
     RestartEngine,
+    /// Load a custom colour palette from a JSON file and make it active.
+    LoadPalette(std::path::PathBuf),
+    /// Make one of the built-in palettes active, by name.
+    LoadBuiltinPalette(String),
+    /// Re-read the active palette's file from disk.
+    ReloadPalette,
+    /// Drop the active palette, back to the built-in default.
+    ResetPalette,
     EnablePlayback,
     ShowWindow,
     HideWindow,

--- a/src/palette/builtin.rs
+++ b/src/palette/builtin.rs
@@ -1,0 +1,68 @@
+//! Palettes shipped with the app, in the same shape as a user's theme file
+//! so both go through the same resolution path.
+
+use super::theme_file::{ThemeColors, ThemeFile};
+
+/// A built-in palette's name and its factory function.
+type BuiltinEntry = (&'static str, fn() -> ThemeFile);
+
+/// Built-in palettes, by name.
+pub const BUILTIN_PALETTES: &[BuiltinEntry] = &[("Catppuccin Mocha", catppuccin_mocha), ("Nord", nord)];
+
+fn hex(value: &str) -> Option<String> {
+    Some(value.to_string())
+}
+
+fn catppuccin_mocha() -> ThemeFile {
+    // https://github.com/catppuccin/catppuccin - Mocha palette.
+    ThemeFile {
+        name: "Catppuccin Mocha".to_string(),
+        dark: ThemeColors {
+            window: hex("#1e1e2e"),
+            panel: hex("#181825"),
+            surface: hex("#313244"),
+            surface_hover: hex("#45475a"),
+            surface_active: hex("#585b70"),
+            outline: hex("#45475a"),
+            text: hex("#cdd6f4"),
+            secondary: hex("#bac2de"),
+            dim: hex("#a6adc8"),
+            accent: hex("#cba6f7"),
+            accent_hover: hex("#b4befe"),
+            on_accent: hex("#1e1e2e"),
+            danger: hex("#f38ba8"),
+            warning: hex("#f9e2af"),
+            overlay: hex("#11111b"),
+            shadow: None,
+        },
+        // Catppuccin doesn't define a light Mocha; light mode falls back to
+        // the app default (every field left unset).
+        light: ThemeColors::default(),
+    }
+}
+
+fn nord() -> ThemeFile {
+    // https://www.nordtheme.com/docs/colors-and-palettes
+    ThemeFile {
+        name: "Nord".to_string(),
+        dark: ThemeColors {
+            window: hex("#2e3440"),
+            panel: hex("#242933"),
+            surface: hex("#3b4252"),
+            surface_hover: hex("#434c5e"),
+            surface_active: hex("#4c566a"),
+            outline: hex("#4c566a"),
+            text: hex("#eceff4"),
+            secondary: hex("#d8dee9"),
+            dim: hex("#8fbcbb"),
+            accent: hex("#88c0d0"),
+            accent_hover: hex("#8fbcbb"),
+            on_accent: hex("#2e3440"),
+            danger: hex("#bf616a"),
+            warning: hex("#ebcb8b"),
+            overlay: hex("#242933"),
+            shadow: None,
+        },
+        light: ThemeColors::default(),
+    }
+}

--- a/src/palette/colors.rs
+++ b/src/palette/colors.rs
@@ -1,0 +1,93 @@
+//! Hex colour parsing for theme files: `#RGB`, `#RGBA`, `#RRGGBB`,
+//! `#RRGGBBAA`. The `#` is optional. Alpha defaults to opaque.
+
+use egui::Color32;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("invalid color '{0}'")]
+pub struct ColorError(pub String);
+
+/// Parses a hex colour string into a [`Color32`], alpha included.
+pub fn parse_hex_color(text: &str) -> Result<Color32, ColorError> {
+    let hex = text.trim().strip_prefix('#').unwrap_or(text.trim());
+    let invalid = || ColorError(text.to_string());
+
+    let digit = |c: u8| -> Result<u8, ColorError> {
+        (c as char).to_digit(16).map(|d| d as u8).ok_or_else(invalid)
+    };
+    let byte = |hi: u8, lo: u8| -> Result<u8, ColorError> { Ok(digit(hi)? * 16 + digit(lo)?) };
+    // A single hex digit repeated, e.g. `#RGB`'s `f` standing for `ff`.
+    let expand = |c: u8| -> Result<u8, ColorError> {
+        let d = digit(c)?;
+        Ok(d * 16 + d)
+    };
+
+    let bytes = hex.as_bytes();
+    match bytes.len() {
+        3 => Ok(Color32::from_rgb(
+            expand(bytes[0])?,
+            expand(bytes[1])?,
+            expand(bytes[2])?,
+        )),
+        4 => Ok(Color32::from_rgba_unmultiplied(
+            expand(bytes[0])?,
+            expand(bytes[1])?,
+            expand(bytes[2])?,
+            expand(bytes[3])?,
+        )),
+        6 => Ok(Color32::from_rgb(
+            byte(bytes[0], bytes[1])?,
+            byte(bytes[2], bytes[3])?,
+            byte(bytes[4], bytes[5])?,
+        )),
+        8 => Ok(Color32::from_rgba_unmultiplied(
+            byte(bytes[0], bytes[1])?,
+            byte(bytes[2], bytes[3])?,
+            byte(bytes[4], bytes[5])?,
+            byte(bytes[6], bytes[7])?,
+        )),
+        _ => Err(invalid()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_rgb() {
+        assert_eq!(parse_hex_color("#ff0000"), Ok(Color32::from_rgb(255, 0, 0)));
+        assert_eq!(parse_hex_color("00ff00"), Ok(Color32::from_rgb(0, 255, 0)));
+    }
+
+    #[test]
+    fn parses_short_rgb() {
+        assert_eq!(parse_hex_color("#f00"), Ok(Color32::from_rgb(255, 0, 0)));
+        assert_eq!(parse_hex_color("#0f0"), Ok(Color32::from_rgb(0, 255, 0)));
+    }
+
+    #[test]
+    fn parses_rgba_with_alpha() {
+        assert_eq!(
+            parse_hex_color("#ff000080"),
+            Ok(Color32::from_rgba_unmultiplied(255, 0, 0, 0x80))
+        );
+    }
+
+    #[test]
+    fn parses_short_rgba() {
+        assert_eq!(
+            parse_hex_color("#f008"),
+            Ok(Color32::from_rgba_unmultiplied(255, 0, 0, 0x88))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid() {
+        assert!(parse_hex_color("#zzz").is_err());
+        assert!(parse_hex_color("#ff00").is_ok()); // 4 digits: RGBA short
+        assert!(parse_hex_color("#ff0").is_ok()); // 3 digits: RGB short
+        assert!(parse_hex_color("#12345").is_err()); // 5 digits: no valid form
+        assert!(parse_hex_color("").is_err());
+    }
+}

--- a/src/palette/manager.rs
+++ b/src/palette/manager.rs
@@ -1,0 +1,252 @@
+//! Holds the currently active custom palette, if any, and resolves it
+//! against dark/light mode on request. Thread-safe so it can sit on `App`
+//! and still be reachable from wherever a hot-reload command arrives.
+
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use crate::theme::Palette;
+
+use super::theme_file::ThemeFile;
+use super::{Result, resolve};
+
+/// A snapshot of the manager's state: enough to render, and to show in
+/// Settings.
+#[derive(Clone, Debug)]
+pub struct PaletteState {
+    /// The active theme's name, or `None` when using the built-in default.
+    pub name: Option<String>,
+    pub palette: Palette,
+    /// Where the active theme file lives on disk, if it came from one
+    /// (built-in palettes and the default have no file to reload).
+    pub source_file: Option<PathBuf>,
+}
+
+struct Inner {
+    theme: Option<ThemeFile>,
+    source_file: Option<PathBuf>,
+}
+
+pub struct PaletteManager {
+    inner: RwLock<Inner>,
+}
+
+impl PaletteManager {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                theme: None,
+                source_file: None,
+            }),
+        }
+    }
+
+    fn locked(&self) -> std::sync::RwLockReadGuard<'_, Inner> {
+        self.inner.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn locked_mut(&self) -> std::sync::RwLockWriteGuard<'_, Inner> {
+        self.inner.write().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// The resolved palette and metadata for the given mode.
+    pub fn current(&self, dark: bool) -> PaletteState {
+        let inner = self.locked();
+        let base = if dark { Palette::dark() } else { Palette::light() };
+        let palette = match &inner.theme {
+            Some(theme) => {
+                let colors = if dark { &theme.dark } else { &theme.light };
+                resolve(base, colors).unwrap_or(base)
+            }
+            None => base,
+        };
+        PaletteState {
+            name: inner.theme.as_ref().map(|theme| theme.name.clone()),
+            palette,
+            source_file: inner.source_file.clone(),
+        }
+    }
+
+    /// Loads a theme file from disk and makes it active. `~` at the start
+    /// of the path is expanded to the home directory, since the path
+    /// usually comes from a text field or command line rather than a
+    /// shell that would have expanded it already.
+    pub fn load_from_file(&self, path: &Path) -> Result<()> {
+        let path = expand_tilde(path);
+        let theme = read_theme_file(&path)?;
+        let mut inner = self.locked_mut();
+        inner.theme = Some(theme);
+        inner.source_file = Some(path);
+        Ok(())
+    }
+
+    /// Makes one of the built-in palettes active.
+    pub fn load_builtin(&self, name: &str) -> Result<()> {
+        let make = super::BUILTIN_PALETTES
+            .iter()
+            .find(|(candidate, _)| *candidate == name)
+            .map(|(_, make)| *make)
+            .ok_or_else(|| super::PaletteError::NotFound(name.to_string()))?;
+        let mut inner = self.locked_mut();
+        inner.theme = Some(make());
+        inner.source_file = None;
+        Ok(())
+    }
+
+    /// Drops the active theme, back to the built-in default.
+    pub fn reset(&self) {
+        let mut inner = self.locked_mut();
+        inner.theme = None;
+        inner.source_file = None;
+    }
+
+    /// Re-reads the active theme's file from disk. No-op if the active
+    /// theme isn't file-backed (built-in, or none).
+    pub fn reload(&self) -> Result<()> {
+        let path = self.locked().source_file.clone();
+        match path {
+            Some(path) => self.load_from_file(&path),
+            None => Ok(()),
+        }
+    }
+
+    /// Built-in palette names, in listing order.
+    pub fn list_builtins(&self) -> Vec<&'static str> {
+        super::BUILTIN_PALETTES.iter().map(|(name, _)| *name).collect()
+    }
+}
+
+impl Default for PaletteManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Expands a leading `~` (or `~/...`) to the home directory. Anything else
+/// passes through unchanged; a `~` that isn't at the start, or that isn't
+/// followed by a path separator, is left as a literal character rather
+/// than guessed at.
+fn expand_tilde(path: &Path) -> PathBuf {
+    let Some(text) = path.to_str() else {
+        return path.to_path_buf();
+    };
+    let Some(rest) = text.strip_prefix('~') else {
+        return path.to_path_buf();
+    };
+    if !rest.is_empty() && !rest.starts_with('/') && !rest.starts_with(std::path::MAIN_SEPARATOR) {
+        return path.to_path_buf();
+    }
+    let Some(home) = std::env::var_os("HOME") else {
+        return path.to_path_buf();
+    };
+    let mut expanded = PathBuf::from(home);
+    if let Some(rest) = rest.strip_prefix(['/', std::path::MAIN_SEPARATOR]) {
+        expanded.push(rest);
+    }
+    expanded
+}
+
+fn read_theme_file(path: &Path) -> Result<ThemeFile> {
+    let text = std::fs::read_to_string(path).map_err(|source| super::PaletteError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&text).map_err(|source| super::PaletteError::ParseFile {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_the_built_in_palette() {
+        let manager = PaletteManager::new();
+        let state = manager.current(true);
+        assert_eq!(state.name, None);
+        assert_eq!(state.palette, Palette::dark());
+    }
+
+    #[test]
+    fn loads_a_theme_file_and_overlays_only_named_colors() {
+        let dir = std::env::temp_dir().join(format!("fastpotify-palette-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("theme.json");
+        std::fs::write(
+            &path,
+            r##"{"name":"Test","dark":{"accent":"#ff0000"}}"##,
+        )
+        .unwrap();
+
+        let manager = PaletteManager::new();
+        manager.load_from_file(&path).unwrap();
+        let state = manager.current(true);
+        assert_eq!(state.name.as_deref(), Some("Test"));
+        assert_eq!(state.palette.accent, egui::Color32::from_rgb(255, 0, 0));
+        // Untouched field keeps the default.
+        assert_eq!(state.palette.text, Palette::dark().text);
+        assert_eq!(state.source_file, Some(path.clone()));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn reset_returns_to_the_default() {
+        let manager = PaletteManager::new();
+        manager.load_builtin("Nord").unwrap();
+        assert!(manager.current(true).name.is_some());
+        manager.reset();
+        assert_eq!(manager.current(true).name, None);
+    }
+
+    #[test]
+    fn unknown_builtin_is_an_error() {
+        let manager = PaletteManager::new();
+        assert!(manager.load_builtin("Nonexistent").is_err());
+    }
+
+    #[test]
+    fn supports_transparency_in_a_theme_color() {
+        let dir = std::env::temp_dir().join(format!("fastpotify-palette-test-alpha-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("theme.json");
+        std::fs::write(&path, r##"{"name":"T","dark":{"overlay":"#00000080"}}"##).unwrap();
+
+        let manager = PaletteManager::new();
+        manager.load_from_file(&path).unwrap();
+        let alpha = manager.current(true).palette.overlay.a();
+        assert_eq!(alpha, 0x80);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn expands_a_leading_tilde_against_home() {
+        if std::env::var_os("HOME").is_none() {
+            return; // nothing to expand against on this runner
+        }
+        let dir = tempdir_under_home("fastpotify-palette-test-tilde");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("theme.json");
+        std::fs::write(&path, r##"{"name":"Tilde"}"##).unwrap();
+
+        let home = std::env::var("HOME").unwrap();
+        let relative = path.strip_prefix(&home).unwrap();
+        let tilde_path = PathBuf::from("~").join(relative);
+
+        let manager = PaletteManager::new();
+        manager.load_from_file(&tilde_path).unwrap();
+        assert_eq!(manager.current(true).name.as_deref(), Some("Tilde"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A directory under `$HOME` for the tilde-expansion test, so the test
+    /// path and `HOME` agree regardless of the platform's temp dir.
+    fn tempdir_under_home(name: &str) -> PathBuf {
+        let home = std::env::var("HOME").expect("HOME is set");
+        PathBuf::from(home).join(format!("{name}-{}", std::process::id()))
+    }
+}

--- a/src/palette/mod.rs
+++ b/src/palette/mod.rs
@@ -1,0 +1,77 @@
+//! Custom colour palettes: hex-defined themes loaded from a JSON file or
+//! picked from the built-in set, with transparency support via the alpha
+//! channel. See [`PaletteManager`] for the entry point the app holds.
+
+mod builtin;
+mod colors;
+mod manager;
+mod theme_file;
+
+pub use builtin::BUILTIN_PALETTES;
+pub use colors::{ColorError, parse_hex_color};
+pub use manager::{PaletteManager, PaletteState};
+pub use theme_file::{ThemeColors, ThemeFile};
+
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, PaletteError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PaletteError {
+    #[error("could not read palette file {path}: {source}")]
+    ReadFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("could not parse palette file {path}: {source}")]
+    ParseFile {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("invalid color '{0}'")]
+    InvalidColor(String),
+    #[error("palette '{0}' not found")]
+    NotFound(String),
+}
+
+impl From<ColorError> for PaletteError {
+    fn from(error: ColorError) -> Self {
+        PaletteError::InvalidColor(error.0)
+    }
+}
+
+/// Overlays `colors` onto `base`, one field at a time; a `None` field keeps
+/// `base`'s value. This is how a custom theme file only needs to name the
+/// colours it wants to change.
+fn resolve(base: crate::theme::Palette, colors: &ThemeColors) -> Result<crate::theme::Palette> {
+    use crate::theme::Palette;
+
+    macro_rules! field {
+        ($name:ident) => {
+            match &colors.$name {
+                Some(hex) => parse_hex_color(hex)?,
+                None => base.$name,
+            }
+        };
+    }
+
+    Ok(Palette {
+        dark: base.dark,
+        window: field!(window),
+        panel: field!(panel),
+        surface: field!(surface),
+        surface_hover: field!(surface_hover),
+        surface_active: field!(surface_active),
+        outline: field!(outline),
+        text: field!(text),
+        secondary: field!(secondary),
+        dim: field!(dim),
+        accent: field!(accent),
+        accent_hover: field!(accent_hover),
+        on_accent: field!(on_accent),
+        danger: field!(danger),
+        warning: field!(warning),
+        overlay: field!(overlay),
+        shadow: field!(shadow),
+    })
+}

--- a/src/palette/theme_file.rs
+++ b/src/palette/theme_file.rs
@@ -1,0 +1,38 @@
+//! The on-disk shape of a custom palette: a name and up to two colour sets,
+//! one per mode. Every colour is optional; anything left out falls back to
+//! the built-in dark or light palette.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ThemeFile {
+    pub name: String,
+    #[serde(default)]
+    pub dark: ThemeColors,
+    #[serde(default)]
+    pub light: ThemeColors,
+}
+
+/// Hex colour strings (`#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`), one field
+/// per [`crate::theme::Palette`] colour. `dark`/`bool` isn't here: it's
+/// which set applies, not a colour.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ThemeColors {
+    pub window: Option<String>,
+    pub panel: Option<String>,
+    pub surface: Option<String>,
+    pub surface_hover: Option<String>,
+    pub surface_active: Option<String>,
+    pub outline: Option<String>,
+    pub text: Option<String>,
+    pub secondary: Option<String>,
+    pub dim: Option<String>,
+    pub accent: Option<String>,
+    pub accent_hover: Option<String>,
+    pub on_accent: Option<String>,
+    pub danger: Option<String>,
+    pub warning: Option<String>,
+    pub overlay: Option<String>,
+    pub shadow: Option<String>,
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 //! User preferences, stored as one readable JSON file.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -62,6 +62,9 @@ pub struct Settings {
     pub audio_cache: bool,
     pub audio_cache_mb: u64,
     pub theme: ThemeChoice,
+    /// A custom colour palette file, loaded over the built-in dark/light
+    /// palette. `None` uses the built-in palette only.
+    pub palette_file: Option<PathBuf>,
     /// Tint the interface with the colour of the playing album's art.
     pub accent_from_art: bool,
     /// Last local volume, 0..=65535.
@@ -157,6 +160,7 @@ impl Default for Settings {
             audio_cache: true,
             audio_cache_mb: 1024,
             theme: ThemeChoice::Dark,
+            palette_file: None,
             accent_from_art: true,
             volume: (u16::MAX as u32 * 70 / 100) as u16,
             sidebar_visible: true,
@@ -347,6 +351,23 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
         assert!(restored.tracklist_compact);
+    }
+
+    #[test]
+    fn older_settings_have_no_palette_file() {
+        let settings: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(settings.palette_file, None);
+    }
+
+    #[test]
+    fn palette_file_round_trips() {
+        let settings = Settings {
+            palette_file: Some("/home/user/theme.json".into()),
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.palette_file, settings.palette_file);
     }
 }
 

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -97,6 +97,12 @@ pub enum ControlCommand {
     /// Refresh the device list. Sent by the `devices` read, which answers
     /// from a snapshot that is only as fresh as the app's last look.
     RefreshDevices,
+    /// Load a custom colour palette from this JSON file.
+    SetPalette(std::path::PathBuf),
+    /// Re-read the active palette's file from disk.
+    ReloadPalette,
+    /// Drop the active palette, back to the built-in default.
+    ResetPalette,
 }
 
 /// Holds whatever marks this process as the running instance. Dropping it
@@ -346,6 +352,9 @@ fn parse(line: &str) -> Option<Request> {
         ("save-toggle", None) => ControlCommand::ToggleSaved,
         ("play-uri", Some(uri)) => ControlCommand::PlayUri(spotify_uri(uri)?),
         ("transfer", Some(id)) => ControlCommand::Transfer(device_id(id)?),
+        ("palette-set", Some(path)) => ControlCommand::SetPalette(file_path(path)?.into()),
+        ("palette-reload", None) => ControlCommand::ReloadPalette,
+        ("palette-reset", None) => ControlCommand::ResetPalette,
         ("nowplaying", None) => return Some(Request::NowPlaying),
         ("devices", None) => return Some(Request::Devices),
         _ => return None,
@@ -377,6 +386,16 @@ fn device_id(text: &str) -> Option<String> {
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'));
     shaped.then(|| text.to_owned())
+}
+
+/// A file path argument, shaped enough to be worth trying: non-empty, no
+/// control characters, and short enough to have come from a command line
+/// rather than an attempt to overrun the read buffer.
+#[cfg(not(target_os = "linux"))]
+fn file_path(text: &str) -> Option<&str> {
+    let shaped =
+        !text.is_empty() && text.len() <= 240 && !text.chars().any(|c| c.is_control());
+    shaped.then_some(text)
 }
 
 /// Reads up to the first newline. A line too long to be one of ours, or any
@@ -555,6 +574,18 @@ mod tests {
         assert_eq!(
             command("fastpotify:transfer a1b2c3d4e5"),
             Some(ControlCommand::Transfer("a1b2c3d4e5".to_owned()))
+        );
+        assert_eq!(
+            command("fastpotify:palette-set /home/user/theme.json"),
+            Some(ControlCommand::SetPalette("/home/user/theme.json".into()))
+        );
+        assert_eq!(
+            command("fastpotify:palette-reload"),
+            Some(ControlCommand::ReloadPalette)
+        );
+        assert_eq!(
+            command("fastpotify:palette-reset"),
+            Some(ControlCommand::ResetPalette)
         );
         assert!(matches!(
             parse("fastpotify:nowplaying"),

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -11,6 +11,7 @@ use crate::theme::{self, Icon, Palette};
 use super::widgets;
 
 const PLAYBACK_DIRTY_ID: &str = "playback-settings-dirty";
+const PALETTE_PATH_ID: &str = "palette-file-path";
 
 fn section(
     ui: &mut egui::Ui,
@@ -442,6 +443,95 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 }
             });
         });
+
+        // Custom colour palettes: hex-defined, loaded from a JSON file or
+        // picked from the built-in set. A fresh snapshot every frame, like
+        // the rest of this page reads `app.settings` directly.
+        let palette_path_id = egui::Id::new(PALETTE_PATH_ID);
+        let palette_state = app.palette_manager.current(palette.dark);
+        let mut palette_path_text = ui
+            .data(|data| data.get_temp::<String>(palette_path_id))
+            .unwrap_or_else(|| {
+                app.settings
+                    .palette_file
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default()
+            });
+
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Colour palette",
+            &match &palette_state.name {
+                Some(name) => format!("Active: {name}"),
+                None => "Using the built-in palette.".to_string(),
+            },
+            |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 6.0;
+                    if palette_state.source_file.is_some()
+                        && theme::soft_button(ui, &palette, Some(Icon::Refresh), "Reload", false)
+                            .clicked()
+                    {
+                        app.actions.push(Action::ReloadPalette);
+                    }
+                    if palette_state.name.is_some()
+                        && theme::soft_button(ui, &palette, Some(Icon::X), "Reset", false)
+                            .clicked()
+                    {
+                        app.actions.push(Action::ResetPalette);
+                    }
+                });
+            },
+        );
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Load from file",
+            "Path to a palette JSON file with hex colours. 8-digit hex (#RRGGBBAA) adds transparency.",
+            |ui| {
+                let response = Frame::new()
+                    .fill(palette.surface)
+                    .corner_radius(CornerRadius::same(6))
+                    .inner_margin(Margin::symmetric(10, 6))
+                    .show(ui, |ui| {
+                        ui.add(
+                            egui::TextEdit::singleline(&mut palette_path_text)
+                                .hint_text(
+                                    egui::RichText::new("/path/to/theme.json").color(palette.dim),
+                                )
+                                .font(theme::regular(13.0))
+                                .frame(egui::Frame::NONE)
+                                .desired_width(260.0),
+                        )
+                    })
+                    .inner;
+                let submit_on_enter = response.lost_focus()
+                    && ui.input(|input| input.key_pressed(egui::Key::Enter));
+                ui.data_mut(|data| data.insert_temp(palette_path_id, palette_path_text.clone()));
+                ui.add_space(6.0);
+                if (theme::pill_button(ui, &palette, "Load", true).clicked() || submit_on_enter)
+                    && !palette_path_text.trim().is_empty()
+                {
+                    app.actions.push(Action::LoadPalette(std::path::PathBuf::from(
+                        palette_path_text.trim(),
+                    )));
+                }
+            },
+        );
+        widgets::setting_row(ui, &palette, "Built-in palettes", "", |ui| {
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 6.0;
+                for name in app.palette_manager.list_builtins() {
+                    let active = palette_state.name.as_deref() == Some(name);
+                    if theme::soft_button(ui, &palette, None, name, active).clicked() && !active {
+                        app.actions.push(Action::LoadBuiltinPalette(name.to_string()));
+                    }
+                }
+            });
+        });
+
         widgets::setting_row(
             ui,
             &palette,


### PR DESCRIPTION
## Why

Fastpotify ships with fixed dark and light palettes. Ricers and users of tools like Noctalia/Niri who colour-match their whole desktop have no way to make Fastpotify follow a custom colour scheme, and no way to get a translucent window to fit compositor-based Wayland setups. This adds a JSON-defined palette format so the interface's colours (dark and light variants) can be customised per field, with transparency support, for blurred setups.

## What changed

- `src/palette/`: hex colour parser (`#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`), the theme file format (`ThemeFile`/`ThemeColors`, every field optional), two built-in palettes (Catppuccin Mocha, Nord), and `PaletteManager`, which resolves a theme file over the built-in dark/light palette one field at a time and supports hot reload.
- `Settings` gains `palette_file: Option<PathBuf>`, persisted and loaded like any other preference; `~` in a path is expanded against `$HOME`.
- Settings → Appearance gains a "Colour palette" section: a text field to load a theme from a JSON file, Reload (re-reads the active file from disk), Reset (back to the built-in default), and buttons for the built-in palettes.
- The remote control channel gains `palette-set <path>`, `palette-reload`, and `palette-reset` verbs, following the channel's existing scope (macOS/Windows only; Linux already routes control through MPRIS instead and is unaffected).
- The main window now allows OS compositing transparency (`with_transparent(true)`), and its clear colour follows the active palette's `window` colour, alpha included, instead of a hardcoded value. Built-in and named palettes never set alpha below 255 on `window`, so default behaviour is visually unchanged; only a custom palette that sets a translucent `window` shows the desktop behind it.

## Verification

Tested manually on CachyOS Linux (Niri WM, egui/eframe) with a custom Nord/Catppuccin-derived theme file:

- Loading a theme by path, including with a leading `~`.
- Reload after editing the file on disk, without restarting.
- Reset back to the built-in palette.
- Switching between the two built-in palettes.
- 8-digit hex alpha on `overlay`, `shadow`, and `window`, confirming the main window shows the desktop behind it when `window` is translucent, and stays opaque with the built-in palettes.
- `cargo test --locked --all-targets`: 191 passed, including new `palette::colors`, `palette::manager`, and `settings` tests.

Not exercised: the remote-control `palette-*` verbs, since those only run
on macOS/Windows.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.