### PR TITLE
Bring the window back out of the Dock when the Dock asks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4861,6 +4861,11 @@ impl App {
                     // No window exists; the outer loop creates one.
                     self.wants_show = true;
                 } else {
+                    // A minimized window has to be restored before it can be
+                    // focused: Focus alone leaves it in the Dock, and the
+                    // platform draws no frames while it is down there, so
+                    // nothing arrives to ask a second time.
+                    ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
                     ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
                 }
             }
@@ -6715,6 +6720,39 @@ mod tests {
             "the new screen is noted"
         );
         assert_eq!(app.settings.milkdrop_fps, 30, "their number stands");
+    }
+
+    /// A window in the Dock is drawn no frames, so the one frame a Show
+    /// request buys has to be the frame that brings it back. Focus alone
+    /// leaves it down there, and nothing asks again.
+    #[test]
+    fn showing_a_minimized_window_restores_it_before_focusing_it() {
+        // #given a window exists, minimized rather than closed
+        let mut app = headless_app();
+        let ctx = egui::Context::default();
+        assert!(!app.window_hidden, "a window this app still owns");
+
+        // #when something asks for the window: the Dock, the tray, or
+        // `fastpotify show`
+        let mut output = ctx.run_ui(Default::default(), |ui| {
+            app.apply(Action::ShowWindow, ui.ctx());
+        });
+        output.textures_delta.clear();
+
+        // #then
+        let commands = &output
+            .viewport_output
+            .get(&egui::ViewportId::ROOT)
+            .expect("the root viewport")
+            .commands;
+        assert!(
+            commands.contains(&egui::ViewportCommand::Minimized(false)),
+            "asked to show, but never asked to come out of the Dock: {commands:?}"
+        );
+        assert!(
+            commands.contains(&egui::ViewportCommand::Focus),
+            "restored but left behind whatever is in front of it: {commands:?}"
+        );
     }
 
     fn headless_app() -> App {

--- a/src/tray_native.rs
+++ b/src/tray_native.rs
@@ -241,17 +241,28 @@ mod host {
     thread_local! {
         /// The status item, which only the main thread may touch.
         pub static ITEM: RefCell<Option<Item>> = const { RefCell::new(None) };
-        pub(super) static REOPEN: RefCell<Option<Sender<TrayCommand>>> = const { RefCell::new(None) };
+        /// The channel a Dock click asks through, and the wake that makes
+        /// somebody read it.
+        pub(super) static REOPEN: RefCell<Option<(Sender<TrayCommand>, Wake)>> = const { RefCell::new(None) };
     }
 
-    pub(super) fn request_reopen(has_visible_windows: bool) -> Bool {
-        if !has_visible_windows {
-            REOPEN.with(|slot| {
-                if let Some(sender) = slot.borrow().as_ref() {
-                    let _ = sender.send(TrayCommand::Show);
-                }
-            });
-        }
+    /// A Dock click, asking for the app back.
+    ///
+    /// `has_visible_windows` is not the question it sounds like: a window
+    /// sitting in the Dock still counts as visible, which is exactly the
+    /// case that needs help, so the flag is not consulted. Asking for a
+    /// window that is already up costs a focus and nothing else.
+    pub(super) fn request_reopen(_has_visible_windows: bool) -> Bool {
+        REOPEN.with(|slot| {
+            if let Some((sender, wake)) = slot.borrow().as_ref() {
+                let _ = sender.send(TrayCommand::Show);
+                // Ask for a frame as well as leaving a message. A minimized
+                // window is drawn none at all, and every repaint this app
+                // schedules is armed by the frame before it, so the only
+                // reader of that message is a loop that has already stopped.
+                wake();
+            }
+        });
         Bool::YES
     }
 
@@ -302,7 +313,7 @@ mod host {
             log::warn!("the status item can only be made on the main thread");
             return;
         };
-        REOPEN.with(|slot| *slot.borrow_mut() = Some(sender.clone()));
+        REOPEN.with(|slot| *slot.borrow_mut() = Some((sender.clone(), Arc::clone(&wake))));
         install_reopen_handler(&NSApplication::sharedApplication(mtm));
         match build(sender, wake) {
             Ok(item) => {
@@ -419,16 +430,42 @@ pub fn idle(duration: Duration) {
 mod tests {
     use super::*;
 
+    /// A Dock click asks for the window whatever AppKit says about visible
+    /// ones, and asks for a frame as well as leaving a message.
+    ///
+    /// Both halves are load-bearing. A window in the Dock is reported as
+    /// visible, so a handler that trusted that flag did nothing at all for
+    /// the one case that needed it; and a minimized window is drawn no
+    /// frames, so the message alone would wait for a reader that has
+    /// stopped running.
     #[test]
-    fn dock_reopen_requests_a_window_only_when_none_is_visible() {
+    fn a_dock_click_asks_for_the_window_and_for_a_frame() {
         let (sender, commands) = std::sync::mpsc::channel();
-        host::REOPEN.with(|slot| *slot.borrow_mut() = Some(sender));
+        let woken = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&woken);
+        let wake: Wake = Arc::new(move || {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        });
+        host::REOPEN.with(|slot| *slot.borrow_mut() = Some((sender, wake)));
 
+        // A minimized window is the reported-visible case, and the one the
+        // bug report is about.
         assert!(host::request_reopen(true).as_bool());
-        assert!(commands.try_recv().is_err());
+        assert_eq!(
+            commands.try_recv(),
+            Ok(TrayCommand::Show),
+            "a window in the Dock reports as visible, and was left there"
+        );
+        assert_eq!(
+            woken.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the message was left but nobody was asked to read it"
+        );
 
+        // No window at all: the tray case, which already worked.
         assert!(host::request_reopen(false).as_bool());
         assert_eq!(commands.try_recv(), Ok(TrayCommand::Show));
+        assert_eq!(woken.load(std::sync::atomic::Ordering::SeqCst), 2);
         host::REOPEN.with(|slot| *slot.borrow_mut() = None);
     }
 }


### PR DESCRIPTION
Closes #141.

## Why

Minimizing the Winamp mini player was unrecoverable. The window came back
when the Dock icon was clicked, but came back dead: the clock stopped at
whatever second it went down at, the macOS menu bar took clicks and did
nothing with them, and only the music carried on. The only way out was
force-quitting.

## What changed

macOS draws no frames for a minimized window, and every repaint this app
schedules is armed by the frame before it. So the first frame that does not
run is the last one: nothing re-arms, the loop parks in the run loop waiting
for an event, and the queues holding menu picks, tray commands and control
commands are never read again. The window AppKit puts back on screen is the
last frame it drew.

Three things kept it down there, and all three had to go:
1. **`applicationShouldHandleReopen:` only acted when AppKit reported no
   visible windows.** A window sitting in the Dock is reported as *visible*,
   so the one case that needed the handler was the one case it ignored. The
   flag is no longer consulted; asking for a window that is already up costs
   a focus and nothing else.
2. **It left a message without asking anybody to read it.** The `Show` it
   sends can only be read by the frame loop, which by then has stopped, so it
   wakes the app too — the way the status item's own menu items already do.
3. **`Show` then focused a window that was still minimized.** `Focus` does
   not bring a window out of the Dock, so even a frame that was bought would
   have spent it on a no-op. It restores the window first, then focuses it.

Each fix is useless without the others: the first gets the handler to act,
the second buys a frame, the third makes that frame count.

## Verification

**Diagnosis.** Sampling a stuck instance showed the main thread 100% idle in
`__CFRunLoopServiceMachPort` — parked in the run loop, not deadlocked and not
spinning. Logging the delegate then showed it firing with
`has_visible_windows=true` for a window in the Dock, and so doing nothing:

```
17:21:55  reopen handler installed on WinitApplicationDelegate
17:23:07  frame=4020 at 72.6s          ← last frame before the Dock click
17:23:11  applicationShouldHandleReopen visible=true   ← guard bails
17:23:12  frame=4050 at 77.1s          ← one passive frame, then silence
```

**Before**, the mini player is painted but stale — 02:52 on the mini player
against 3:53 in Spotify, the same track:

<!-- drag in the frozen-clock screenshot here -->

**After**, the four steps from #141 (play a song, open the mini player,
minimize it, click the Dock icon) return a live window on macOS 26.2.

Commands run, all passing:

```sh
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets                  # 256 passed
cargo test --locked --all-targets --all-features   # 256 passed
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
```

Two tests, both checked to fail without their fix rather than pass either way:

- `a_dock_click_asks_for_the_window_and_for_a_frame` — fails with *"a window in
  the Dock reports as visible, and was left there"* if the guard returns.
- `showing_a_minimized_window_restores_it_before_focusing_it` — asserts `Show`
  emits `Minimized(false)` before `Focus`.

**Platforms, honestly:** written, reproduced, and tested on macOS 26.2 (arm64)
via the mini player. The change is inside `#[cfg(target_os = "macos")]` code
plus one shared viewport command; Linux and Windows compile and their tests
pass, but I have not run either, and neither has the Dock behaviour this fixes.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] I updated documentation for user-visible behaviour, settings, files, or network access — **not applicable**: this restores documented behaviour rather than changing it, and adds no setting, file, or network access. Nothing in the README or the guide describes minimizing.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
