### PR TITLE
Add type-ahead navigation to song lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ those things, and [CONTRIBUTING.md](CONTRIBUTING.md) prohibits them.
 | `M` | Mute |
 | `S` / `R` | Shuffle / cycle repeat |
 | `Q` | Queue panel |
+| `A`–`Z` | Jump in the song list (Enter plays, Esc clears) |
 | `Ctrl+F` or `/` | Search |
 | `Ctrl+B` | Show or hide the sidebar |
 | `Alt+←` / `Alt+→` | Back or forward |
@@ -175,6 +176,18 @@ those things, and [CONTRIBUTING.md](CONTRIBUTING.md) prohibits them.
 | `Ctrl+Q` | Quit |
 
 On macOS, `Cmd` replaces `Ctrl`.
+
+Typing letters on a playlist, album, or Liked Songs page jumps to the first
+song whose title starts with what you typed, the way file explorers jump to
+files: more letters narrow the search, the same first letter again moves to
+the next match, Enter starts playing, and Esc clears it. Matching forgives
+case, accents, punctuation, spaces, and a leading The (`dont` finds
+"Don't Stop", `letit` finds "Let It Be"); Space plays or pauses until a
+search is active, then it types a space; and a Loose type-ahead setting
+also matches letters anywhere in a title — as an unbroken run first, then
+scattered in order. While such a list is
+open, `M`, `S`, `R`, `Q`, and `L` belong to that search; they keep their
+shortcuts everywhere else, and the setting can be turned off in Settings.
 
 ## Controlling it from outside
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ With Type-ahead in song lists enabled, typing letters on a playlist, album,
 or Liked Songs page jumps to the first song whose title starts with what you
 typed, the way file explorers jump to files: more letters narrow the search,
 and with Loose type-ahead off, the same first letter again moves to the next
-match. Enter starts playing; Esc or one second without typing clears it.
+match. Enter starts playing; Esc or two seconds without typing clears it.
 Matching forgives case,
 accents, punctuation, spaces, and a leading The (`dont` finds "Don't Stop",
 `letit` finds "Let It Be"); Space

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ With Type-ahead in song lists enabled, typing letters on a playlist, album,
 or Liked Songs page jumps to the first song whose title starts with what you
 typed, the way file explorers jump to files: more letters narrow the search,
 and with Loose type-ahead off, the same first letter again moves to the next
-match. Enter starts playing and Esc clears it. Matching forgives case,
+match. Enter starts playing; Esc or one second without typing clears it.
+Matching forgives case,
 accents, punctuation, spaces, and a leading The (`dont` finds "Don't Stop",
 `letit` finds "Let It Be"); Space
 plays or pauses until a search is active, then it types a space; and a Loose

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ those things, and [CONTRIBUTING.md](CONTRIBUTING.md) prohibits them.
 | `M` | Mute |
 | `S` / `R` | Shuffle / cycle repeat |
 | `Q` | Queue panel |
-| `A`–`Z` | Jump in the song list (Enter plays, Esc clears) |
+| `A`–`Z` | Jump in the song list when enabled (Enter plays, Esc clears) |
 | `Ctrl+F` or `/` | Search |
 | `Ctrl+B` | Show or hide the sidebar |
 | `Alt+←` / `Alt+→` | Back or forward |
@@ -177,17 +177,20 @@ those things, and [CONTRIBUTING.md](CONTRIBUTING.md) prohibits them.
 
 On macOS, `Cmd` replaces `Ctrl`.
 
-Typing letters on a playlist, album, or Liked Songs page jumps to the first
-song whose title starts with what you typed, the way file explorers jump to
-files: more letters narrow the search, the same first letter again moves to
-the next match, Enter starts playing, and Esc clears it. Matching forgives
-case, accents, punctuation, spaces, and a leading The (`dont` finds
-"Don't Stop", `letit` finds "Let It Be"); Space plays or pauses until a
-search is active, then it types a space; and a Loose type-ahead setting
-also matches letters anywhere in a title — as an unbroken run first, then
-scattered in order. While such a list is
-open, `M`, `S`, `R`, `Q`, and `L` belong to that search; they keep their
-shortcuts everywhere else, and the setting can be turned off in Settings.
+With Type-ahead in song lists enabled, typing letters on a playlist, album,
+or Liked Songs page jumps to the first song whose title starts with what you
+typed, the way file explorers jump to files: more letters narrow the search,
+and with Loose type-ahead off, the same first letter again moves to the next
+match. Enter starts playing and Esc clears it. Matching forgives case,
+accents, punctuation, spaces, and a leading The (`dont` finds "Don't Stop",
+`letit` finds "Let It Be"); Space
+plays or pauses until a search is active, then it types a space; and a Loose
+type-ahead setting also matches letters anywhere in a title — as an unbroken
+run first, then scattered in order. A letter cannot be both a search and a
+shortcut, so while such a list is open, `M`, `S`, `R`, `Q`, and `L` type into
+the search instead of controlling mute, shuffle, repeat, queue, and lyrics.
+Those shortcuts keep working everywhere else. Type-ahead is off by default
+and can be enabled in Settings.
 
 ## Controlling it from outside
 

--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -1,6 +1,6 @@
 ---
 title: Everyday Use
-description: Library ordering and local play history.
+description: Library ordering, local play history, and type-ahead navigation.
 nav_order: 3
 ---
 
@@ -21,3 +21,15 @@ Paused time and seeking do not count.
 
 The local list is stored in `history.json` and is never uploaded. Settings →
 Storage shows its location and has a **Clear history** button.
+
+## Jumping to a song by typing
+
+Enable **Type-ahead in song lists** in Settings to let plain letters jump to
+matching titles in playlists, albums, Liked Songs, and Top Songs. The match
+ignores case, accents, punctuation, spaces, and leading articles. **Loose
+type-ahead** also finds an unbroken run or letters scattered in order.
+
+The matched row is highlighted. Enter plays it, Backspace edits the query,
+and Escape or two seconds without typing clears it. Because a letter cannot
+be both search text and a shortcut, `M`, `S`, `R`, `Q`, and `L` do not run
+their usual shortcuts on those pages while type-ahead is enabled.

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -55,8 +55,8 @@ main fields are:
 | `accent_from_art` | `true` | Tint pages with album art |
 | `sidebar_compact` | `false` | Names only in the library sidebar, no covers |
 | `tracklist_compact` | `false` | One-line track rows without covers |
-| `typeahead_jump` | `true` | Plain typing jumps to matching songs in track lists |
-| `typeahead_loose` | `false` | Also match typed letters elsewhere in a title, in order |
+| `typeahead_jump` | `false` | Plain typing jumps to matching songs in track lists |
+| `typeahead_loose` | `true` | Also match typed letters elsewhere in a title, in order |
 | `winamp_window` | `false` | The window is the Winamp mini player |
 | `skin` | none | File or folder name in the skins folder; blank uses the built-in skin |
 | `skin_scale` | by display | Screen pixels per skin pixel, 1 to 4 |

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -55,6 +55,8 @@ main fields are:
 | `accent_from_art` | `true` | Tint pages with album art |
 | `sidebar_compact` | `false` | Names only in the library sidebar, no covers |
 | `tracklist_compact` | `false` | One-line track rows without covers |
+| `typeahead_jump` | `true` | Plain typing jumps to matching songs in track lists |
+| `typeahead_loose` | `false` | Also match typed letters elsewhere in a title, in order |
 | `winamp_window` | `false` | The window is the Winamp mini player |
 | `skin` | none | File or folder name in the skins folder; blank uses the built-in skin |
 | `skin_scale` | by display | Screen pixels per skin pixel, 1 to 4 |

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -468,6 +468,13 @@ impl PlayableItem {
     pub fn is_track(&self) -> bool {
         matches!(self, Self::Track(_))
     }
+
+    pub fn is_available(&self) -> bool {
+        match self {
+            Self::Track(track) => track.is_playable != Some(false) && !track.is_local,
+            Self::Episode(_) => true,
+        }
+    }
 }
 
 /// An entry in a playlist. `item` is the 2026 name, `track` the classic one.

