### PR TITLE
Load Now Playing artwork from the disk cache, not the network

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 //! The application: state, event handling, and the actions views ask for.
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use egui::Color32;
@@ -133,6 +134,10 @@ pub struct App {
     last_settings_save: Instant,
     pub backend: Backend,
     media_controls: Option<MediaService>,
+    /// The artwork the media controls were last given, and the URL it came
+    /// from. Finding the file touches the disk and the controls are synced
+    /// every frame, so the answer is kept until the artwork changes.
+    media_art: Option<(String, PathBuf)>,
     tray: Option<TrayService>,
     pub window_hidden: bool,
     /// The window should close but the process should stay in the tray.
@@ -416,6 +421,7 @@ impl App {
             last_settings_save: Instant::now(),
             backend,
             media_controls,
+            media_art: None,
             tray,
             window_hidden: false,
             hide_intent: false,
@@ -1921,7 +1927,27 @@ impl App {
         }
     }
 
+    /// The downloaded file for `url`, once the art cache has it.
+    ///
+    /// The media controls are handed a file rather than the URL, so the disk
+    /// is asked until the download lands and the answer remembered after
+    /// that; see `media_native::file_url` for why a URL will not do.
+    fn media_art_file(&mut self, url: &str) -> Option<PathBuf> {
+        if let Some((known, file)) = &self.media_art
+            && known == url
+        {
+            return Some(file.clone());
+        }
+        let file = self.backend.art().cached_file(url)?;
+        self.media_art = Some((url.to_owned(), file.clone()));
+        Some(file)
+    }
+
     fn sync_media_controls(&mut self) {
+        let art_file = self
+            .now_playing()
+            .and_then(|now| now.art_url)
+            .and_then(|url| self.media_art_file(&url));
         let state = match self.now_playing() {
             Some(now) => MediaState {
                 playback: if now.playing {
@@ -1941,6 +1967,7 @@ impl App {
                         .collect(),
                     album: now.album_name.clone(),
                     art_url: now.art_url.clone(),
+                    art_file,
                     duration_ms: now.duration_ms,
                 }),
                 position_ms: now.position_ms,
@@ -4813,6 +4840,10 @@ impl App {
             Action::ClearArtCache => match self.backend.art().clear_disk_cache() {
                 Ok(bytes) => {
                     ctx.forget_all_images();
+                    // The media controls hold a path into what was just
+                    // deleted; forget it, or the next sync hands the system
+                    // a file that is no longer there.
+                    self.media_art = None;
                     self.toast(format!(
                         "Cleared {:.1} MB of artwork",
                         bytes as f64 / 1_048_576.0
@@ -6735,6 +6766,39 @@ mod tests {
             app.control_devices_snapshot(),
             crate::single_instance::NO_DEVICES
         );
+    }
+
+    /// The media controls are handed a downloaded file, never a URL: macOS
+    /// loads cover art itself and dereferences a failed load without
+    /// checking it, so a URL that does not answer aborts the process. The
+    /// sync runs every frame, so the answer is remembered -- which means
+    /// emptying the cache has to forget it, or the path outlives the file.
+    #[test]
+    fn the_media_controls_only_hear_about_artwork_that_exists() {
+        // #given
+        let mut app = headless_app();
+        let ctx = egui::Context::default();
+        let url = "https://i.scdn.co/image/abc";
+        let file = app.dirs.cache.join("art").join("0badc0de");
+        std::fs::create_dir_all(file.parent().expect("a parent")).expect("the art cache");
+        std::fs::write(&file, b"jpeg-ish").expect("a cached file");
+
+        // #then nothing has been downloaded for this song yet
+        assert_eq!(app.media_art_file(url), None);
+
+        // #when the cache holds it, that file is what the controls are told
+        app.media_art = Some((url.to_owned(), file.clone()));
+        assert_eq!(app.media_art_file(url), Some(file.clone()));
+
+        // #then another song is not covered by what is remembered
+        assert_eq!(app.media_art_file("https://i.scdn.co/image/def"), None);
+
+        // #when the artwork cache is emptied, the remembered path goes too
+        app.actions.push(Action::ClearArtCache);
+        app.apply_actions(&ctx);
+        assert_eq!(app.media_art, None, "a path into a deleted cache");
+
+        let _ = std::fs::remove_file(&file);
     }
 
     /// The device slot is written when Spotify answers rather than every

--- a/src/images.rs
+++ b/src/images.rs
@@ -77,6 +77,20 @@ impl ArtLoader {
         }
     }
 
+    /// The disk-cache file holding `url`'s artwork, once it has been fetched.
+    ///
+    /// The cache is written atomically (a `.part` file, then a rename), so a
+    /// file that is here at all holds a complete, successful response. The
+    /// desktop media controls hand this path to the platform instead of the
+    /// remote URL: macOS loads cover art itself, synchronously, inside a
+    /// callback that cannot report a failure.
+    pub fn cached_file(&self, url: &str) -> Option<PathBuf> {
+        let path = self.inner.cache_path(url);
+        std::fs::metadata(&path)
+            .is_ok_and(|meta| meta.is_file() && meta.len() > 0)
+            .then_some(path)
+    }
+
     pub fn clear_disk_cache(&self) -> std::io::Result<u64> {
         let mut removed = 0;
         for entry in std::fs::read_dir(&self.inner.cache_dir)? {
@@ -267,6 +281,38 @@ pub fn accent_color(bytes: &[u8]) -> Option<[u8; 3]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The media controls ask for a file rather than a URL, and have to be
+    /// told "not yet" rather than handed a path to nothing: macOS loads cover
+    /// art itself and dereferences a failed load without checking it, which
+    /// takes the whole process with it.
+    #[test]
+    fn a_cached_file_is_named_only_once_it_is_really_there() {
+        let dir = std::env::temp_dir().join(format!("fastpotify-art-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("a runtime to hand the loader");
+        let loader = ArtLoader::new(
+            reqwest::Client::new(),
+            runtime.handle().clone(),
+            dir.clone(),
+        );
+        let url = "https://i.scdn.co/image/abc";
+
+        assert_eq!(loader.cached_file(url), None, "nothing downloaded yet");
+
+        // A half-written download never appears under its real name -- the
+        // cache renames one into place -- but an empty file is not artwork.
+        let path = loader.inner.cache_path(url);
+        std::fs::write(&path, b"").expect("an empty file");
+        assert_eq!(loader.cached_file(url), None, "empty is not artwork");
+
+        std::fs::write(&path, b"\xff\xd8\xff jpeg-ish").expect("a file with bytes");
+        assert_eq!(loader.cached_file(url), Some(path));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn accent_color_finds_dominant_hue() {

--- a/src/media.rs
+++ b/src/media.rs
@@ -4,6 +4,8 @@
 //! Playing on macOS answer the same questions, so the interface speaks this
 //! vocabulary and each platform module translates it.
 
+use std::path::PathBuf;
+
 use crate::player::{Playback, RepeatMode};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -31,6 +33,11 @@ pub struct MediaTrack {
     pub artists: Vec<String>,
     pub album: String,
     pub art_url: Option<String>,
+    /// The same artwork on disk, once the art cache holds it. Windows and
+    /// macOS take this rather than `art_url`, because they load the image
+    /// themselves; MPRIS only passes the URL along, so Linux keeps using
+    /// `art_url`.
+    pub art_file: Option<PathBuf>,
     pub duration_ms: u32,
 }
 

--- a/src/media_native.rs
+++ b/src/media_native.rs
@@ -9,6 +9,7 @@
 //! closing to the tray. macOS needs none of that: its handlers run on the
 //! main thread, which the headless loop in `main` keeps pumping.
 
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::time::Duration;
@@ -25,6 +26,41 @@ type Wake = Arc<dyn Fn() + Send + Sync>;
 
 /// How far a seek button without an amount moves.
 const SEEK_STEP_MS: i64 = 10_000;
+
+/// Where cover art lives, in the spelling each platform reads back.
+///
+/// Only ever a local file. Handed a remote URL, macOS fetches it itself,
+/// synchronously, on a queue of its own, and dereferences the result without
+/// checking it: artwork that fails to arrive -- an offline laptop, a slow
+/// network, a CDN with a bad minute -- aborts the process from inside a
+/// callback that cannot unwind. So the art cache downloads it first and this
+/// names the file.
+///
+/// The two platforms want different spellings after `file://`. macOS parses
+/// the whole thing as a URL, so anything URL-significant in the path has to
+/// be escaped or it silently reads as a fragment and the load fails the same
+/// way. Windows takes the remainder as a plain path and opens it as-is, so
+/// escaping it there would break it instead.
+#[cfg(target_os = "macos")]
+fn file_url(path: &Path) -> String {
+    use std::fmt::Write;
+    let mut url = String::from("file://");
+    for byte in path.to_string_lossy().bytes() {
+        match byte {
+            b'/' | b'-' | b'.' | b'_' | b'~' => url.push(byte as char),
+            _ if byte.is_ascii_alphanumeric() => url.push(byte as char),
+            _ => {
+                let _ = write!(url, "%{byte:02X}");
+            }
+        }
+    }
+    url
+}
+
+#[cfg(not(target_os = "macos"))]
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
 
 fn command_for(event: MediaControlEvent, track_uri: &str) -> Option<MediaCommand> {
     let step = |direction: SeekDirection, ms: i64| match direction {
@@ -105,12 +141,21 @@ impl Bridge {
                 .as_ref()
                 .map(|track| track.uri.clone())
                 .unwrap_or_default();
+            // Never a remote URL: see `file_url`. Artwork that has not been
+            // downloaded yet is simply left out, and the next state with the
+            // file in place sets it, because `MediaTrack` compares equal only
+            // while the art file is the same one.
+            let cover = state
+                .track
+                .as_ref()
+                .and_then(|track| track.art_file.as_deref())
+                .map(file_url);
             let metadata = match &state.track {
                 Some(track) => MediaMetadata {
                     title: Some(track.title.as_str()),
                     album: Some(track.album.as_str()),
                     artist: Some(artist.as_str()),
-                    cover_url: track.art_url.as_deref(),
+                    cover_url: cover.as_deref(),
                     duration: Some(Duration::from_millis(u64::from(track.duration_ms))),
                 },
                 None => MediaMetadata::default(),
@@ -358,5 +403,66 @@ impl MediaService {
         {
             act(bridge);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cover art is never handed over as a network URL. macOS loads whatever
+    /// it is given synchronously and dereferences the result unchecked, so a
+    /// fetch that fails takes the process with it.
+    #[test]
+    fn artwork_is_a_local_file() {
+        let url = file_url(Path::new("/tmp/fastpotify/art/0badc0de"));
+        assert!(url.starts_with("file://"));
+        assert!(!url.starts_with("http"));
+    }
+
+    /// macOS parses the whole string as a URL. A `#` in the path -- a home
+    /// directory is enough to put one there -- ends it early, the image comes
+    /// back nil, and the unchecked dereference aborts. Escaping is what keeps
+    /// the path a path.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_macos_url_escapes_what_a_url_would_read() {
+        assert_eq!(
+            file_url(Path::new("/Users/ada #1/Caches/art/0badc0de")),
+            "file:///Users/ada%20%231/Caches/art/0badc0de"
+        );
+        // Separators and the unreserved set stay legible.
+        assert_eq!(
+            file_url(Path::new("/a-b/c.d/e_f~g/0badc0de")),
+            "file:///a-b/c.d/e_f~g/0badc0de"
+        );
+    }
+
+    /// Windows takes the remainder as a plain path and opens it directly, so
+    /// escaping it there would break the very case it fixes on macOS.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn a_windows_url_keeps_the_path_as_written() {
+        assert_eq!(
+            file_url(Path::new(r"C:\Users\ada #1\art\0badc0de")),
+            r"file://C:\Users\ada #1\art\0badc0de"
+        );
+    }
+
+    /// Artwork arrives after the song does. The bridge sets the metadata
+    /// again when it lands, which works only because a track carrying the
+    /// file differs from the same track without it.
+    #[test]
+    fn art_arriving_is_a_change_worth_sending() {
+        let bare = crate::media::MediaTrack {
+            uri: "spotify:track:1".to_owned(),
+            art_url: Some("https://i.scdn.co/image/abc".to_owned()),
+            ..Default::default()
+        };
+        let with_art = crate::media::MediaTrack {
+            art_file: Some(std::path::PathBuf::from("/tmp/fastpotify/art/0badc0de")),
+            ..bare.clone()
+        };
+        assert_ne!(bare, with_art);
     }
 }


### PR DESCRIPTION
## The problem

On macOS, Fastpotify aborts when cover art fails to load.

`media_native.rs` passed `track.art_url` — an `i.scdn.co` URL — to souvlaki as
`cover_url`. souvlaki's macOS backend fetches that itself, synchronously, on a
GCD queue, and then dereferences the result **without checking it**:

```rust
// souvlaki-0.8.3/src/platform/macos/mod.rs:320
unsafe fn load_image_from_url(url: &str) -> (id, CGSize) {
    let url = ns_url(url);
    let image: id = msg_send!(class!(NSImage), alloc);
    let image: id = msg_send!(image, initWithContentsOfURL: url);
    let size: CGSize = msg_send!(image, size);   // <-- nil here
    (image, CGSize::new(size.width, size.height))
}
```

The iOS branch twenty lines above does check for nil. The macOS one does not,
so a struct-returning message to `nil` panics inside an Objective-C callback
that cannot unwind, and the process aborts:

```
thread '<unnamed>' panicked at souvlaki-0.8.3/src/platform/macos/mod.rs:324:24:
null pointer dereference occurred
thread caused non-unwinding panic. aborting.
```

Any track change where the artwork fetch fails takes the whole app down, and
the music with it — an offline laptop, a slow network, a CDN having a bad
minute. It is not `panic = "abort"`; the callback cannot unwind either way.

I hit this through demo mode, where `picsum.photos` was returning 503 — **two
of three launches aborted**. Verified in isolation that the trigger is exactly
what it looks like:

```swift
NSImage(contentsOf: URL(string: "https://picsum.photos/seed/fastpotify0/640/640")!)
// -> nil
```

## The fix

Stop handing the platform a URL. `ArtLoader` has already downloaded the image
and written it atomically (`.part`, then rename), so a file that is present is
a complete, successful response — name that file instead.

- `ArtLoader::cached_file` reports the disk-cache file once it really exists
  and is non-empty.
- `MediaTrack` gains `art_file`. Windows and macOS use it; **Linux is
  untouched** — MPRIS passes the URL along for someone else to fetch and never
  dereferences anything, so it keeps using `art_url`.
- Artwork that has not landed yet is simply left out, and set when it arrives:
  `MediaTrack` derives `PartialEq`, so a track carrying the file differs from
  the same track without it and the existing change detection re-sends.

Two details worth flagging for review:

**The two platforms spell the file differently after `file://`.** macOS parses
the whole string as a URL, so anything URL-significant has to be escaped or the
load fails the same way — I confirmed a `#` in the path (a home directory is
enough to put one there) returns nil and aborts, while the escaped form loads.
Windows trims the prefix and opens the remainder as a plain path, where
escaping would break it. Hence the `cfg` split in `file_url`.

**The controls are synced every frame**, so resolving the file is memoised
rather than stat-ing the disk 60 times a second. That means clearing the
artwork cache has to forget it too, or the remembered path outlives the file
and reintroduces the crash by another door — `Action::ClearArtCache` now does.

## Verification

- **8/8 clean launches** under the condition that aborted 2 of 3 before
  (`picsum.photos` returning 522 throughout).
- 5 new tests: the escaping on each platform, the cache only naming files that
  exist, art arriving counting as a change, and the cleared cache forgetting
  the path. I checked the last one fails without its fix rather than passing
  either way.
- Full checklist from CONTRIBUTING.md green on macOS (arm64): `fmt`, both
  `clippy` runs with `-D warnings`, both `cargo test` runs, doc tests, and
  `rustdoc`. **Not run:** the Jekyll docs build (no docs change).

**Platform coverage, honestly:** built, tested, and run on macOS 26.2 (arm64)
only. Linux and Windows are reasoned about and compile-checked through the
`cfg` split — I have not run either.

## Notes

No docs change: this alters how artwork reaches the OS, not any setting, file,
or user-facing behaviour beyond artwork appearing once downloaded instead of
being fetched a second time by the system. Happy to add a line to
`how-it-connects.md` if you would rather record that the OS no longer makes its
own request for cover art.

The underlying defect is upstream in souvlaki, and this only removes
Fastpotify's way of triggering it. A nil check in `load_image_from_url` is a
few lines and I am happy to send it there too — say the word if you would
rather carry it as a `[patch.crates-io]` entry alongside the `projectm-sys` and
`librespot` ones instead of, or as well as, this.
