### PR TITLE
Prefer a Han fallback face from the reader's region

### DIFF
--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use skrifa::MetadataProvider as _;
+use skrifa::raw::TableProvider as _;
 
 /// Registered font name, file bytes, and face index.
 pub struct Fallback {
@@ -58,9 +59,6 @@ const HAN_REGIONS: &[(&str, &str)] = &[
     ("ja", "jp"),
     ("ko", "kr"),
 ];
-
-/// The regional cuts a pan-CJK family can name itself after.
-const HAN_REGION_NAMES: &[&str] = &["sc", "tc", "hk", "jp", "kr"];
 
 /// How deep to walk each font directory. Distributions nest a level or two
 /// (`/usr/share/fonts/truetype/noto`); nothing legitimate goes deeper, and the
@@ -181,6 +179,12 @@ fn rank_family(path: &Path, wanted: &[&str], best: &mut Option<(usize, PathBuf, 
 
 /// A face that covers a script, and how well it suits the interface.
 struct Candidate {
+    /// Drawn for another Han region than the locale's. A Japanese face draws
+    /// 中 and so passes the coverage probe, but every simplified character it
+    /// lacks would come from whatever fallback follows, at that font's size
+    /// and baseline, so it ranks below any face from the right region and
+    /// serves only when it is all there is.
+    foreign: bool,
     score: u32,
     path: PathBuf,
     index: u32,
@@ -313,25 +317,31 @@ fn probe_file(path: &Path, han: &str, best: &mut BTreeMap<&str, Candidate>) {
             .to_lowercase();
         let charmap = font.charmap();
         let outlines = font.outline_glyphs();
+        // A face must draw the character, not merely map it: a bitmap or
+        // colour-only font passes the charmap and renders nothing.
+        let draws = |character: char| {
+            charmap
+                .map(character)
+                .is_some_and(|glyph| outlines.get(glyph).is_some())
+        };
         for (script, probe, hint) in FALLBACK_SCRIPTS {
-            // A face must draw the character, not merely map it: a bitmap or
-            // colour-only font passes the charmap and renders nothing.
-            let covers = charmap
-                .map(*probe)
-                .is_some_and(|glyph| outlines.get(glyph).is_some());
-            if !covers {
+            if !draws(*probe) {
                 continue;
             }
             let score = face_score(&family, attributes.weight.value(), han, hint);
+            let foreign = *script == "han" && {
+                let code_pages = font.os2().ok().and_then(|os2| os2.ul_code_page_range_1());
+                !covers_han_region(code_pages, han)
+            };
             // Ties break on the path so two machines carrying the same fonts
             // resolve the same face, whatever order their directories list.
-            if best
-                .get(script)
-                .is_none_or(|held| (score, path) < (held.score, held.path.as_path()))
-            {
+            if best.get(script).is_none_or(|held| {
+                (foreign, score, path) < (held.foreign, held.score, held.path.as_path())
+            }) {
                 best.insert(
                     script,
                     Candidate {
+                        foreign,
                         score,
                         path: path.to_path_buf(),
                         index,
@@ -385,12 +395,32 @@ fn face_score(family: &str, weight: f32, han: &str, hint: &str) -> u32 {
     if let Some(region) = family
         .rsplit(' ')
         .next()
-        .filter(|region| HAN_REGION_NAMES.contains(region))
+        .filter(|region| han_code_page(region).is_some())
         && region != han
     {
         score += 40;
     }
     score
+}
+
+/// The OS/2 `ulCodePageRange1` bit a face sets to declare it covers a
+/// region's legacy character set: Shift JIS, GB 2312, Wansung, or Big5.
+fn han_code_page(region: &str) -> Option<u32> {
+    match region {
+        "jp" => Some(17),
+        "sc" => Some(18),
+        "kr" => Some(19),
+        "tc" | "hk" => Some(20),
+        _ => None,
+    }
+}
+
+/// Whether a face's declared code pages include the region's character set.
+/// A face too old to declare any is taken at its word: none.
+fn covers_han_region(code_pages: Option<u32>, han: &str) -> bool {
+    han_code_page(han)
+        .zip(code_pages)
+        .is_some_and(|(bit, pages)| pages & (1 << bit) != 0)
 }
 
 /// The user's locale, lowercased, or an empty string when none is set. A
@@ -501,6 +531,18 @@ mod tests {
             simplified,
             "each locale ranks its own cut the same"
         );
+    }
+
+    #[test]
+    fn a_face_declares_the_regions_it_covers() {
+        // Hiragino Sans covers 中 but declares only Shift JIS.
+        let japanese = Some(1 << 17);
+        assert!(covers_han_region(japanese, "jp"));
+        assert!(!covers_han_region(japanese, "sc"));
+        assert!(!covers_han_region(None, "sc"), "no OS/2 table, no claim");
+        for (_, region) in HAN_REGIONS {
+            assert!(han_code_page(region).is_some(), "{region} has a code page");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

Follow-up to #10. On macOS, a Simplified Chinese title such as 刘珂矣 or 半壶纱 rendered with its characters at two different sizes and baselines. The han fallback ranks faces by name, and Hiragino Sans, a Japanese font, beat PingFang and Heiti because it calls itself "Sans". It draws the probe character 中 and so passes the coverage check, but it carries no simplified-only characters (刘, 壶, 纱, 纯, 乐, 寻, 风…). Those fell through to the next fallback that had them, Arial Unicode MS, whose em box and baseline differ.

## What changed

A face declares the legacy character sets it covers in the OS/2 table's `ulCodePageRange1` bits (Shift JIS, GB 2312, Wansung, Big5), the same signal Windows font linking reads. The han probe now checks that bit for the locale's region, and a face that does not declare it ranks below every face that does. The rank is an explicit tier in the candidate comparison rather than a numeric penalty, so it cannot drift out of proportion with the naming scores. A wrong-region face still serves when it is all a machine has.

The five region names that were listed in a separate constant now come from the same lookup as the code page bits, so there is one table to extend instead of two.

I checked the bits against the fonts on a current macOS install and they match reality: Hiragino Sans declares only JIS, Hiragino Sans GB declares JIS and GB, Heiti SC/TC declare all five, Apple SD Gothic Neo only Korean, Songti only GB. Noto Sans CJK declares all of them, so on Linux nothing changes and the locale still picks the regional cut by name as before.

## Verification

- macOS 27, `LANG=en_US.UTF-8`: the han fallback moved from `ヒラギノ角ゴシック W4.ttc` (Hiragino Sans) to `Hiragino Sans GB.ttc`; kana still resolve to Hiragino Sans. A demo render of an artist page patched with the titles above shows every character at one size on one baseline. Confirmed in the running app against a real library.
- Arch Linux with Noto Sans CJK: identical before and after.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked --all-targets` (247 passing), and `RUSTDOCFLAGS='-D warnings' cargo doc` are clean. The macOS run used `--no-default-features` because that machine has no CMake; the all-features jobs are left to CI.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access. (No new settings, files, or network access.)
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoLoTwcjKiy1MxtdEb2RX2