--- a/src/app.rs
+++ b/src/app.rs
@@ -218,6 +218,9 @@ pub struct App {
     pub recents_view: Vec<crate::api::models::PlayHistory>,
     pub recents_generation: u64,
     pub queue_tab: QueueTab,
+    /// Changes whenever account-scoped data is discarded, so UI caches
+    /// cannot reuse rows from the previous account.
+    pub data_revision: u64,
     pub search: SearchState,
     pub playlist_pages: HashMap<String, PlaylistPage>,
     load_generation: u64,
@@ -489,6 +492,7 @@ impl App {
                 .as_deref()
                 .and_then(QueueTab::decode)
                 .unwrap_or_default(),
+            data_revision: 0,
             search: SearchState::default(),
             playlist_pages: HashMap::new(),
             load_generation: 0,
@@ -1140,6 +1144,7 @@ impl App {
     }
 
     fn reset_data(&mut self) {
+        self.data_revision = self.data_revision.wrapping_add(1);
         self.library = Library::default();
         self.home = HomeData::default();
         self.playlist_pages.clear();
@@ -3108,6 +3113,7 @@ impl App {
                 {
                     return;
                 }
+                let succeeded = result.is_ok();
                 let mut uris = Vec::new();
                 let mut adders: Vec<String> = Vec::new();
                 if let Some(page) = self.playlist_pages.get_mut(&id) {
@@ -3168,7 +3174,7 @@ impl App {
                     });
                 }
                 // A sorted table means the whole list, not the loaded part.
-                if self.table_sorts.contains_key(&Page::Playlist(id.clone())) {
+                if succeeded && self.table_sorts.contains_key(&Page::Playlist(id.clone())) {
                     self.load_more(Page::Playlist(id));
                 }
             }
@@ -3311,6 +3317,7 @@ impl App {
                 }
             },
             ApiResponse::SavedTracks { offset, result } => {
+                let succeeded = result.is_ok();
                 match result {
                     Ok(page) => {
                         for item in &page.items {
@@ -3321,7 +3328,7 @@ impl App {
                     Err(error) => self.library.liked.fail(error.to_string()),
                 }
                 // A sorted table means the whole list, not the loaded part.
-                if self.table_sorts.contains_key(&Page::LikedSongs) {
+                if succeeded && self.table_sorts.contains_key(&Page::LikedSongs) {
                     self.load_more(Page::LikedSongs);
                 }
             }
@@ -3533,6 +3540,7 @@ impl App {
                 self.request_contains(uris);
             }
             ApiResponse::AlbumTracks { id, offset, result } => {
+                let succeeded = result.is_ok();
                 let mut uris = Vec::new();
                 if let Some(page) = self.album_pages.get_mut(&id) {
                     match result {
@@ -3545,7 +3553,7 @@ impl App {
                 }
                 self.request_contains(uris);
                 // A sorted table means the whole list, not the loaded part.
-                if self.table_sorts.contains_key(&Page::Album(id.clone())) {
+                if succeeded && self.table_sorts.contains_key(&Page::Album(id.clone())) {
                     self.load_more(Page::Album(id));
                 }
             }
@@ -6707,6 +6715,29 @@ mod tests {
         );
         app.local_ready = true;
         app
+    }
+
+    #[test]
+    fn a_failed_sorted_page_waits_for_an_explicit_retry() {
+        let mut app = headless_app();
+        app.table_sorts.insert(
+            Page::LikedSongs,
+            TableSort {
+                column: SortColumn::Title,
+                ascending: true,
+            },
+        );
+        app.library.liked.loading = true;
+        app.library.liked.next_offset = Some(0);
+        app.handle_api(ApiResponse::SavedTracks {
+            offset: 0,
+            result: Err(crate::api::ApiError::Network("offline".into())),
+        });
+        assert!(!app.library.liked.loading);
+        assert_eq!(
+            app.library.liked.error.as_deref(),
+            Some("network error: offline")
+        );
     }
 
     /// Shuffle picks a random loaded track or Web API offset. Local librespot

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1589,6 +1589,13 @@ mod tests {
         (ctx, app, root)
     }
 
+    fn typeahead_settings() -> Settings {
+        Settings {
+            typeahead_jump: true,
+            ..Settings::default()
+        }
+    }
+
     fn press(ctx: &egui::Context, app: &mut App, key: egui::Key) {
         frame_events(
             ctx,
@@ -1611,7 +1618,11 @@ mod tests {
     /// the search points at, through the same plumbing a double-click uses.
     #[test]
     fn typeahead_letters_play_the_matched_row_on_enter() {
-        let (ctx, mut app, root) = playlist_app("typeahead-enter", Settings::default());
+        let settings = Settings {
+            typeahead_loose: false,
+            ..typeahead_settings()
+        };
+        let (ctx, mut app, root) = playlist_app("typeahead-enter", settings);
         // "rr": the first letter lands on the first Rosewood (trk0), the
         // second cycles to the next one (trk20), as the same letter does in
         // a file explorer.
@@ -1629,7 +1640,7 @@ mod tests {
     /// way typing works: "ro" narrows from "r" instead of starting over.
     #[test]
     fn typeahead_accumulates_across_frames() {
-        let (ctx, mut app, root) = playlist_app("typeahead-frames", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-frames", typeahead_settings());
         type_text(&ctx, &mut app, "r");
         frame(&ctx, &mut app);
         type_text(&ctx, &mut app, "o");
@@ -1647,7 +1658,7 @@ mod tests {
     /// "day", space, "b" still lands on "Day by Day".
     #[test]
     fn space_joins_an_active_search() {
-        let (ctx, mut app, root) = playlist_app("typeahead-space", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-space", typeahead_settings());
         type_text(&ctx, &mut app, "day");
         frame(&ctx, &mut app);
         // A real space arrives as a key and as text in the same frame.
@@ -1681,6 +1692,7 @@ mod tests {
     #[test]
     fn loose_typeahead_matches_letters_anywhere() {
         let settings = Settings {
+            typeahead_jump: true,
             typeahead_loose: true,
             ..Settings::default()
         };
@@ -1702,7 +1714,7 @@ mod tests {
     /// shortcuts; everywhere else they still are.
     #[test]
     fn while_a_song_list_is_open_the_plain_letters_belong_to_typeahead() {
-        let (ctx, mut app, root) = playlist_app("typeahead-gate", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-gate", typeahead_settings());
         press(&ctx, &mut app, egui::Key::L);
         assert!(
             !app.show_lyrics_panel,
@@ -1736,7 +1748,7 @@ mod tests {
     /// order, so Space joins the new query rather than toggling playback.
     #[test]
     fn first_frame_space_joins_the_query_without_toggling_playback() {
-        let (ctx, mut app, root) = playlist_app("typeahead-first-space", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-first-space", typeahead_settings());
         let playing = app.believed_playing();
         frame_events(
             &ctx,
@@ -1765,7 +1777,7 @@ mod tests {
     /// window page is a playlist, so its ordinary shortcuts keep working.
     #[test]
     fn winamp_keeps_plain_letter_shortcuts_from_a_playlist_page() {
-        let (ctx, mut app, root) = playlist_app("typeahead-winamp", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-winamp", typeahead_settings());
         app.settings.winamp_window = true;
         frame(&ctx, &mut app);
         press(&ctx, &mut app, egui::Key::L);
@@ -1778,7 +1790,7 @@ mod tests {
     /// ordinary letter shortcuts while its Retry control is showing.
     #[test]
     fn a_failed_playlist_keeps_plain_letter_shortcuts() {
-        let (ctx, mut app, root) = playlist_app("typeahead-failed", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-failed", typeahead_settings());
         app.playlist_pages.get_mut("pl1").unwrap().playlist = Loadable::Failed("offline".into());
         press(&ctx, &mut app, egui::Key::L);
         assert!(app.show_lyrics_panel);
@@ -1790,7 +1802,7 @@ mod tests {
     /// must not start playing.
     #[test]
     fn device_picker_blocks_typeahead_playback() {
-        let (ctx, mut app, root) = playlist_app("typeahead-devices", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-devices", typeahead_settings());
         type_text(&ctx, &mut app, "r");
         app.show_devices = true;
         press(&ctx, &mut app, egui::Key::Enter);
@@ -1804,7 +1816,7 @@ mod tests {
     /// listener left and later revisited.
     #[test]
     fn navigating_away_clears_the_page_typeahead() {
-        let (ctx, mut app, root) = playlist_app("typeahead-navigation", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-navigation", typeahead_settings());
         type_text(&ctx, &mut app, "r");
         app.open(Page::Home);
         frame(&ctx, &mut app);
@@ -1821,7 +1833,7 @@ mod tests {
     /// rows arrive, then resolves normally.
     #[test]
     fn typeahead_waits_for_an_initially_empty_loading_table() {
-        let (ctx, mut app, root) = playlist_app("typeahead-loading", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-loading", typeahead_settings());
         let items = {
             let page = app.playlist_pages.get_mut("pl1").unwrap();
             page.items.loading = true;
@@ -1848,7 +1860,7 @@ mod tests {
     /// being requested again every frame by an unmatched query.
     #[test]
     fn typeahead_does_not_retry_a_failed_page_automatically() {
-        let (ctx, mut app, root) = playlist_app("typeahead-error", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-error", typeahead_settings());
         app.table_sorts.insert(
             Page::Playlist("pl1".into()),
             TableSort {
@@ -1872,7 +1884,7 @@ mod tests {
     /// double-clicking a row.
     #[test]
     fn typeahead_enter_does_not_play_an_unavailable_track() {
-        let (ctx, mut app, root) = playlist_app("typeahead-unavailable", Settings::default());
+        let (ctx, mut app, root) = playlist_app("typeahead-unavailable", typeahead_settings());
         let page = app.playlist_pages.get_mut("pl1").unwrap();
         let item = &mut page.items.items[0];
         let playable = item.item.as_mut().or(item.track.as_mut()).unwrap();

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1558,4 +1558,332 @@ mod tests {
         let older: Settings = serde_json::from_str("{}").unwrap();
         assert!(older.sidebar_order.is_empty());
     }
+
+    /// An app with the sample data, the playlist page open, and a couple of
+    /// frames drawn, for the keyboard tests below.
+    fn playlist_app(name: &str, settings: Settings) -> (egui::Context, App, std::path::PathBuf) {
+        let root = std::env::temp_dir().join(format!("fastpotify-{name}-{}", std::process::id()));
+        let dirs = AppDirs {
+            config: root.join("config"),
+            state: root.join("state"),
+            cache: root.join("cache"),
+        };
+        let ctx = egui::Context::default();
+        let waker = crate::backend::Waker::default();
+        waker.attach(&ctx);
+        let mut app = App::new(
+            &waker,
+            dirs,
+            settings,
+            AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        );
+        app.attach(&ctx);
+        populate(&mut app);
+        app.open(Page::Playlist("pl1".into()));
+        for _ in 0..3 {
+            frame(&ctx, &mut app);
+        }
+        (ctx, app, root)
+    }
+
+    fn press(ctx: &egui::Context, app: &mut App, key: egui::Key) {
+        frame_events(
+            ctx,
+            app,
+            vec![egui::Event::Key {
+                key,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+        );
+    }
+
+    fn type_text(ctx: &egui::Context, app: &mut App, text: &str) {
+        frame_events(ctx, app, vec![egui::Event::Text(text.into())]);
+    }
+
+    /// Typing on a playlist page jumps the list, and Enter plays the row
+    /// the search points at, through the same plumbing a double-click uses.
+    #[test]
+    fn typeahead_letters_play_the_matched_row_on_enter() {
+        let (ctx, mut app, root) = playlist_app("typeahead-enter", Settings::default());
+        // "rr": the first letter lands on the first Rosewood (trk0), the
+        // second cycles to the next one (trk20), as the same letter does in
+        // a file explorer.
+        type_text(&ctx, &mut app, "rr");
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(
+            app.play_pending("spotify:track:trk20"),
+            "Enter should play the row the search points at"
+        );
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Letters typed in separate frames accumulate into one search, the
+    /// way typing works: "ro" narrows from "r" instead of starting over.
+    #[test]
+    fn typeahead_accumulates_across_frames() {
+        let (ctx, mut app, root) = playlist_app("typeahead-frames", Settings::default());
+        type_text(&ctx, &mut app, "r");
+        frame(&ctx, &mut app);
+        type_text(&ctx, &mut app, "o");
+        frame(&ctx, &mut app);
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(
+            app.play_pending("spotify:track:trk0"),
+            "'ro' should keep the first Rosewood while it still matches"
+        );
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A space keypress mid-search joins the text instead of ending it:
+    /// "day", space, "b" still lands on "Day by Day".
+    #[test]
+    fn space_joins_an_active_search() {
+        let (ctx, mut app, root) = playlist_app("typeahead-space", Settings::default());
+        type_text(&ctx, &mut app, "day");
+        frame(&ctx, &mut app);
+        // A real space arrives as a key and as text in the same frame.
+        frame_events(
+            &ctx,
+            &mut app,
+            vec![
+                egui::Event::Key {
+                    key: egui::Key::Space,
+                    physical_key: None,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::Text(" ".into()),
+            ],
+        );
+        frame(&ctx, &mut app);
+        type_text(&ctx, &mut app, "b");
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(
+            app.play_pending("spotify:track:trk9"),
+            "the search should carry the space and land on Day by Day"
+        );
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// With the loose setting on, letters that appear anywhere in a
+    /// title, in order, find it.
+    #[test]
+    fn loose_typeahead_matches_letters_anywhere() {
+        let settings = Settings {
+            typeahead_loose: true,
+            ..Settings::default()
+        };
+        let (ctx, mut app, root) = playlist_app("typeahead-loose", settings);
+        // "ey" is no prefix and no unbroken run in any title; loose mode
+        // reads it as letters in order, and Elysian is the first title
+        // that carries an e and then a y.
+        type_text(&ctx, &mut app, "ey");
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(
+            app.play_pending("spotify:track:trk4"),
+            "loose mode should read 'ey' into Elysian"
+        );
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// While a song list is open, the plain keys it searches with are not
+    /// shortcuts; everywhere else they still are.
+    #[test]
+    fn while_a_song_list_is_open_the_plain_letters_belong_to_typeahead() {
+        let (ctx, mut app, root) = playlist_app("typeahead-gate", Settings::default());
+        press(&ctx, &mut app, egui::Key::L);
+        assert!(
+            !app.show_lyrics_panel,
+            "L should type into the search, not open the lyrics"
+        );
+        app.open(Page::Home);
+        frame(&ctx, &mut app);
+        press(&ctx, &mut app, egui::Key::L);
+        assert!(app.show_lyrics_panel);
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// With the setting off, typed letters mean nothing to the list.
+    #[test]
+    fn typeahead_off_leaves_the_list_alone() {
+        let settings = Settings {
+            typeahead_jump: false,
+            ..Settings::default()
+        };
+        let (ctx, mut app, root) = playlist_app("typeahead-off", settings);
+        type_text(&ctx, &mut app, "rr");
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(!app.play_pending("spotify:track:trk0"));
+        assert!(!app.play_pending("spotify:track:trk20"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A letter and Space can arrive in one frame. The list reads them in
+    /// order, so Space joins the new query rather than toggling playback.
+    #[test]
+    fn first_frame_space_joins_the_query_without_toggling_playback() {
+        let (ctx, mut app, root) = playlist_app("typeahead-first-space", Settings::default());
+        let playing = app.believed_playing();
+        frame_events(
+            &ctx,
+            &mut app,
+            vec![
+                egui::Event::Text("day".into()),
+                egui::Event::Key {
+                    key: egui::Key::Space,
+                    physical_key: None,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::Text(" ".into()),
+                egui::Event::Text("b".into()),
+            ],
+        );
+        assert_eq!(app.believed_playing(), playing);
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(app.play_pending("spotify:track:trk9"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// The mini player has no song-table listener, even when the hidden main
+    /// window page is a playlist, so its ordinary shortcuts keep working.
+    #[test]
+    fn winamp_keeps_plain_letter_shortcuts_from_a_playlist_page() {
+        let (ctx, mut app, root) = playlist_app("typeahead-winamp", Settings::default());
+        app.settings.winamp_window = true;
+        frame(&ctx, &mut app);
+        press(&ctx, &mut app, egui::Key::L);
+        assert!(app.show_lyrics_panel);
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A failed page has no type-ahead listener, so it must not reserve the
+    /// ordinary letter shortcuts while its Retry control is showing.
+    #[test]
+    fn a_failed_playlist_keeps_plain_letter_shortcuts() {
+        let (ctx, mut app, root) = playlist_app("typeahead-failed", Settings::default());
+        app.playlist_pages.get_mut("pl1").unwrap().playlist = Loadable::Failed("offline".into());
+        press(&ctx, &mut app, egui::Key::L);
+        assert!(app.show_lyrics_panel);
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A popup owns Enter while it is open; a highlighted row underneath it
+    /// must not start playing.
+    #[test]
+    fn device_picker_blocks_typeahead_playback() {
+        let (ctx, mut app, root) = playlist_app("typeahead-devices", Settings::default());
+        type_text(&ctx, &mut app, "r");
+        app.show_devices = true;
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(!app.play_pending("spotify:track:trk0"));
+        assert!(!app.play_pending("spotify:track:trk20"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A type-ahead belongs to the visible page, not to a page that the
+    /// listener left and later revisited.
+    #[test]
+    fn navigating_away_clears_the_page_typeahead() {
+        let (ctx, mut app, root) = playlist_app("typeahead-navigation", Settings::default());
+        type_text(&ctx, &mut app, "r");
+        app.open(Page::Home);
+        frame(&ctx, &mut app);
+        app.open(Page::Playlist("pl1".into()));
+        frame(&ctx, &mut app);
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(!app.play_pending("spotify:track:trk0"));
+        assert!(!app.play_pending("spotify:track:trk20"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A query typed while the first rows are loading survives until those
+    /// rows arrive, then resolves normally.
+    #[test]
+    fn typeahead_waits_for_an_initially_empty_loading_table() {
+        let (ctx, mut app, root) = playlist_app("typeahead-loading", Settings::default());
+        let items = {
+            let page = app.playlist_pages.get_mut("pl1").unwrap();
+            page.items.loading = true;
+            page.items.next_offset = Some(0);
+            page.items.revision = page.items.revision.wrapping_add(1);
+            std::mem::take(&mut page.items.items)
+        };
+        type_text(&ctx, &mut app, "rose");
+        {
+            let page = app.playlist_pages.get_mut("pl1").unwrap();
+            page.items.items = items;
+            page.items.loading = false;
+            page.items.next_offset = None;
+            page.items.revision = page.items.revision.wrapping_add(1);
+        }
+        frame(&ctx, &mut app);
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(app.play_pending("spotify:track:trk0"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A failed next page waits for the visible Retry control instead of
+    /// being requested again every frame by an unmatched query.
+    #[test]
+    fn typeahead_does_not_retry_a_failed_page_automatically() {
+        let (ctx, mut app, root) = playlist_app("typeahead-error", Settings::default());
+        app.table_sorts.insert(
+            Page::Playlist("pl1".into()),
+            TableSort {
+                column: SortColumn::Title,
+                ascending: true,
+            },
+        );
+        {
+            let page = app.playlist_pages.get_mut("pl1").unwrap();
+            page.items.loading = false;
+            page.items.next_offset = Some(page.items.items.len() as u32);
+            page.items.error = Some("offline".into());
+        }
+        type_text(&ctx, &mut app, "zzzz");
+        assert!(!app.playlist_pages["pl1"].items.loading);
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Enter follows the same availability rule as clicking or
+    /// double-clicking a row.
+    #[test]
+    fn typeahead_enter_does_not_play_an_unavailable_track() {
+        let (ctx, mut app, root) = playlist_app("typeahead-unavailable", Settings::default());
+        let page = app.playlist_pages.get_mut("pl1").unwrap();
+        let item = &mut page.items.items[0];
+        let playable = item.item.as_mut().or(item.track.as_mut()).unwrap();
+        if let PlayableItem::Track(track) = playable {
+            track.is_local = true;
+        }
+        page.items.revision = page.items.revision.wrapping_add(1);
+        type_text(&ctx, &mut app, "r");
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(!app.play_pending("spotify:track:trk0"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1856,6 +1856,35 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    /// A request in flight does not make typed text permanent: one second
+    /// without another key always ends the type-ahead.
+    #[test]
+    fn typeahead_expires_while_initial_rows_are_still_loading() {
+        let (ctx, mut app, root) = playlist_app("typeahead-loading-expiry", typeahead_settings());
+        let items = {
+            let page = app.playlist_pages.get_mut("pl1").unwrap();
+            page.items.loading = true;
+            page.items.next_offset = Some(0);
+            page.items.revision = page.items.revision.wrapping_add(1);
+            std::mem::take(&mut page.items.items)
+        };
+        type_text(&ctx, &mut app, "rose");
+        std::thread::sleep(std::time::Duration::from_millis(1_050));
+        frame(&ctx, &mut app);
+        {
+            let page = app.playlist_pages.get_mut("pl1").unwrap();
+            page.items.items = items;
+            page.items.loading = false;
+            page.items.next_offset = None;
+            page.items.revision = page.items.revision.wrapping_add(1);
+        }
+        frame(&ctx, &mut app);
+        press(&ctx, &mut app, egui::Key::Enter);
+        assert!(!app.play_pending("spotify:track:trk0"));
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     /// A failed next page waits for the visible Retry control instead of
     /// being requested again every frame by an unmatched query.
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1856,7 +1856,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    /// A request in flight does not make typed text permanent: one second
+    /// A request in flight does not make typed text permanent: two seconds
     /// without another key always ends the type-ahead.
     #[test]
     fn typeahead_expires_while_initial_rows_are_still_loading() {
@@ -1869,7 +1869,7 @@ mod tests {
             std::mem::take(&mut page.items.items)
         };
         type_text(&ctx, &mut app, "rose");
-        std::thread::sleep(std::time::Duration::from_millis(1_050));
+        std::thread::sleep(std::time::Duration::from_millis(2_050));
         frame(&ctx, &mut app);
         {
             let page = app.playlist_pages.get_mut("pl1").unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -281,8 +281,8 @@ mod tests {
     fn older_settings_keep_the_sidebar_visible() {
         let settings: Settings = serde_json::from_str("{}").unwrap();
         assert!(settings.sidebar_visible);
-        assert!(settings.typeahead_jump);
-        assert!(!settings.typeahead_loose);
+        assert!(!settings.typeahead_jump);
+        assert!(settings.typeahead_loose);
     }
 
     #[test]
@@ -375,14 +375,14 @@ mod tests {
     #[test]
     fn typeahead_choices_round_trip() {
         let settings = Settings {
-            typeahead_jump: false,
-            typeahead_loose: true,
+            typeahead_jump: true,
+            typeahead_loose: false,
             ..Settings::default()
         };
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
-        assert!(!restored.typeahead_jump);
-        assert!(restored.typeahead_loose);
+        assert!(restored.typeahead_jump);
+        assert!(!restored.typeahead_loose);
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -82,6 +82,12 @@ pub struct Settings {
     pub queue_width: f32,
     /// Use compact single-line rows without cover art in track lists.
     pub tracklist_compact: bool,
+    /// Plain letters jump to the matching song in the track lists, the
+    /// way file explorers jump to files.
+    pub typeahead_jump: bool,
+    /// Type-ahead also fits when the typed letters appear anywhere in a
+    /// title, in order, not only at its start.
+    pub typeahead_loose: bool,
     pub search_history: Vec<String>,
     pub show_shortcut_hints: bool,
     /// An optional personal Spotify Web API application id. The shared
@@ -174,6 +180,8 @@ impl Default for Settings {
             lyrics_width: 360.0,
             queue_width: 360.0,
             tracklist_compact: false,
+            typeahead_jump: false,
+            typeahead_loose: true,
             search_history: Vec::new(),
             show_shortcut_hints: true,
             web_client_id: None,
@@ -273,6 +281,8 @@ mod tests {
     fn older_settings_keep_the_sidebar_visible() {
         let settings: Settings = serde_json::from_str("{}").unwrap();
         assert!(settings.sidebar_visible);
+        assert!(settings.typeahead_jump);
+        assert!(!settings.typeahead_loose);
     }
 
     #[test]
@@ -360,6 +370,19 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
         assert!(restored.tracklist_compact);
+    }
+
+    #[test]
+    fn typeahead_choices_round_trip() {
+        let settings = Settings {
+            typeahead_jump: false,
+            typeahead_loose: true,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert!(!restored.typeahead_jump);
+        assert!(restored.typeahead_loose);
     }
 }
 

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -392,7 +392,6 @@ fn typeahead_input(
             && search.has_needle()
             && search.row.is_none()
             && (loading || (!error && can_load_more));
-        search.set_waiting_for_results(waits_for_more, now);
         if waits_for_more && !loading {
             app.actions.push(Action::LoadMore(page.clone()));
         }

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -1,6 +1,7 @@
 //! Playlist, album, and Liked Songs pages: a hero, actions, and a track table.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use egui::{Align, Layout, Rect, Sense, Vec2, pos2, vec2};
 
@@ -12,6 +13,7 @@ use crate::model::{
 use crate::theme::{self, Icon, Palette};
 use crate::util;
 
+use super::typeahead;
 use super::widgets::{self, TrackRow};
 
 pub struct Hero<'a> {
@@ -276,9 +278,34 @@ pub struct TableCache {
     pub sort: Option<TableSort>,
     pub needle: String,
     pub items_revision: u64,
+    pub items_len: usize,
     pub user_names_revision: u64,
     pub visible: Arc<[usize]>,
     pub view_uris: Option<Arc<[String]>>,
+    /// The visible titles as the type-ahead search reads them, prepared
+    /// once per view instead of once per keystroke.
+    pub typeahead_titles: Arc<[typeahead::NormalizedTitle]>,
+}
+
+fn table_cache_id(data_revision: u64, page: &Page) -> egui::Id {
+    egui::Id::new("table-view-cache")
+        .with(data_revision)
+        .with(page)
+}
+
+fn clear_table_caches_for_revision(ctx: &egui::Context, data_revision: u64) {
+    let marker = egui::Id::new("table-view-cache-revision");
+    if ctx.data(|data| data.get_temp::<u64>(marker)) == Some(data_revision) {
+        return;
+    }
+    ctx.data_mut(|data| {
+        data.remove_by_type::<Arc<TableCache>>();
+        data.insert_temp(marker, data_revision);
+    });
+}
+
+pub(super) fn begin_frame(app: &App, ctx: &egui::Context) {
+    clear_table_caches_for_revision(ctx, app.data_revision);
 }
 
 pub fn prepare_table_view(
@@ -290,13 +317,14 @@ pub fn prepare_table_view(
     sort: Option<TableSort>,
     items_revision: u64,
 ) -> Arc<TableCache> {
-    let cache_id = egui::Id::new("table-view-cache").with(page);
+    let cache_id = table_cache_id(app.data_revision, page);
     let cached = ui.data(|d| d.get_temp::<Arc<TableCache>>(cache_id));
 
     let is_valid = cached.as_ref().is_some_and(|c| {
         c.sort == sort
             && c.needle == needle
             && c.items_revision == items_revision
+            && c.items_len == items.len()
             && c.user_names_revision == app.user_names_revision
     });
 
@@ -310,16 +338,83 @@ pub fn prepare_table_view(
                 .map(|&index| items[index].0.uri().to_string())
                 .collect::<Arc<[String]>>()
         });
+        let typeahead_titles = visible
+            .iter()
+            .map(|&index| typeahead::normalize_title(items[index].0.name()))
+            .collect::<Arc<[typeahead::NormalizedTitle]>>();
         let entry = Arc::new(TableCache {
             sort,
             needle: needle.to_string(),
             items_revision,
+            items_len: items.len(),
             user_names_revision: app.user_names_revision,
             visible: visible.into(),
             view_uris,
+            typeahead_titles,
         });
         ui.data_mut(|d| d.insert_temp(cache_id, Arc::clone(&entry)));
         entry
+    }
+}
+
+struct TypeaheadFrame {
+    search: typeahead::Search,
+    previous_row: Option<usize>,
+    actions: Vec<typeahead::InputAction>,
+}
+
+fn typeahead_input(
+    app: &mut App,
+    ui: &mut egui::Ui,
+    page: &Page,
+    titles: &[typeahead::NormalizedTitle],
+    loading: bool,
+    error: bool,
+    can_load_more: bool,
+) -> TypeaheadFrame {
+    let state_id = typeahead::state_id(app, page);
+    let mut search = ui
+        .data(|data| data.get_temp::<typeahead::Search>(state_id))
+        .unwrap_or_default();
+    let previous_row = search.row;
+    let typing = ui.ctx().memory(|memory| memory.focused().is_some());
+    let mut actions = Vec::new();
+    if typeahead::owns_keyboard(app, ui.ctx()) && !typing {
+        typeahead::enable_ime(ui.ctx());
+        let now = Instant::now();
+        search.expire(now);
+        search.set_loose(app.settings.typeahead_loose);
+        search.revalidate(titles);
+        let events = ui.input(|input| input.events.clone());
+        actions = search.handle_events(&events, titles);
+
+        let waits_for_more = !search.buffer().is_empty()
+            && search.has_needle()
+            && search.row.is_none()
+            && (loading || (!error && can_load_more));
+        search.set_waiting_for_results(waits_for_more, now);
+        if waits_for_more && !loading {
+            app.actions.push(Action::LoadMore(page.clone()));
+        }
+        search.schedule_expiry(ui.ctx(), now);
+    } else {
+        search.clear();
+    }
+    typeahead::hint(ui.ctx(), app.palette, page, search.buffer());
+    ui.data_mut(|data| data.insert_temp(state_id, search.clone()));
+    TypeaheadFrame {
+        search,
+        previous_row,
+        actions,
+    }
+}
+
+fn typeahead_while_loading(app: &mut App, ui: &mut egui::Ui, page: &Page) {
+    let frame = typeahead_input(app, ui, page, &[], true, false, false);
+    for action in frame.actions {
+        if action == typeahead::InputAction::TogglePlay {
+            app.actions.push(Action::TogglePlay);
+        }
     }
 }
 
@@ -442,6 +537,45 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
         .collect();
     let rows = entry.visible.len();
     let mut pick = None;
+    // Type-ahead jump: the row the search points at is painted beneath the
+    // rows and the page scrolls to it.
+    let TypeaheadFrame {
+        search,
+        previous_row,
+        actions,
+    } = typeahead_input(
+        app,
+        ui,
+        &table.page,
+        &entry.typeahead_titles,
+        table.loading,
+        table.error.is_some(),
+        table.can_load_more,
+    );
+    let mut play_rows = Vec::new();
+    for action in actions {
+        match action {
+            typeahead::InputAction::TogglePlay => app.actions.push(Action::TogglePlay),
+            typeahead::InputAction::Play {
+                row,
+                pointer_event_before,
+            } => play_rows.push((row, pointer_event_before)),
+        }
+    }
+    if let Some(row) = search.row
+        && search.row != previous_row
+    {
+        ui.scroll_to_rect(
+            Rect::from_min_max(
+                pos2(ui.max_rect().left(), list_top + row as f32 * row_height),
+                pos2(
+                    ui.max_rect().right(),
+                    list_top + (row + 1) as f32 * row_height,
+                ),
+            ),
+            Some(Align::Center),
+        );
+    }
     widgets::virtual_rows(ui, entry.visible.len(), row_height, |ui, row| {
         let index = entry.visible[row];
         let (item, added_at, added_by) = &table.items[index];
@@ -455,6 +589,21 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
             },
             0.12,
         );
+        if search.row == Some(row) {
+            ui.painter().rect_filled(
+                Rect::from_min_max(
+                    pos2(ui.max_rect().left(), list_top + row as f32 * row_height),
+                    pos2(
+                        ui.max_rect().right(),
+                        list_top + (row + 1) as f32 * row_height,
+                    ),
+                ),
+                egui::CornerRadius::same(6),
+                palette
+                    .accent
+                    .gamma_multiply(if palette.dark { 0.35 } else { 0.25 }),
+            );
+        }
         if let Some(asked) = widgets::track_row(
             ui,
             app,
@@ -484,6 +633,27 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
     // Escape clears the current selection.
     if !picked.is_empty() && ui.input(|input| input.key_pressed(egui::Key::Escape)) {
         app.clear_picked_rows();
+    }
+    // Row widgets register their menus while drawing. Defer Enter until now
+    // so a popup opened earlier in this same event batch owns the key.
+    if !app.show_devices && app.dialog.is_none() {
+        let popup_open = egui::Popup::is_any_open(ui.ctx());
+        for (row, pointer_event_before) in play_rows {
+            if popup_open && pointer_event_before {
+                continue;
+            }
+            if row >= entry.visible.len() {
+                continue;
+            }
+            let index = entry.visible[row];
+            if table.items[index].0.is_available() {
+                app.actions.push(Action::PlayFromRow {
+                    context: context.clone(),
+                    uri: table.items[index].0.uri().to_string(),
+                    index: if sorted { row as u32 } else { index as u32 },
+                });
+            }
+        }
     }
     if let Some(slot) = move_slot {
         // Draw the destination line between shifted rows.
@@ -531,6 +701,7 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
         && !needle.is_empty()
         && table.can_load_more
         && !table.loading
+        && table.error.is_none()
     {
         // Filtering a partially loaded list: keep fetching so matches appear.
         app.actions.push(Action::LoadMore(table.page));
@@ -539,7 +710,7 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
             ui,
             app,
             table.page,
-            table.can_load_more && !table.loading,
+            table.can_load_more && !table.loading && table.error.is_none(),
         );
     }
 }
@@ -666,11 +837,13 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
         Loadable::Loaded(tracks) => tracks.clone(),
         Loadable::Loading | Loadable::NotLoaded => {
             widgets::loading_row(ui, &palette);
+            typeahead_while_loading(app, ui, &Page::TopSongs);
             return;
         }
         Loadable::Failed(error) => {
             let error = error.clone();
             widgets::error_row(ui, app, &error, Some(Page::TopSongs));
+            typeahead::clear_state(app, ui.ctx(), &Page::TopSongs);
             return;
         }
     };
@@ -702,6 +875,7 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
 
 pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let Some(mut page) = app.playlist_pages.remove(id) else {
+        typeahead_while_loading(app, ui, &Page::Playlist(id.to_string()));
         app.ensure_loaded(Page::Playlist(id.to_string()));
         return;
     };
@@ -838,11 +1012,13 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
         Loadable::Loading | Loadable::NotLoaded => {
             ui.add_space(40.0);
             widgets::loading_row(ui, &palette);
+            typeahead_while_loading(app, ui, &Page::Playlist(id.to_string()));
         }
         Loadable::Failed(error) => {
             let error = error.clone();
             ui.add_space(40.0);
             widgets::error_row(ui, app, &error, Some(Page::Playlist(id.to_string())));
+            typeahead::clear_state(app, ui.ctx(), &Page::Playlist(id.to_string()));
         }
     }
     app.playlist_pages.insert(id.to_string(), page);
@@ -850,6 +1026,7 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
 
 pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let Some(page) = app.album_pages.remove(id) else {
+        typeahead_while_loading(app, ui, &Page::Album(id.to_string()));
         app.ensure_loaded(Page::Album(id.to_string()));
         return;
     };
@@ -964,11 +1141,13 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
         Loadable::Loading | Loadable::NotLoaded => {
             ui.add_space(40.0);
             widgets::loading_row(ui, &palette);
+            typeahead_while_loading(app, ui, &Page::Album(id.to_string()));
         }
         Loadable::Failed(error) => {
             let error = error.clone();
             ui.add_space(40.0);
             widgets::error_row(ui, app, &error, Some(Page::Album(id.to_string())));
+            typeahead::clear_state(app, ui.ctx(), &Page::Album(id.to_string()));
         }
     }
     app.album_pages.insert(id.to_string(), page);
@@ -1264,9 +1443,11 @@ mod tests {
             sort,
             needle: "desp".to_string(),
             items_revision: 5,
+            items_len: 1,
             user_names_revision: 2,
             visible: Arc::new([2]),
             view_uris: Some(Arc::new(["spotify:track:t_2".to_string()])),
+            typeahead_titles: Arc::new([typeahead::normalize_title("Despacito")]),
         };
 
         // Cache hit
@@ -1274,6 +1455,7 @@ mod tests {
             cache.sort == sort
                 && cache.needle == "desp"
                 && cache.items_revision == 5
+                && cache.items_len == 1
                 && cache.user_names_revision == 2
         );
 
@@ -1290,7 +1472,24 @@ mod tests {
         // Cache miss on items_revision change
         assert_ne!(cache.items_revision, 6);
 
+        // Cache miss when a producer appends rows without changing revision.
+        assert_ne!(cache.items_len, 2);
+
         // Cache miss on user_names_revision change
         assert_ne!(cache.user_names_revision, 3);
+
+        // Account-scoped rows never share an egui cache generation.
+        assert_ne!(
+            table_cache_id(1, &Page::TopSongs),
+            table_cache_id(2, &Page::TopSongs)
+        );
+
+        let ctx = egui::Context::default();
+        clear_table_caches_for_revision(&ctx, 1);
+        let held_id = table_cache_id(1, &Page::TopSongs);
+        ctx.data_mut(|data| data.insert_temp(held_id, Arc::new(cache)));
+        assert!(ctx.data(|data| data.get_temp::<Arc<TableCache>>(held_id).is_some()));
+        clear_table_caches_for_revision(&ctx, 2);
+        assert!(ctx.data(|data| data.get_temp::<Arc<TableCache>>(held_id).is_none()));
     }
 }

--- a/src/ui/keys.rs
+++ b/src/ui/keys.rs
@@ -16,6 +16,10 @@ pub(super) const MILKDROP_SHORTCUT: &str = platform_shortcut("Ctrl+Shift+K", "Cm
 
 pub fn handle(app: &mut App, ctx: &egui::Context) {
     let typing = ctx.memory(|memory| memory.focused().is_some());
+    // On the song lists, type-ahead owns the plain letters: M, S, R, Q, and
+    // L type into the search instead of meaning mute, shuffle, repeat,
+    // queue, and lyrics. Everywhere else they keep their shortcuts.
+    let typeahead_jumps = super::typeahead::owns_keyboard(app, ctx);
     let mut actions = Vec::new();
     ctx.input_mut(|input| {
         let mut key = |modifiers: Modifiers, key: Key, action: Action| {
@@ -103,12 +107,18 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
             );
             key(Modifiers::SHIFT, Key::ArrowLeft, Action::SeekBy(-10_000));
             key(Modifiers::SHIFT, Key::ArrowRight, Action::SeekBy(10_000));
-            key(Modifiers::NONE, Key::Space, Action::TogglePlay);
-            key(Modifiers::NONE, Key::M, Action::ToggleMute);
-            key(Modifiers::NONE, Key::S, Action::ToggleShuffle);
-            key(Modifiers::NONE, Key::R, Action::CycleRepeat);
-            key(Modifiers::NONE, Key::Q, Action::ToggleQueuePanel);
-            key(Modifiers::NONE, Key::L, Action::ToggleLyricsPanel);
+            // The list handles Space too, so letters and Space are interpreted
+            // in their real event order when they arrive in one frame.
+            if !typeahead_jumps {
+                key(Modifiers::NONE, Key::Space, Action::TogglePlay);
+            }
+            if !typeahead_jumps {
+                key(Modifiers::NONE, Key::M, Action::ToggleMute);
+                key(Modifiers::NONE, Key::S, Action::ToggleShuffle);
+                key(Modifiers::NONE, Key::R, Action::CycleRepeat);
+                key(Modifiers::NONE, Key::Q, Action::ToggleQueuePanel);
+                key(Modifiers::NONE, Key::L, Action::ToggleLyricsPanel);
+            }
             key(Modifiers::NONE, Key::Slash, Action::FocusSearch);
         }
     });
@@ -173,6 +183,7 @@ pub const SHORTCUTS: &[(&str, &str)] = &[
     ("R", "Cycle repeat"),
     ("Q", "Show the queue"),
     ("L", "Show the lyrics"),
+    ("A–Z", "Jump in the song list (Enter plays, Esc clears)"),
     (platform_shortcut("Ctrl+F  or  /", "Cmd+F  or  /"), "Search"),
     (SIDEBAR_SHORTCUT, "Show or hide the sidebar"),
     ("Alt+←  /  Alt+→", "Back or forward"),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod settings;
 pub mod show;
 pub mod sidebar;
 pub mod topbar;
+mod typeahead;
 pub mod widgets;
 pub mod winamp;
 
@@ -30,6 +31,8 @@ use crate::theme::{self, Icon};
 pub fn show(app: &mut App, ui: &mut egui::Ui) {
     let ctx = ui.ctx().clone();
     let ctx = &ctx;
+    collection::begin_frame(app, ctx);
+    typeahead::enter_page(app, ctx);
     keys::handle(app, ctx);
     for path in winamp::dropped_skins(ctx) {
         app.actions.push(Action::InstallSkin(path));

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -503,7 +503,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui,
             &palette,
             "Type-ahead in song lists",
-            "Typing letters jumps to the matching song in playlists and albums.",
+            "Typing letters jumps to matching songs; plain-letter shortcuts are unavailable on those pages.",
             |ui| {
                 if widgets::switch(ui, &palette, &mut app.settings.typeahead_jump).changed() {
                     changed = true;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -502,6 +502,28 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         widgets::setting_row(
             ui,
             &palette,
+            "Type-ahead in song lists",
+            "Typing letters jumps to the matching song in playlists and albums.",
+            |ui| {
+                if widgets::switch(ui, &palette, &mut app.settings.typeahead_jump).changed() {
+                    changed = true;
+                }
+            },
+        );
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Loose type-ahead",
+            "Typing also matches when the letters appear anywhere in a song title, in order.",
+            |ui| {
+                if widgets::switch(ui, &palette, &mut app.settings.typeahead_loose).changed() {
+                    changed = true;
+                }
+            },
+        );
+        widgets::setting_row(
+            ui,
+            &palette,
             "Interface zoom",
             super::keys::platform_shortcut(
                 "Ctrl+Plus and Ctrl+Minus work anywhere; Ctrl+0 resets.",

--- a/src/ui/typeahead.rs
+++ b/src/ui/typeahead.rs
@@ -16,7 +16,7 @@ use crate::model::{Loadable, Page};
 use crate::theme::{self, Palette};
 
 /// How long the typed characters survive without another keystroke.
-const TIMEOUT: Duration = Duration::from_secs(1);
+const TIMEOUT: Duration = Duration::from_secs(2);
 
 /// A title as the search sees it: lowercased, accents folded, and
 /// punctuation and spaces gone, plus where the title begins without a
@@ -206,6 +206,9 @@ pub struct Search {
     pub row: Option<usize>,
     /// Whether letters may match anywhere in a title, from the setting.
     loose: bool,
+    /// The last IME candidate text, so a platform repeating the same preedit
+    /// event every frame does not look like fresh typing forever.
+    ime_preedit: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -232,7 +235,7 @@ impl Search {
         !normalize_typed(&self.buffer).is_empty()
     }
 
-    /// Drops the search after one second without typing, at the start of a
+    /// Drops the search after two seconds without typing, at the start of a
     /// frame.
     pub fn expire(&mut self, now: Instant) {
         if let Some(elapsed) = self
@@ -345,9 +348,13 @@ impl Search {
         for event in events {
             match event {
                 Event::Text(text) | Event::Paste(text) => self.type_text(text, titles),
-                Event::Ime(ImeEvent::Commit(text)) => self.type_text(text, titles),
+                Event::Ime(ImeEvent::Commit(text)) => {
+                    self.ime_preedit.clear();
+                    self.type_text(text, titles);
+                }
                 Event::Ime(ImeEvent::Preedit { text, .. }) => {
-                    if !text.is_empty() || !self.buffer.is_empty() {
+                    if text != &self.ime_preedit {
+                        self.ime_preedit.clone_from(text);
                         self.last_keystroke = Some(Instant::now());
                     }
                 }
@@ -1005,7 +1012,7 @@ mod tests {
     }
 
     #[test]
-    fn ime_preedit_restarts_the_one_second_timeout() {
+    fn ime_preedit_restarts_the_two_second_timeout() {
         let titles = titles();
         let mut search = Search::default();
         search.type_char('b', &titles);
@@ -1017,6 +1024,15 @@ mod tests {
             &titles,
         );
         let composed_at = Instant::now();
+        let first_keystroke = search.last_keystroke;
+        search.handle_events(
+            &[Event::Ime(ImeEvent::Preedit {
+                text: "ぼ".into(),
+                active_range_chars: None,
+            })],
+            &titles,
+        );
+        assert_eq!(search.last_keystroke, first_keystroke);
         search.expire(composed_at + TIMEOUT / 2);
         assert_eq!(search.buffer(), "b");
         search.expire(composed_at + TIMEOUT + Duration::from_millis(1));

--- a/src/ui/typeahead.rs
+++ b/src/ui/typeahead.rs
@@ -206,12 +206,6 @@ pub struct Search {
     pub row: Option<usize>,
     /// Whether letters may match anywhere in a title, from the setting.
     loose: bool,
-    /// An unmatched query is waiting for another page. It does not expire
-    /// while the request is in flight.
-    waiting_for_results: bool,
-    /// IME preedit text is still being composed. The committed query must
-    /// not disappear while the candidate window is open.
-    ime_composing: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -238,23 +232,12 @@ impl Search {
         !normalize_typed(&self.buffer).is_empty()
     }
 
-    /// Starts or finishes a wait for another page. Once results arrive,
-    /// the ordinary timeout starts from their arrival rather than from the
-    /// keystroke that requested them.
-    pub fn set_waiting_for_results(&mut self, waiting: bool, now: Instant) {
-        if self.waiting_for_results && !waiting && !self.buffer.is_empty() {
-            self.last_keystroke = Some(now);
-        }
-        self.waiting_for_results = waiting;
-    }
-
-    /// Drops the search after a moment of silence, at the start of a frame.
+    /// Drops the search after one second without typing, at the start of a
+    /// frame.
     pub fn expire(&mut self, now: Instant) {
-        if !self.waiting_for_results
-            && !self.ime_composing
-            && let Some(elapsed) = self
-                .last_keystroke
-                .and_then(|keystroke| now.checked_duration_since(keystroke))
+        if let Some(elapsed) = self
+            .last_keystroke
+            .and_then(|keystroke| now.checked_duration_since(keystroke))
             && elapsed >= TIMEOUT
         {
             *self = Self::default();
@@ -263,9 +246,6 @@ impl Search {
 
     /// Wakes the otherwise idle UI exactly when this search should expire.
     pub fn schedule_expiry(&self, ctx: &Context, now: Instant) {
-        if self.waiting_for_results || self.ime_composing {
-            return;
-        }
         if let Some(keystroke) = self.last_keystroke {
             let elapsed = now.checked_duration_since(keystroke).unwrap_or_default();
             ctx.request_repaint_after(TIMEOUT.saturating_sub(elapsed));
@@ -300,13 +280,11 @@ impl Search {
         {
             self.row = Some(found);
             self.last_keystroke = Some(Instant::now());
-            self.waiting_for_results = false;
             return;
         }
 
         self.buffer = candidate;
         self.last_keystroke = Some(Instant::now());
-        self.waiting_for_results = false;
 
         // Punctuation and spaces stay visible in the hint but do not move a
         // match when they add nothing to the normalized query.
@@ -334,7 +312,6 @@ impl Search {
         let needle = normalize_typed(&self.buffer);
         self.row = find(titles, &needle, 0, false, self.loose);
         self.last_keystroke = Some(Instant::now());
-        self.waiting_for_results = false;
     }
 
     /// Escape: end the search at once.
@@ -368,12 +345,8 @@ impl Search {
         for event in events {
             match event {
                 Event::Text(text) | Event::Paste(text) => self.type_text(text, titles),
-                Event::Ime(ImeEvent::Commit(text)) => {
-                    self.ime_composing = false;
-                    self.type_text(text, titles);
-                }
+                Event::Ime(ImeEvent::Commit(text)) => self.type_text(text, titles),
                 Event::Ime(ImeEvent::Preedit { text, .. }) => {
-                    self.ime_composing = !text.is_empty();
                     if !text.is_empty() || !self.buffer.is_empty() {
                         self.last_keystroke = Some(Instant::now());
                     }
@@ -1032,7 +1005,7 @@ mod tests {
     }
 
     #[test]
-    fn ime_preedit_keeps_an_existing_query_alive() {
+    fn ime_preedit_restarts_the_one_second_timeout() {
         let titles = titles();
         let mut search = Search::default();
         search.type_char('b', &titles);
@@ -1044,12 +1017,9 @@ mod tests {
             &titles,
         );
         let composed_at = Instant::now();
-        search.expire(composed_at + TIMEOUT * 10);
+        search.expire(composed_at + TIMEOUT / 2);
         assert_eq!(search.buffer(), "b");
-        search.handle_events(&[Event::Ime(ImeEvent::Commit("o".into()))], &titles);
-        assert_eq!(search.buffer(), "bo");
-        let committed_at = Instant::now();
-        search.expire(committed_at + TIMEOUT + Duration::from_millis(1));
+        search.expire(composed_at + TIMEOUT + Duration::from_millis(1));
         assert!(search.buffer().is_empty());
     }
 
@@ -1116,19 +1086,13 @@ mod tests {
     }
 
     #[test]
-    fn an_unmatched_search_waits_for_a_loading_page() {
+    fn an_unmatched_search_expires_while_another_page_loads() {
         let mut search = Search::default();
         search.type_char('z', &[]);
-        let waiting_at = Instant::now();
-        search.set_waiting_for_results(true, waiting_at);
-        search.expire(waiting_at + TIMEOUT * 10);
+        let typed_at = Instant::now();
+        search.expire(typed_at + TIMEOUT / 2);
         assert_eq!(search.buffer(), "z");
-
-        let arrived_at = waiting_at + TIMEOUT * 10;
-        search.set_waiting_for_results(false, arrived_at);
-        search.expire(arrived_at + TIMEOUT / 2);
-        assert_eq!(search.buffer(), "z");
-        search.expire(arrived_at + TIMEOUT + Duration::from_millis(1));
+        search.expire(typed_at + TIMEOUT + Duration::from_millis(1));
         assert!(search.buffer().is_empty());
     }
 

--- a/src/ui/typeahead.rs
+++ b/src/ui/typeahead.rs
@@ -1,0 +1,1179 @@
+//! Type-ahead jump in the song lists, the way file explorers do it: plain
+//! letters select the first title that starts with what was typed, more
+//! letters narrow the search, and a moment of silence clears it again.
+//! Matching forgives what titles have and hands skip: case, accents,
+//! punctuation, spaces, and a leading The.
+
+use std::time::{Duration, Instant};
+
+use egui::{
+    Align2, Context, CornerRadius, Event, Frame, Id, ImeEvent, Margin, Order, Rect, Stroke, pos2,
+    vec2,
+};
+
+use crate::app::App;
+use crate::model::{Loadable, Page};
+use crate::theme::{self, Palette};
+
+/// How long the typed characters survive without another keystroke.
+const TIMEOUT: Duration = Duration::from_secs(1);
+
+/// A title as the search sees it: lowercased, accents folded, and
+/// punctuation and spaces gone, plus where the title begins without a
+/// leading "the", "a", or "an".
+#[derive(Clone, Debug)]
+pub struct NormalizedTitle {
+    full: String,
+    article_start: usize,
+}
+
+impl NormalizedTitle {
+    pub fn full(&self) -> &str {
+        &self.full
+    }
+
+    /// The title ignoring a leading article; the whole title when it
+    /// starts with none.
+    fn article(&self) -> &str {
+        &self.full[self.article_start..]
+    }
+}
+
+/// Prepares a title for the search: `"The Beatles: 1"` becomes
+/// `thebeatles1`, ready to meet a typed `beatles`.
+pub fn normalize_title(name: &str) -> NormalizedTitle {
+    let mut words: Vec<String> = Vec::new();
+    let mut word = String::new();
+    for ch in name.chars() {
+        for lower in ch.to_lowercase() {
+            if lower.is_alphanumeric() {
+                push_folded(&mut word, lower);
+            } else if !word.is_empty() {
+                words.push(std::mem::take(&mut word));
+            }
+        }
+    }
+    if !word.is_empty() {
+        words.push(word);
+    }
+    let mut full = String::with_capacity(words.iter().map(String::len).sum());
+    for word in &words {
+        full.push_str(word);
+    }
+    // Only a whole first word is an article: "The Beatles" gives up
+    // "the", "Theoretical" keeps every letter.
+    let article_start = match words.first().map(String::as_str) {
+        Some("the" | "a" | "an") => words[0].len(),
+        _ => 0,
+    };
+    NormalizedTitle {
+        full,
+        article_start,
+    }
+}
+
+/// Prepares typed text to meet a title: spaces and punctuation are
+/// dropped, accents fold, case goes.
+fn normalize_typed(text: &str) -> String {
+    let mut out = String::new();
+    for ch in text.chars() {
+        for lower in ch.to_lowercase() {
+            if lower.is_alphanumeric() {
+                push_folded(&mut out, lower);
+            }
+        }
+    }
+    out
+}
+
+/// Folds the accents of a lowercased letter, so a typed `e` meets an `é`.
+/// A hand-rolled map of the common Latin accents, so no folding crate
+/// joins the build; everything else passes through untouched.
+fn push_folded(out: &mut String, lower: char) {
+    let folded = match lower {
+        'à' | 'á' | 'â' | 'ã' | 'ä' | 'å' | 'ā' | 'ă' | 'ą' | 'ǎ' | 'ǟ' | 'ǡ' | 'ǻ' | 'ȁ' | 'ȃ'
+        | 'ạ' | 'ả' | 'ấ' | 'ầ' | 'ẩ' | 'ẫ' | 'ậ' | 'ắ' | 'ằ' | 'ẳ' | 'ẵ' | 'ặ' => {
+            'a'
+        }
+        'ç' | 'ć' | 'ĉ' | 'ċ' | 'č' => 'c',
+        'ď' | 'đ' | 'ð' => 'd',
+        'è' | 'é' | 'ê' | 'ë' | 'ē' | 'ĕ' | 'ė' | 'ę' | 'ě' | 'ȅ' | 'ȇ' | 'ẹ' | 'ẻ' | 'ẽ' | 'ế'
+        | 'ề' | 'ể' | 'ễ' | 'ệ' => 'e',
+        'ĝ' | 'ğ' | 'ġ' | 'ģ' => 'g',
+        'ĥ' | 'ħ' => 'h',
+        'ì' | 'í' | 'î' | 'ï' | 'ĩ' | 'ī' | 'ĭ' | 'į' | 'ı' | 'ǐ' | 'ȉ' | 'ȋ' | 'ị' | 'ỉ' => {
+            'i'
+        }
+        'ĵ' => 'j',
+        'ķ' => 'k',
+        'ĺ' | 'ļ' | 'ľ' | 'ŀ' | 'ł' => 'l',
+        'ñ' | 'ń' | 'ņ' | 'ň' | 'ŋ' => 'n',
+        'ò' | 'ó' | 'ô' | 'õ' | 'ö' | 'ø' | 'ō' | 'ŏ' | 'ő' | 'ơ' | 'ǒ' | 'ǫ' | 'ǭ' | 'ǿ' | 'ȍ'
+        | 'ȏ' | 'ọ' | 'ỏ' | 'ố' | 'ồ' | 'ổ' | 'ỗ' | 'ộ' | 'ớ' | 'ờ' | 'ở' | 'ỡ' | 'ợ' => {
+            'o'
+        }
+        'ŕ' | 'ŗ' | 'ř' => 'r',
+        'ś' | 'ŝ' | 'š' | 'ş' | 'ș' => 's',
+        'ţ' | 'ť' | 'ŧ' | 'ț' => 't',
+        'ù' | 'ú' | 'û' | 'ü' | 'ũ' | 'ū' | 'ŭ' | 'ů' | 'ű' | 'ų' | 'ư' | 'ǔ' | 'ǖ' | 'ǘ' | 'ǚ'
+        | 'ǜ' | 'ȕ' | 'ȗ' | 'ụ' | 'ủ' | 'ứ' | 'ừ' | 'ử' | 'ữ' | 'ự' => 'u',
+        'ŵ' | 'ẁ' | 'ẃ' | 'ẅ' => 'w',
+        'ý' | 'ÿ' | 'ŷ' | 'ỳ' | 'ỵ' | 'ỷ' | 'ỹ' => 'y',
+        'ź' | 'ż' | 'ž' => 'z',
+        'æ' => {
+            out.push_str("ae");
+            return;
+        }
+        'œ' => {
+            out.push_str("oe");
+            return;
+        }
+        'ß' => {
+            out.push_str("ss");
+            return;
+        }
+        'þ' => {
+            out.push_str("th");
+            return;
+        }
+        plain => {
+            out.push(plain);
+            return;
+        }
+    };
+    out.push(folded);
+}
+
+/// Where a match may live, in the order one is preferred: the title as
+/// typed, then without its leading article; loose mode adds the letters
+/// as an unbroken run, then scattered anywhere in order.
+#[derive(Clone, Copy)]
+enum Tier {
+    PrefixFull,
+    PrefixArticle,
+    SubstringFull,
+    SubstringArticle,
+    SubsequenceFull,
+    SubsequenceArticle,
+}
+
+const PREFIX_TIERS: [Tier; 2] = [Tier::PrefixFull, Tier::PrefixArticle];
+const LOOSE_TIERS: [Tier; 6] = [
+    Tier::PrefixFull,
+    Tier::PrefixArticle,
+    Tier::SubstringFull,
+    Tier::SubstringArticle,
+    Tier::SubsequenceFull,
+    Tier::SubsequenceArticle,
+];
+
+fn tiers(loose: bool) -> &'static [Tier] {
+    if loose { &LOOSE_TIERS } else { &PREFIX_TIERS }
+}
+
+fn tier_matches(title: &NormalizedTitle, needle: &str, tier: Tier) -> bool {
+    match tier {
+        Tier::PrefixFull => title.full().starts_with(needle),
+        Tier::PrefixArticle => title.article().starts_with(needle),
+        Tier::SubstringFull => title.full().contains(needle),
+        Tier::SubstringArticle => title.article().contains(needle),
+        Tier::SubsequenceFull => subsequence(title.full(), needle),
+        Tier::SubsequenceArticle => subsequence(title.article(), needle),
+    }
+}
+
+/// Whether `needle`'s letters appear in `title` in order — the loose
+/// mode's way of matching.
+fn subsequence(title: &str, needle: &str) -> bool {
+    let mut rest = title;
+    for ch in needle.chars() {
+        match rest.find(ch) {
+            Some(at) => rest = &rest[at + ch.len_utf8()..],
+            None => return false,
+        }
+    }
+    true
+}
+
+/// The type-ahead search of one song list, kept per page in egui's
+/// temporary data.
+#[derive(Clone, Default)]
+pub struct Search {
+    buffer: String,
+    last_keystroke: Option<Instant>,
+    /// The row the search currently points at, in the list's display
+    /// order, as produced by the table's view cache.
+    pub row: Option<usize>,
+    /// Whether letters may match anywhere in a title, from the setting.
+    loose: bool,
+    /// An unmatched query is waiting for another page. It does not expire
+    /// while the request is in flight.
+    waiting_for_results: bool,
+    /// IME preedit text is still being composed. The committed query must
+    /// not disappear while the candidate window is open.
+    ime_composing: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InputAction {
+    TogglePlay,
+    Play {
+        row: usize,
+        pointer_event_before: bool,
+    },
+}
+
+impl Search {
+    /// Sets whether letters may match anywhere in a title, from the
+    /// setting; read again every frame.
+    pub fn set_loose(&mut self, loose: bool) {
+        self.loose = loose;
+    }
+
+    pub fn buffer(&self) -> &str {
+        &self.buffer
+    }
+
+    pub fn has_needle(&self) -> bool {
+        !normalize_typed(&self.buffer).is_empty()
+    }
+
+    /// Starts or finishes a wait for another page. Once results arrive,
+    /// the ordinary timeout starts from their arrival rather than from the
+    /// keystroke that requested them.
+    pub fn set_waiting_for_results(&mut self, waiting: bool, now: Instant) {
+        if self.waiting_for_results && !waiting && !self.buffer.is_empty() {
+            self.last_keystroke = Some(now);
+        }
+        self.waiting_for_results = waiting;
+    }
+
+    /// Drops the search after a moment of silence, at the start of a frame.
+    pub fn expire(&mut self, now: Instant) {
+        if !self.waiting_for_results
+            && !self.ime_composing
+            && let Some(elapsed) = self
+                .last_keystroke
+                .and_then(|keystroke| now.checked_duration_since(keystroke))
+            && elapsed >= TIMEOUT
+        {
+            *self = Self::default();
+        }
+    }
+
+    /// Wakes the otherwise idle UI exactly when this search should expire.
+    pub fn schedule_expiry(&self, ctx: &Context, now: Instant) {
+        if self.waiting_for_results || self.ime_composing {
+            return;
+        }
+        if let Some(keystroke) = self.last_keystroke {
+            let elapsed = now.checked_duration_since(keystroke).unwrap_or_default();
+            ctx.request_repaint_after(TIMEOUT.saturating_sub(elapsed));
+        }
+    }
+
+    /// A typed character. Every letter lands in the buffer, matched or
+    /// not, so what was typed stays typed: a prefix that matches nothing
+    /// yet can still match once the list loads further, and the hint shows
+    /// every key. The same letter again only cycles when it cannot extend
+    /// anything and the buffer is that one letter, the way Explorer
+    /// cycles through a first letter's matches.
+    pub fn type_char(&mut self, ch: char, titles: &[NormalizedTitle]) {
+        let candidate = format!("{}{ch}", self.buffer);
+        let needle = normalize_typed(&candidate);
+        let previous_needle = normalize_typed(&self.buffer);
+        let typed = normalize_typed(&ch.to_string());
+        let repeated = self.buffer.chars().count() == 1 && typed == previous_needle;
+        let found = find(titles, &needle, 0, false, self.loose);
+
+        // A second copy of a one-letter query cycles only when the doubled
+        // text is not itself a title prefix.
+        if found.is_none()
+            && repeated
+            && let Some(found) = find(
+                titles,
+                &previous_needle,
+                self.row.map_or(0, |row| row + 1),
+                true,
+                self.loose,
+            )
+        {
+            self.row = Some(found);
+            self.last_keystroke = Some(Instant::now());
+            self.waiting_for_results = false;
+            return;
+        }
+
+        self.buffer = candidate;
+        self.last_keystroke = Some(Instant::now());
+        self.waiting_for_results = false;
+
+        // Punctuation and spaces stay visible in the hint but do not move a
+        // match when they add nothing to the normalized query.
+        if needle == previous_needle {
+            if !self.row.is_some_and(|row| {
+                row < titles.len() && matches_any(&titles[row], &needle, self.loose)
+            }) {
+                self.row = found;
+            }
+            return;
+        }
+
+        if let Some(found) = found {
+            self.row = Some(found);
+            return;
+        }
+        // Nothing starts with the text typed so far; the row goes until a
+        // title carries the buffer again.
+        self.row = None;
+    }
+
+    /// Backspace: drop the last character and search again from the top.
+    pub fn backspace(&mut self, titles: &[NormalizedTitle]) {
+        self.buffer.pop();
+        let needle = normalize_typed(&self.buffer);
+        self.row = find(titles, &needle, 0, false, self.loose);
+        self.last_keystroke = Some(Instant::now());
+        self.waiting_for_results = false;
+    }
+
+    /// Escape: end the search at once.
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Re-checks the remembered row after the list changed under it.
+    pub fn revalidate(&mut self, titles: &[NormalizedTitle]) {
+        if self.buffer.is_empty() {
+            self.row = None;
+            return;
+        }
+        let needle = normalize_typed(&self.buffer);
+        let still_there = self.row.is_some_and(|row| {
+            row < titles.len() && matches_any(&titles[row], &needle, self.loose)
+        });
+        if !still_there {
+            self.row = find(titles, &needle, 0, false, self.loose);
+        }
+    }
+
+    /// Applies keyboard text and editing keys in their original event order.
+    pub fn handle_events(
+        &mut self,
+        events: &[Event],
+        titles: &[NormalizedTitle],
+    ) -> Vec<InputAction> {
+        let mut actions = Vec::new();
+        let mut pointer_event = false;
+        for event in events {
+            match event {
+                Event::Text(text) | Event::Paste(text) => self.type_text(text, titles),
+                Event::Ime(ImeEvent::Commit(text)) => {
+                    self.ime_composing = false;
+                    self.type_text(text, titles);
+                }
+                Event::Ime(ImeEvent::Preedit { text, .. }) => {
+                    self.ime_composing = !text.is_empty();
+                    if !text.is_empty() || !self.buffer.is_empty() {
+                        self.last_keystroke = Some(Instant::now());
+                    }
+                }
+                Event::Ime(ImeEvent::DeleteSurrounding { before_chars, .. }) => {
+                    for _ in 0..*before_chars {
+                        self.backspace(titles);
+                    }
+                }
+                Event::Key {
+                    key: egui::Key::Backspace,
+                    pressed: true,
+                    ..
+                } => self.backspace(titles),
+                Event::Key {
+                    key: egui::Key::Escape,
+                    pressed: true,
+                    repeat: false,
+                    ..
+                } => self.clear(),
+                Event::Key {
+                    key: egui::Key::Enter,
+                    pressed: true,
+                    repeat: false,
+                    ..
+                } => {
+                    if let Some(row) = self.row {
+                        actions.push(InputAction::Play {
+                            row,
+                            pointer_event_before: pointer_event,
+                        });
+                    }
+                }
+                Event::Key {
+                    key: egui::Key::Space,
+                    pressed: true,
+                    repeat: false,
+                    ..
+                } if self.buffer.is_empty() => actions.push(InputAction::TogglePlay),
+                Event::PointerButton { .. } => pointer_event = true,
+                _ => {}
+            }
+        }
+        actions
+    }
+
+    fn type_text(&mut self, text: &str, titles: &[NormalizedTitle]) {
+        for ch in text.chars() {
+            if ch.is_control() || (ch.is_whitespace() && self.buffer.is_empty()) {
+                continue;
+            }
+            self.type_char(ch, titles);
+        }
+    }
+}
+
+/// Whether the title carries the needle under any tier the mode allows.
+fn matches_any(title: &NormalizedTitle, needle: &str, loose: bool) -> bool {
+    tiers(loose)
+        .iter()
+        .any(|tier| tier_matches(title, needle, *tier))
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct ActiveTarget {
+    data_revision: u64,
+    page: Option<Page>,
+}
+
+fn state_id_for(data_revision: u64, page: &Page) -> Id {
+    Id::new("typeahead").with(data_revision).with(page)
+}
+
+pub(crate) fn state_id(app: &App, page: &Page) -> Id {
+    state_id_for(app.data_revision, page)
+}
+
+fn set_active_target(app: &App, ctx: &Context, page: Option<Page>) {
+    let memory_id = Id::new("active-typeahead-target");
+    let current = ActiveTarget {
+        data_revision: app.data_revision,
+        page,
+    };
+    let previous = ctx.data(|data| data.get_temp::<ActiveTarget>(memory_id));
+    if previous.as_ref() == Some(&current) {
+        return;
+    }
+    if let Some(previous) = previous {
+        if let Some(page) = previous.page {
+            ctx.data_mut(|data| {
+                data.remove::<Search>(state_id_for(previous.data_revision, &page));
+            });
+        }
+        ctx.memory_mut(|memory| memory.interrupt_ime());
+    }
+    ctx.data_mut(|data| data.insert_temp(memory_id, current));
+}
+
+pub fn enter_page(app: &App, ctx: &Context) {
+    set_active_target(app, ctx, Some(app.page().clone()));
+}
+
+pub fn leave_page(app: &App, ctx: &Context) {
+    set_active_target(app, ctx, None);
+}
+
+/// Whether the visible main-window page has a type-ahead listener. A failed
+/// page and the Winamp window leave the ordinary playback shortcuts alone.
+pub fn owns_keyboard(app: &App, ctx: &Context) -> bool {
+    let page_listens = match app.page() {
+        Page::TopSongs => !matches!(&app.home.top_songs, Loadable::Failed(_)),
+        Page::Playlist(id) => app
+            .playlist_pages
+            .get(id)
+            .is_none_or(|page| !matches!(&page.playlist, Loadable::Failed(_))),
+        Page::Album(id) => app
+            .album_pages
+            .get(id)
+            .is_none_or(|page| !matches!(&page.album, Loadable::Failed(_))),
+        Page::LikedSongs => true,
+        _ => false,
+    };
+    app.settings.typeahead_jump
+        && !app.settings.winamp_window
+        && app.is_connected()
+        && app.user.is_some()
+        && app.dialog.is_none()
+        && !app.show_devices
+        && !egui::Popup::is_any_open(ctx)
+        && page_listens
+}
+
+pub fn clear_state(app: &App, ctx: &Context, page: &Page) {
+    ctx.data_mut(|data| data.remove::<Search>(state_id(app, page)));
+}
+
+/// Type-ahead has no text widget of its own, so it publishes the IME target
+/// directly while it owns the keyboard. Committed composition arrives as an
+/// ordinary search event while the candidate window sits by the hint.
+pub fn enable_ime(ctx: &Context) {
+    let content = ctx.content_rect();
+    let cursor_rect = Rect::from_min_size(
+        pos2(
+            content.center().x,
+            content.top() + theme::TOP_BAR_HEIGHT + 24.0,
+        ),
+        vec2(1.0, 18.0),
+    );
+    ctx.output_mut(|output| {
+        output.ime = Some(egui::output::IMEOutput {
+            purpose: egui::IMEPurpose::Normal,
+            rect: cursor_rect.expand(8.0),
+            cursor_rect,
+            should_interrupt_composition: false,
+        });
+    });
+}
+
+/// The first title from `from` onwards the needle fits, under the first
+/// tier that has a match, wrapping back to the top when `wrap`.
+fn find(
+    titles: &[NormalizedTitle],
+    needle: &str,
+    from: usize,
+    wrap: bool,
+    loose: bool,
+) -> Option<usize> {
+    if needle.is_empty() || titles.is_empty() {
+        return None;
+    }
+    for tier in tiers(loose) {
+        let found = (0..titles.len())
+            .map(|offset| (from + offset) % titles.len())
+            .take(if wrap {
+                titles.len()
+            } else {
+                titles.len().saturating_sub(from)
+            })
+            .find(|&index| tier_matches(&titles[index], needle, *tier));
+        if found.is_some() {
+            return found;
+        }
+    }
+    None
+}
+
+/// The transient pill above the page showing what has been typed, so the
+/// letters taken over by the search are visible somewhere.
+pub fn hint(ctx: &Context, palette: Palette, page: &Page, buffer: &str) {
+    if buffer.is_empty() {
+        return;
+    }
+    egui::Area::new(egui::Id::new(("typeahead-hint", page.encode())))
+        .order(Order::Tooltip)
+        .interactable(false)
+        // Clears the top bar, whose height the pill floats beneath.
+        .anchor(Align2::CENTER_TOP, vec2(0.0, theme::TOP_BAR_HEIGHT + 10.0))
+        .show(ctx, |ui| {
+            Frame::new()
+                .fill(palette.overlay)
+                .stroke(Stroke::new(1.0, palette.outline))
+                .corner_radius(CornerRadius::same(theme::RADIUS))
+                .inner_margin(Margin::symmetric(12, 7))
+                .shadow(egui::epaint::Shadow {
+                    offset: [0, 4],
+                    blur: 16,
+                    spread: 0,
+                    color: palette.shadow,
+                })
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 7.0;
+                        theme::text(ui, "Jump", theme::medium(12.5), palette.secondary);
+                        // Every key the listener typed, never cut short:
+                        // the text is the search's memory.
+                        ui.add(
+                            egui::Label::new(
+                                egui::RichText::new(buffer)
+                                    .font(theme::medium(13.5))
+                                    .color(palette.text),
+                            )
+                            .selectable(false),
+                        );
+                    });
+                });
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn titles() -> Vec<NormalizedTitle> {
+        [
+            "Bohemian Rhapsody",
+            "Cancion Animal",
+            "Bob",
+            "Bohemian Like You",
+            "Despacito",
+            "Ubermensch",
+        ]
+        .iter()
+        .map(|title| normalize_title(title))
+        .collect()
+    }
+
+    #[test]
+    fn more_letters_narrow_the_first_match() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+        search.type_char('o', &titles);
+        assert_eq!(search.buffer(), "bo");
+        // Bohemian remains the first match while the longer query still
+        // matches it; only repeated one-letter queries cycle.
+        assert_eq!(search.row, Some(0));
+        search.type_char('h', &titles);
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn the_same_letter_cycles_through_the_matches() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(2));
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(3));
+        // It wraps back to the top.
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn a_repeated_ligature_cycles_its_matches() {
+        let titles = ["Æsir", "Æon"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        search.type_char('æ', &titles);
+        assert_eq!(search.row, Some(0));
+        search.type_char('æ', &titles);
+        assert_eq!(search.buffer(), "æ");
+        assert_eq!(search.row, Some(1));
+    }
+
+    #[test]
+    fn a_letter_that_fits_nowhere_stays_in_the_buffer() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        search.type_char('o', &titles);
+        // "bod" matches nothing, yet every letter stays typed: the hint
+        // shows them all, and a later title can still carry the text.
+        search.type_char('d', &titles);
+        assert_eq!(search.buffer(), "bod");
+        assert_eq!(search.row, None);
+        // Backspace walks the text back and finds again, from the top.
+        search.backspace(&titles);
+        assert_eq!(search.buffer(), "bo");
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn a_letter_that_matches_nothing_is_kept() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('z', &titles);
+        assert_eq!(search.buffer(), "z");
+        assert_eq!(search.row, None);
+    }
+
+    #[test]
+    fn a_repeated_letter_beyond_the_first_extends_the_text() {
+        let titles = titles();
+        let mut search = Search::default();
+        // "ca" matches Cancion; a second letter that cannot extend it is
+        // kept as text instead of hijacking the search, so words with
+        // doubled letters type as typed.
+        search.type_char('c', &titles);
+        search.type_char('a', &titles);
+        assert_eq!(search.row, Some(1));
+        search.type_char('l', &titles);
+        assert_eq!(search.buffer(), "cal");
+        assert_eq!(search.row, None);
+        search.type_char('l', &titles);
+        assert_eq!(search.buffer(), "call");
+        assert_eq!(search.row, None);
+    }
+
+    #[test]
+    fn matching_ignores_case() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('D', &titles);
+        assert_eq!(search.row, Some(4));
+        // "dE" still only fits Despacito, in any casing.
+        search.type_char('E', &titles);
+        assert_eq!(search.row, Some(4));
+        assert_eq!(search.buffer(), "DE");
+    }
+
+    #[test]
+    fn matching_ignores_punctuation_and_spaces() {
+        let titles = ["Don't Stop", "Let It Be"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        search.type_char('d', &titles);
+        search.type_char('o', &titles);
+        search.type_char('n', &titles);
+        // The typed apostrophe rides along but changes nothing.
+        search.type_char('\'', &titles);
+        assert_eq!(search.buffer(), "don'");
+        assert_eq!(search.row, Some(0));
+        // "dontstop" meets "Don't Stop" without any punctuation.
+        search.type_char('t', &titles);
+        search.type_char('s', &titles);
+        search.type_char('t', &titles);
+        search.type_char('o', &titles);
+        search.type_char('p', &titles);
+        assert_eq!(search.row, Some(0));
+        // So does "letit" meet "Let It Be", spaces and all.
+        search.clear();
+        search.type_char('l', &titles);
+        search.type_char('e', &titles);
+        search.type_char('t', &titles);
+        search.type_char('i', &titles);
+        search.type_char('t', &titles);
+        assert_eq!(search.buffer(), "letit");
+        assert_eq!(search.row, Some(1));
+    }
+
+    #[test]
+    fn ignored_punctuation_does_not_move_the_match() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+        search.type_char('.', &titles);
+        assert_eq!(search.buffer(), "b.");
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn a_space_joins_an_active_search() {
+        let titles = ["Let It Be"]
+            .iter()
+            .map(|t| normalize_title(t))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        search.type_char('l', &titles);
+        search.type_char('e', &titles);
+        search.type_char('t', &titles);
+        // The space shows in the text and is ignored by the match.
+        search.type_char(' ', &titles);
+        assert_eq!(search.buffer(), "let ");
+        assert_eq!(search.row, Some(0));
+        search.type_char('i', &titles);
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn matching_folds_accents() {
+        let titles = ["Canción"]
+            .iter()
+            .map(|t| normalize_title(t))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        for ch in "cancion".chars() {
+            search.type_char(ch, &titles);
+        }
+        assert_eq!(search.buffer(), "cancion");
+        assert_eq!(search.row, Some(0));
+        assert_eq!(normalize_title("Canción").full(), "cancion");
+    }
+
+    #[test]
+    fn matching_folds_modern_latin_accents_and_ligatures() {
+        assert_eq!(
+            normalize_title("Șapte, Ắn, Æsir & Œuvre").full(),
+            "sapteanaesiroeuvre"
+        );
+        let titles = ["Șapte Seri", "Œuvre"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        for ch in "sapte".chars() {
+            search.type_char(ch, &titles);
+        }
+        assert_eq!(search.row, Some(0));
+        assert_eq!(normalize_title("Mơ ước").full(), "mouoc");
+    }
+
+    #[test]
+    fn a_leading_article_is_a_fallback_form() {
+        assert_eq!(normalize_title("The Beatles").article(), "beatles");
+        assert_eq!(
+            normalize_title("A Day in the Life").article(),
+            "dayinthelife"
+        );
+        // Only a whole first word is an article.
+        assert_eq!(normalize_title("Theoretical").article(), "theoretical");
+
+        let both = ["The House of Sun", "House of Night"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        search.type_char('h', &both);
+        search.type_char('o', &both);
+        search.type_char('u', &both);
+        search.type_char('s', &both);
+        search.type_char('e', &both);
+        // Between an article-carried and a plain title, the plain wins.
+        assert_eq!(search.row, Some(1));
+
+        // With the plain one gone, the article yields.
+        let only_the = ["The House of Sun"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        search.type_char('h', &only_the);
+        search.type_char('o', &only_the);
+        search.type_char('u', &only_the);
+        search.type_char('s', &only_the);
+        search.type_char('e', &only_the);
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn loose_mode_matches_letters_anywhere_in_order() {
+        let titles = titles();
+        let mut search = Search::default();
+        // Without loose mode, "bl" after the first letter finds nothing
+        // (Bohemian Rhapsody has no l).
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+        search.type_char('l', &titles);
+        assert_eq!(search.row, None);
+        // With it, the letters may appear anywhere in order.
+        search.clear();
+        search.loose = true;
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+        search.type_char('l', &titles);
+        // Rhapsody has no l, so the search moves on to Like You.
+        assert_eq!(search.row, Some(3));
+        search.type_char('y', &titles);
+        assert_eq!(search.buffer(), "bly");
+        assert_eq!(search.row, Some(3));
+    }
+
+    #[test]
+    fn loose_mode_prefers_an_unbroken_run_over_scattered_letters() {
+        // "orm" is scattered through the champion but an unbroken run at
+        // the end of the storm; the run wins, whoever sits first.
+        let titles: Vec<_> = ["Porntstart Champion", "Sainted by the Storm"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect();
+        let mut search = Search {
+            loose: true,
+            ..Default::default()
+        };
+        for ch in "orm".chars() {
+            search.type_char(ch, &titles);
+        }
+        assert_eq!(search.buffer(), "orm");
+        assert_eq!(search.row, Some(1));
+    }
+
+    #[test]
+    fn loose_mode_reads_the_typed_text_as_one_run() {
+        // "the storm" is an unbroken run inside the sainted title; the
+        // darkstorm galaxy only scatters the same letters.
+        let titles: Vec<_> = [
+            "Goblin King of the Darkstorm Galaxy",
+            "Sainted by the Storm",
+        ]
+        .iter()
+        .map(|title| normalize_title(title))
+        .collect();
+        let mut search = Search {
+            loose: true,
+            ..Default::default()
+        };
+        for ch in "the storm".chars() {
+            search.type_char(ch, &titles);
+        }
+        assert_eq!(search.buffer(), "the storm");
+        assert_eq!(search.row, Some(1));
+    }
+
+    #[test]
+    fn loose_mode_searches_the_whole_list_for_a_longer_text() {
+        let titles = titles();
+        let mut search = Search {
+            loose: true,
+            ..Default::default()
+        };
+        // "bly" lands on Bohemian Like You, row 3.
+        search.type_char('b', &titles);
+        search.type_char('l', &titles);
+        search.type_char('y', &titles);
+        assert_eq!(search.row, Some(3));
+        // A new text searches the whole list again: "anc" fits Cancion
+        // Animal, back at row 1.
+        search.clear();
+        search.loose = true;
+        for ch in "anc".chars() {
+            search.type_char(ch, &titles);
+        }
+        assert_eq!(search.row, Some(1));
+    }
+
+    #[test]
+    fn backspace_shortens_and_searches_from_the_top() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        search.type_char('o', &titles);
+        search.backspace(&titles);
+        assert_eq!(search.buffer(), "b");
+        assert_eq!(search.row, Some(0));
+        search.backspace(&titles);
+        assert_eq!(search.buffer(), "");
+        assert_eq!(search.row, None);
+    }
+
+    fn key(key: egui::Key, repeat: bool) -> Event {
+        Event::Key {
+            key,
+            physical_key: None,
+            pressed: true,
+            repeat,
+            modifiers: egui::Modifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn events_are_applied_in_the_order_they_arrive() {
+        let titles = ["Ab", "Ac"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        search.type_char('a', &titles);
+        search.type_char('b', &titles);
+        search.handle_events(
+            &[key(egui::Key::Backspace, false), Event::Text("c".into())],
+            &titles,
+        );
+        assert_eq!(search.buffer(), "ac");
+        assert_eq!(search.row, Some(1));
+
+        search.handle_events(
+            &[
+                key(egui::Key::Backspace, true),
+                key(egui::Key::Backspace, true),
+            ],
+            &titles,
+        );
+        assert_eq!(search.buffer(), "");
+    }
+
+    #[test]
+    fn a_space_uses_the_query_state_at_its_place_in_the_event_stream() {
+        let titles = ["A B"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect::<Vec<_>>();
+        let mut search = Search::default();
+        let actions = search.handle_events(
+            &[
+                Event::Text("a".into()),
+                key(egui::Key::Space, false),
+                Event::Text(" ".into()),
+                Event::Text("b".into()),
+            ],
+            &titles,
+        );
+        assert!(actions.is_empty());
+        assert_eq!(search.buffer(), "a b");
+        assert_eq!(search.row, Some(0));
+
+        search.clear();
+        let actions = search.handle_events(
+            &[key(egui::Key::Space, false), Event::Text(" ".into())],
+            &titles,
+        );
+        assert_eq!(actions, vec![InputAction::TogglePlay]);
+        assert!(search.buffer().is_empty());
+    }
+
+    #[test]
+    fn paste_and_ime_commits_type_into_the_search() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.handle_events(
+            &[
+                Event::Paste("bo".into()),
+                Event::Ime(ImeEvent::Commit("h".into())),
+            ],
+            &titles,
+        );
+        assert_eq!(search.buffer(), "boh");
+        assert_eq!(search.row, Some(0));
+    }
+
+    #[test]
+    fn ime_preedit_keeps_an_existing_query_alive() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        search.handle_events(
+            &[Event::Ime(ImeEvent::Preedit {
+                text: "ぼ".into(),
+                active_range_chars: None,
+            })],
+            &titles,
+        );
+        let composed_at = Instant::now();
+        search.expire(composed_at + TIMEOUT * 10);
+        assert_eq!(search.buffer(), "b");
+        search.handle_events(&[Event::Ime(ImeEvent::Commit("o".into()))], &titles);
+        assert_eq!(search.buffer(), "bo");
+        let committed_at = Instant::now();
+        search.expire(committed_at + TIMEOUT + Duration::from_millis(1));
+        assert!(search.buffer().is_empty());
+    }
+
+    #[test]
+    fn repeated_enter_is_ignored() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        let actions = search.handle_events(
+            &[key(egui::Key::Enter, false), key(egui::Key::Enter, true)],
+            &titles,
+        );
+        assert_eq!(
+            actions,
+            vec![InputAction::Play {
+                row: 0,
+                pointer_event_before: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn enter_remembers_whether_a_pointer_event_preceded_it() {
+        let titles = titles();
+        let pointer = |pressed| Event::PointerButton {
+            pos: egui::Pos2::ZERO,
+            button: egui::PointerButton::Primary,
+            pressed,
+            modifiers: egui::Modifiers::NONE,
+        };
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        let actions =
+            search.handle_events(&[pointer(false), key(egui::Key::Enter, false)], &titles);
+        assert_eq!(
+            actions,
+            vec![InputAction::Play {
+                row: 0,
+                pointer_event_before: true,
+            }]
+        );
+        let actions = search.handle_events(&[key(egui::Key::Enter, false), pointer(true)], &titles);
+        assert_eq!(
+            actions,
+            vec![InputAction::Play {
+                row: 0,
+                pointer_event_before: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_moment_of_silence_clears_the_search() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        assert_eq!(search.row, Some(0));
+        let typed_at = Instant::now();
+        search.expire(typed_at + TIMEOUT / 2);
+        assert_eq!(search.row, Some(0));
+        search.expire(typed_at + TIMEOUT + Duration::from_millis(1));
+        assert_eq!(search.buffer(), "");
+        assert_eq!(search.row, None);
+    }
+
+    #[test]
+    fn an_unmatched_search_waits_for_a_loading_page() {
+        let mut search = Search::default();
+        search.type_char('z', &[]);
+        let waiting_at = Instant::now();
+        search.set_waiting_for_results(true, waiting_at);
+        search.expire(waiting_at + TIMEOUT * 10);
+        assert_eq!(search.buffer(), "z");
+
+        let arrived_at = waiting_at + TIMEOUT * 10;
+        search.set_waiting_for_results(false, arrived_at);
+        search.expire(arrived_at + TIMEOUT / 2);
+        assert_eq!(search.buffer(), "z");
+        search.expire(arrived_at + TIMEOUT + Duration::from_millis(1));
+        assert!(search.buffer().is_empty());
+    }
+
+    #[test]
+    fn escape_clears_the_search_at_once() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('b', &titles);
+        search.clear();
+        assert_eq!(search.buffer(), "");
+        assert_eq!(search.row, None);
+    }
+
+    #[test]
+    fn a_changed_list_revalidates_the_row() {
+        let titles = titles();
+        let mut search = Search::default();
+        search.type_char('d', &titles);
+        assert_eq!(search.row, Some(4));
+        // The list shrinks and Despacito is gone.
+        let shorter: Vec<_> = ["Bohemian Rhapsody", "Despacito"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect();
+        search.revalidate(&shorter);
+        assert_eq!(search.row, Some(1));
+        // The match is gone entirely.
+        let without: Vec<_> = ["Bohemian Rhapsody"]
+            .iter()
+            .map(|title| normalize_title(title))
+            .collect();
+        search.revalidate(&without);
+        assert_eq!(search.row, None);
+        assert_eq!(search.buffer(), "d");
+    }
+
+    #[test]
+    fn escape_and_an_empty_list_are_safe() {
+        let mut search = Search::default();
+        search.revalidate(&[]);
+        assert_eq!(search.row, None);
+        search.type_char('b', &[]);
+        assert_eq!(search.buffer(), "b");
+        assert_eq!(search.row, None);
+        search.backspace(&[]);
+        assert_eq!(search.buffer(), "");
+    }
+}

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -668,10 +668,7 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) -> Option<RowPic
             .is_some_and(|uri| uri == row.item.uri());
     let playing = is_current && app.believed_playing();
     let hovered = ui.rect_contains_pointer(rect);
-    let unavailable = match row.item {
-        PlayableItem::Track(track) => track.is_playable == Some(false) || track.is_local,
-        PlayableItem::Episode(_) => false,
-    };
+    let unavailable = !row.item.is_available();
 
     if row.picked {
         // Picked rows read as a block, so a run of them looks like one

--- a/src/ui/winamp/mod.rs
+++ b/src/ui/winamp/mod.rs
@@ -315,6 +315,7 @@ pub fn show(app: &mut App, ui: &mut Ui) {
         app.winamp.last_pos = Some([rect.min.x, rect.min.y]);
     }
     let focused = focused.unwrap_or(true);
+    super::typeahead::leave_page(app, &ctx);
     super::keys::handle(app, &ctx);
     for path in dropped_skins(&ctx) {
         app.actions.push(Action::InstallSkin(path));


### PR DESCRIPTION
## Why

I have missed this in music players ever since encountering it in what I think was iTunes: when a long song list is already open, typing should jump straight to the song instead of making me reach for a filter or scroll through the list.

This fits Fastpotify's native, fast interface because the matching is entirely local and follows the list already on screen. It adds no network work or dependency.

There is an unavoidable key-ownership tradeoff. While type-ahead is enabled and a supported song list is open, `M`, `S`, `R`, `Q`, and `L` are search text, so the mute, shuffle, repeat, queue, and lyrics shortcuts cannot fire on that page. They continue to work everywhere else. Type-ahead is therefore opt-in, while Loose matching defaults on for users who enable it.

No issue linked; no matching issue or pull request was found.

## What changed

- Add opt-in type-ahead navigation to playlists, albums, Liked Songs, and Top Songs.
- Normalize case, common Latin accents and ligatures, punctuation, spacing, and leading articles before matching.
- Add optional loose matching, preferring prefixes, then contiguous substrings, then ordered subsequences.
- Keep input event order intact for text, Space, Enter, Backspace, Escape, paste, and IME composition.
- Highlight and scroll to the matching row; Enter plays it through the same row action as direct interaction.
- Revalidate searches as sorted, filtered, or paginated rows change, and request another page when an unmatched query may still resolve.
- Leave ordinary shortcuts active when type-ahead is disabled, the mini player owns the window, a page failed, or a dialog, popup, device picker, or text field owns input.
- Add backward-compatible settings, focused unit and demo-mode integration coverage, and user/reference documentation.
<img width="1117" height="849" alt="Screenshot_20260901_111740" src="https://github.com/user-attachments/assets/e0e61a1d-236d-4735-a540-e2b49a618f28" />

https://github.com/user-attachments/assets/77ad9be6-6279-4156-a9d4-441eff5bfbdc


## Verification

Tested on Linux 7.2.2-arch1-1 x86_64:

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets` (256 passed)
- `cargo test --locked --all-targets --all-features` (256 passed)
- `cargo test --locked --all-features --doc`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- `(cd docs && BUNDLE_PATH=/tmp/opencode/fastpotify-gems BUNDLE_FROZEN=true bundle exec jekyll build)`
- `cargo build --locked --release --features demo`

No static screenshot is attached: the important behavior is transient keyboard ownership, ordered input, timeout, and playback dispatch. Demo-mode integration tests exercise those paths directly, including matching, Space, Enter, dialogs, failed/loading pages, unavailable tracks, navigation, and shortcut fallback.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.