### PR TITLE
Update installation instructions for Rust and add Fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ brew install --cask crmne/tap/fastpotify
 Everywhere else, build the single binary with Rust 1.95 or newer:
 
 ```bash
-cargo install --path .
+cargo install --path . --locked
 ```
 
 MilkDrop uses libprojectM, which is built from source. This needs CMake, a C++
 compiler, and libclang. To build without MilkDrop or those tools, run
-`cargo install --path . --no-default-features`. On Linux, you also need the
+`cargo install --path . --locked --no-default-features`. On Linux, you also need the
 development packages for ALSA, PulseAudio or PipeWire, and the windowing
 libraries. On Arch:
 
@@ -109,6 +109,13 @@ and on Debian or Ubuntu:
 ```bash
 sudo apt install libasound2-dev libpulse-dev libxkbcommon-dev libwayland-dev \
   cmake clang libclang-dev
+```
+
+and on Fedora:
+
+```bash
+sudo dnf install alsa-lib-devel pulseaudio-libs-devel libxkbcommon-devel \
+  wayland-devel cmake clang libclang-devel
 ```
 
 On Windows, libprojectM is built with Visual Studio 2022, CMake, LLVM, and


### PR DESCRIPTION
## Why

**Build failures on `cargo install`:** Running `cargo install --path .` ignores `Cargo.lock` by default, pulling transitive dependency updates (notably newer versions of `vergen` and `vergen-lib`) that cause compilation errors in `librespot-core`'s build script (`error[E0277]: the trait bound Build: Add is not satisfied`). Adding `--locked` enforces the reproducible dependency tree.

## What changed

- Updated the installation command in `README.md` to `cargo install --path . --locked`.
- Added native system dependency installation instructions for Fedora (dnf) alongside the existing Arch and Ubuntu/Debian instructions.