### PR TITLE
Fix Nix package build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,20 @@ jobs:
               Select-Object -ExpandProperty FullName
           }
 
+  nix:
+    name: Nix package
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: wimpysworld/nothing-but-nix@v9
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+      - run: nix build .#default
+
   docs:
     name: docs
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,13 @@
               cargo = toolchain;
               rustc = toolchain;
             };
+            cmakeWithLibdir = pkgs.writeShellScript "cmake-fastpotify" ''
+              if [[ "$1" == "--build" ]]; then
+                exec ${pkgs.cmake}/bin/cmake "$@"
+              else
+                exec ${pkgs.cmake}/bin/cmake "$@" -DCMAKE_INSTALL_LIBDIR=lib
+              fi
+            '';
             runtimeLibs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
               with pkgs;
               [
@@ -109,7 +116,15 @@
             pname = "fastpotify";
             version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
             src = self;
-            cargoLock.lockFile = ./Cargo.lock;
+
+            # The lock file contains git dependencies. fetchCargoVendor includes
+            # them in the fixed-output dependency tree, unlike cargoLock alone.
+            cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+              pname = "fastpotify";
+              version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
+              src = self;
+              hash = "sha256-e/uJwqYszz7ASo5elWcTIX6Smb0xJgQZA5fgHuwvzaE=";
+            };
 
             nativeBuildInputs =
               with pkgs;
@@ -127,11 +142,17 @@
                 [
                   alsa-lib
                   libpulseaudio
-                  # libprojectM links OpenGL directly.
+                  # libprojectM links OpenGL directly and its GL loader needs
+                  # X11 headers while it is built.
                   libGL
+                  libx11
                 ]
               )
               ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk ];
+
+            # projectm-sys expects CMake to install into lib/, while CMake
+            # defaults to lib64/ on NixOS.
+            env.CMAKE = "${cmakeWithLibdir}";
 
             # The GUI dlopens its Wayland, X11 and GL libraries at run time.
             postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
## Why

`nix build .#fastpotify` fails when Cargo tries to vendor the git dependencies in `Cargo.lock`. On NixOS, the MilkDrop dependency also needs X11 headers at build time and installs its library under `lib64` while `projectm-sys` expects `lib`.

## What changed

- Use `fetchCargoVendor` so the git dependencies are included in the fixed-output dependency tree.
- Add `libx11` to the Linux build inputs.
- Wrap CMake to set `CMAKE_INSTALL_LIBDIR=lib` during configuration while leaving `cmake --build` unchanged.

## Verification

- `nix flake check --no-build`
- `nix build .#fastpotify --no-link -L` (x86_64-linux; 211 tests passed)
- `nix fmt`
- `git diff --check`

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [ ] I added or updated tests for behaviour that can regress. (Packaging-only change.)
- [ ] I ran formatting, Clippy, and the relevant tests locally. (The relevant Nix package tests were run; Clippy was not run because this is a packaging-only change.)
- [x] I updated documentation for user-visible behaviour, settings, files, or network access. (Not applicable.)
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
