### PR TITLE
feat: Custom scheme support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,7 +5491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ everyday use, and connection details.
   of what you are looking at or listening to. Turn it off in Settings.
 - **Light and dark**, or follow the system. Custom colour schemes are
   supported: drop a JSON file into `~/.config/fastpotify/schemes/` and select
-  it in Settings. Press `Ctrl+Shift+R` / `Cmd+Shift+R` to reload a scheme
+  it in Settings. Press `Ctrl+Shift+R` / `Cmd+Shift+R` or run
+  `fastpotify scheme reload` to reload a scheme
   after editing.
 - **Winamp mini player.** `Ctrl+M` opens a small player for classic `.wsz`
   skins, drawn at 1x to 4x scale. It includes a spectrum analyser, playlist,
@@ -217,7 +218,13 @@ fastpotify seek -- -15         fastpotify like
 fastpotify seek-to 90          fastpotify play-uri spotify:playlist:37i9…
 fastpotify show                fastpotify transfer <device-id>
 fastpotify now-playing [--raw] fastpotify devices [--raw]
+fastpotify scheme reload
 ```
+
+On all platforms, `fastpotify scheme reload` reloads colour schemes from disk
+and updates the active scheme immediately without needing window focus,
+making it suitable for post-hook scripts from desktop theming tools such as
+Noctalia.
 
 `shuffle` and `repeat` toggle when used without an argument. Pass a state to
 set it directly. `like` adds or removes the playing track from your library.
@@ -255,8 +262,8 @@ Place `.json` files in `~/.config/fastpotify/schemes/`. Each file defines a
 colour scheme with hex values (e.g. `"#1ed760"`). Missing fields fall back to
 the built-in dark palette, so partial overrides work. The scheme's `name`
 field sets the button label in Settings; the filename stem is used when `name`
-is empty. Press `Ctrl+Shift+R` / `Cmd+Shift+R` to reload the active scheme
-after editing.
+is empty. Press `Ctrl+Shift+R` / `Cmd+Shift+R` or run `fastpotify scheme reload`
+to reload the active scheme after editing.
 
 Caches (audio, artwork) live under the cache directory and can be deleted at
 any time without signing you out.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ everyday use, and connection details.
   starts.
 - **Album-art colour.** Pages and the player bar take a tint from the cover
   of what you are looking at or listening to. Turn it off in Settings.
-- **Light and dark**, or follow the system.
+- **Light and dark**, or follow the system. Custom colour schemes are
+  supported: drop a JSON file into `~/.config/fastpotify/schemes/` and select
+  it in Settings. Press `Ctrl+Shift+R` / `Cmd+Shift+R` to reload a scheme
+  after editing.
 - **Winamp mini player.** `Ctrl+M` opens a small player for classic `.wsz`
   skins, drawn at 1x to 4x scale. It includes a spectrum analyser, playlist,
   and equalizer. Drop a skin from the
@@ -245,6 +248,15 @@ autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
 from artwork, and the mini player's skin and size.
 Playback settings apply when you press **Apply and restart playback**.
+
+### Custom colour schemes
+
+Place `.json` files in `~/.config/fastpotify/schemes/`. Each file defines a
+colour scheme with hex values (e.g. `"#1ed760"`). Missing fields fall back to
+the built-in dark palette, so partial overrides work. The scheme's `name`
+field sets the button label in Settings; the filename stem is used when `name`
+is empty. Press `Ctrl+Shift+R` / `Cmd+Shift+R` to reload the active scheme
+after editing.
 
 Caches (audio, artwork) live under the cache directory and can be deleted at
 any time without signing you out.

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
               pname = "fastpotify";
               version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
               src = self;
-              hash = "sha256-l2pWMz/X2RpWaAHMjOZrmQ8v1Ux+JECdh+/aQn/pzjM=";
+              hash = "sha256-EDBVZ7eJjZFtVd7XIKVLUH0sUlyEO5Z1rwwJfzmpArc=";
             };
 
             nativeBuildInputs =

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,8 @@ pub struct App {
     /// Sample data is loaded; Spotify requests are disabled.
     pub offline: bool,
     pub palette: Palette,
-    applied_dark: Option<bool>,
+    /// The last theme choice that was applied, to detect when it changes.
+    applied_theme: Option<ThemeChoice>,
     /// Available custom colour schemes scanned from the schemes directory.
     pub available_schemes: Vec<(String, theme::ColorScheme)>,
 
@@ -473,7 +474,7 @@ impl App {
             control_devices_stale: true,
             offline: false,
             palette: Palette::dark(),
-            applied_dark: None,
+            applied_theme: None,
             available_schemes: Vec::new(),
             auth: AuthStatus::Starting,
             user: None,
@@ -648,7 +649,7 @@ impl App {
                 }
             }
         });
-        self.applied_dark = None;
+        self.applied_theme = None;
         self.winamp.forget_textures();
         self.window_hidden = false;
         self.hide_intent = false;
@@ -1880,17 +1881,11 @@ impl App {
         let new_palette = match &self.settings.theme {
             ThemeChoice::Dark => Some(Palette::dark()),
             ThemeChoice::Light => Some(Palette::light()),
-            ThemeChoice::System => {
-                if self.applied_dark != Some(dark) {
-                    Some(if dark {
-                        Palette::dark()
-                    } else {
-                        Palette::light()
-                    })
-                } else {
-                    None
-                }
-            }
+            ThemeChoice::System => Some(if dark {
+                Palette::dark()
+            } else {
+                Palette::light()
+            }),
             ThemeChoice::Custom(name) => self
                 .available_schemes
                 .iter()
@@ -1898,12 +1893,11 @@ impl App {
                 .map(|(_, scheme)| scheme.to_palette()),
         };
         if let Some(palette) = new_palette
-            && (self.applied_dark != Some(dark)
-                || matches!(&self.settings.theme, ThemeChoice::Custom(_)))
+            && self.applied_theme.as_ref() != Some(&self.settings.theme)
         {
             self.palette = palette;
             theme::apply(ctx, &self.palette);
-            self.applied_dark = Some(dark);
+            self.applied_theme = Some(self.settings.theme.clone());
             self.accents.clear();
             self.accent_pending.clear();
         }
@@ -5466,7 +5460,7 @@ impl App {
             }
             Action::ReloadTheme => {
                 self.available_schemes = self.load_schemes();
-                self.applied_dark = None;
+                self.applied_theme = None;
                 self.toast("Colour scheme reloaded");
             }
             Action::Quit => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,7 +22,7 @@ use crate::paths::AppDirs;
 use crate::player::{EngineConfig, LoadSpec, LocalState, Playback, PlayerCommand, RepeatMode};
 use crate::settings::{SessionState, Settings, ThemeChoice};
 use crate::single_instance::ControlCommand;
-use crate::theme::{self, Palette};
+use crate::theme::{self, ColorScheme, Palette};
 use crate::tray::{TrayCommand, TrayService};
 use crate::util;
 
@@ -170,6 +170,8 @@ pub struct App {
     pub offline: bool,
     pub palette: Palette,
     applied_dark: Option<bool>,
+    /// Available custom colour schemes scanned from the schemes directory.
+    pub available_schemes: Vec<(String, theme::ColorScheme)>,
 
     pub auth: AuthStatus,
     pub user: Option<User>,
@@ -472,6 +474,7 @@ impl App {
             offline: false,
             palette: Palette::dark(),
             applied_dark: None,
+            available_schemes: Vec::new(),
             auth: AuthStatus::Starting,
             user: None,
             local_device_id: None,
@@ -608,6 +611,7 @@ impl App {
             winamp: crate::winamp::WinampState::new(session.winamp_pos, tap, eq),
         };
         app.local.volume = app.settings.volume;
+        app.available_schemes = app.load_schemes();
         // What was played here is on disk and needs nothing from the
         // network, so the tab has rows before Spotify has answered.
         app.rebuild_recents();
@@ -627,10 +631,22 @@ impl App {
     pub fn attach(&mut self, ctx: &egui::Context) {
         theme::install(ctx);
         ctx.add_bytes_loader(std::sync::Arc::new(self.backend.art().clone()));
-        ctx.set_theme(match self.settings.theme {
+        ctx.set_theme(match &self.settings.theme {
             ThemeChoice::Dark => egui::ThemePreference::Dark,
             ThemeChoice::Light => egui::ThemePreference::Light,
             ThemeChoice::System => egui::ThemePreference::System,
+            ThemeChoice::Custom(name) => {
+                let dark = self
+                    .available_schemes
+                    .iter()
+                    .find(|(n, _)| n == name)
+                    .is_none_or(|(_, s)| s.dark);
+                if dark {
+                    egui::ThemePreference::Dark
+                } else {
+                    egui::ThemePreference::Light
+                }
+            }
         });
         self.applied_dark = None;
         self.winamp.forget_textures();
@@ -1861,17 +1877,70 @@ impl App {
 
     fn apply_theme(&mut self, ctx: &egui::Context) {
         let dark = ctx.theme() == egui::Theme::Dark;
-        if self.applied_dark != Some(dark) {
-            self.palette = if dark {
-                Palette::dark()
-            } else {
-                Palette::light()
-            };
+        let new_palette = match &self.settings.theme {
+            ThemeChoice::Dark => Some(Palette::dark()),
+            ThemeChoice::Light => Some(Palette::light()),
+            ThemeChoice::System => {
+                if self.applied_dark != Some(dark) {
+                    Some(if dark {
+                        Palette::dark()
+                    } else {
+                        Palette::light()
+                    })
+                } else {
+                    None
+                }
+            }
+            ThemeChoice::Custom(name) => self
+                .available_schemes
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, scheme)| scheme.to_palette()),
+        };
+        if let Some(palette) = new_palette
+            && (self.applied_dark != Some(dark)
+                || matches!(&self.settings.theme, ThemeChoice::Custom(_)))
+        {
+            self.palette = palette;
             theme::apply(ctx, &self.palette);
             self.applied_dark = Some(dark);
             self.accents.clear();
             self.accent_pending.clear();
         }
+    }
+
+    /// Scan the schemes directory and return all parseable colour schemes,
+    /// keyed by file stem, sorted by name.
+    fn load_schemes(&self) -> Vec<(String, ColorScheme)> {
+        let dir = self.dirs.schemes_dir();
+        let mut schemes = Vec::new();
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return schemes;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string();
+            match std::fs::read_to_string(&path) {
+                Ok(text) => match serde_json::from_str::<ColorScheme>(&text) {
+                    Ok(scheme) => schemes.push((stem, scheme)),
+                    Err(error) => {
+                        log::warn!("scheme {}: {error}", path.display());
+                    }
+                },
+                Err(error) => {
+                    log::warn!("scheme {}: {error}", path.display());
+                }
+            }
+        }
+        schemes.sort_by(|a, b| a.1.name.cmp(&b.1.name).then(a.0.cmp(&b.0)));
+        schemes
     }
 
     fn handle_tray(&mut self) {
@@ -5142,11 +5211,24 @@ impl App {
             }
             Action::SettingsChanged => {
                 self.settings_dirty = true;
-                ctx.set_theme(match self.settings.theme {
+                ctx.set_theme(match &self.settings.theme {
                     ThemeChoice::Dark => egui::ThemePreference::Dark,
                     ThemeChoice::Light => egui::ThemePreference::Light,
                     ThemeChoice::System => egui::ThemePreference::System,
+                    ThemeChoice::Custom(name) => {
+                        let dark = self
+                            .available_schemes
+                            .iter()
+                            .find(|(n, _)| n == name)
+                            .is_none_or(|(_, s)| s.dark);
+                        if dark {
+                            egui::ThemePreference::Dark
+                        } else {
+                            egui::ThemePreference::Light
+                        }
+                    }
                 });
+                self.available_schemes = self.load_schemes();
             }
             Action::RestartEngine => {
                 self.save_settings();
@@ -5381,6 +5463,11 @@ impl App {
                         .download(pack, self.dirs.milkdrop_dir(), ctx.clone());
                     self.toast(format!("Downloading {} presets", pack.name));
                 }
+            }
+            Action::ReloadTheme => {
+                self.available_schemes = self.load_schemes();
+                self.applied_dark = None;
+                self.toast("Colour scheme reloaded");
             }
             Action::Quit => {
                 self.quit_requested = true;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1994,6 +1994,7 @@ impl App {
                 ControlCommand::OpenLink(uri) => Some(Action::OpenLink(uri)),
                 ControlCommand::Transfer(device_id) => Some(Action::Transfer(device_id)),
                 ControlCommand::RefreshDevices => Some(Action::RefreshDevices),
+                ControlCommand::ReloadTheme => Some(Action::ReloadTheme),
             };
             if let Some(action) = action {
                 self.actions.push(action);
@@ -5460,8 +5461,21 @@ impl App {
             }
             Action::ReloadTheme => {
                 self.available_schemes = self.load_schemes();
+                if let ThemeChoice::Custom(name) = &self.settings.theme {
+                    let dark = self
+                        .available_schemes
+                        .iter()
+                        .find(|(n, _)| n == name)
+                        .is_none_or(|(_, s)| s.dark);
+                    ctx.set_theme(if dark {
+                        egui::ThemePreference::Dark
+                    } else {
+                        egui::ThemePreference::Light
+                    });
+                }
                 self.applied_theme = None;
                 self.toast("Colour scheme reloaded");
+                ctx.request_repaint();
             }
             Action::Quit => {
                 self.quit_requested = true;
@@ -8011,6 +8025,26 @@ mod tests {
             "{:?}",
             app.actions
         );
+        assert!(queue.lock().expect("the queue").is_empty());
+    }
+
+    /// Reloading a colour scheme via the control channel produces `Action::ReloadTheme`.
+    #[test]
+    fn a_scheme_reload_control_command_becomes_reload_theme_action() {
+        // #given
+        let mut app = headless_app();
+        let queue: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> = Default::default();
+        app.control_commands = Some(std::sync::Arc::clone(&queue));
+
+        // #when
+        queue
+            .lock()
+            .expect("the queue")
+            .push(ControlCommand::ReloadTheme);
+        app.handle_control_commands();
+
+        // #then
+        assert!(matches!(app.actions.as_slice(), [Action::ReloadTheme]));
         assert!(queue.lock().expect("the queue").is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,17 @@ enum Control {
     },
     /// Bring the window of the running instance forward
     Show,
+    /// Commands for custom colour schemes
+    Scheme {
+        #[command(subcommand)]
+        action: SchemeAction,
+    },
+}
+
+#[derive(Clone, Copy, Debug, clap::Subcommand)]
+enum SchemeAction {
+    /// Reload colour schemes from disk and reapply the active one
+    Reload,
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
@@ -142,7 +153,7 @@ enum Repeat {
 }
 
 /// Sends one control verb to the running instance. Speaks over the
-/// single-instance loopback socket, which Linux does not have.
+/// single-instance loopback socket.
 #[cfg(not(target_os = "linux"))]
 fn run_control(control: Control) -> i32 {
     let raw = matches!(
@@ -184,6 +195,9 @@ fn run_control(control: Control) -> i32 {
         Control::Transfer { device_id } => format!("transfer {device_id}"),
         Control::NowPlaying { .. } => "nowplaying".to_owned(),
         Control::Show => "show".to_owned(),
+        Control::Scheme {
+            action: SchemeAction::Reload,
+        } => "scheme reload".to_owned(),
     };
     match single_instance::send(&verb) {
         Ok(single_instance::Reply::Ok) => 0,
@@ -211,12 +225,26 @@ fn run_control(control: Control) -> i32 {
 }
 
 #[cfg(target_os = "linux")]
-fn run_control(_control: Control) -> i32 {
-    eprintln!(
-        "On Linux the running instance speaks MPRIS instead; use e.g. \
-         `playerctl --player=fastpotify play-pause`."
-    );
-    2
+fn run_control(control: Control) -> i32 {
+    match control {
+        Control::Scheme {
+            action: SchemeAction::Reload,
+        } => match single_instance::send("scheme reload") {
+            Ok(single_instance::Reply::Ok) => 0,
+            Ok(_) => 0,
+            Err(error) => {
+                eprintln!("Fastpotify is not running or does not support remote control: {error}");
+                1
+            }
+        },
+        _ => {
+            eprintln!(
+                "On Linux the running instance speaks MPRIS instead; use e.g. \
+                 `playerctl --player=fastpotify play-pause`."
+            );
+            2
+        }
+    }
 }
 
 /// The `nowplaying` snapshot as one human-readable line.

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,9 +229,8 @@ fn run_control(control: Control) -> i32 {
     match control {
         Control::Scheme {
             action: SchemeAction::Reload,
-        } => match single_instance::send("scheme reload") {
-            Ok(single_instance::Reply::Ok) => 0,
-            Ok(_) => 0,
+        } => match single_instance::reload_theme_in_running_instance() {
+            Ok(()) => 0,
             Err(error) => {
                 eprintln!("Fastpotify is not running or does not support remote control: {error}");
                 1

--- a/src/model.rs
+++ b/src/model.rs
@@ -765,5 +765,7 @@ pub enum Action {
     /// Fetch one of projectM's preset packs into the folder, by its place
     /// in the list.
     DownloadMilkdropPack(usize),
+    /// Reload custom colour schemes from disk and re-apply the active one.
+    ReloadTheme,
     Quit,
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -48,6 +48,11 @@ impl AppDirs {
         self.config.join("skins")
     }
 
+    /// Custom colour schemes, as `.json` files.
+    pub fn schemes_dir(&self) -> PathBuf {
+        self.config.join("schemes")
+    }
+
     /// MilkDrop presets, as `.milk` files, in folders or not, with any
     /// textures they use in a `textures` folder inside.
     pub fn milkdrop_dir(&self) -> PathBuf {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,13 +4,15 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ThemeChoice {
     #[default]
     Dark,
     Light,
     System,
+    /// A custom colour scheme loaded from a JSON file in the schemes directory.
+    Custom(String),
 }
 
 /// Mini-player visualizer mode.
@@ -35,13 +37,14 @@ impl VisMode {
 }
 
 impl ThemeChoice {
-    pub const ALL: [ThemeChoice; 3] = [Self::Dark, Self::Light, Self::System];
+    pub const BUILTINS: [ThemeChoice; 3] = [Self::Dark, Self::Light, Self::System];
 
-    pub fn label(self) -> &'static str {
+    pub fn label(&self) -> &str {
         match self {
             Self::Dark => "Dark",
             Self::Light => "Light",
             Self::System => "Follow system",
+            Self::Custom(name) => name,
         }
     }
 }

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -13,24 +13,19 @@
 //!
 //! macOS and Windows use an exclusive loopback socket for the guard and
 //! control channel. The operating system releases the port when the process
-//! ends.
+//! ends. On Linux, the running instance is guarded by D-Bus and also listens
+//! on the loopback socket for control commands (such as scheme reloading).
 //!
-//! On macOS and Windows, clients send one `fastpotify:<verb>` line and receive
-//! one reply. Commands enter the same action queue as tray and media-key
-//! events. Read commands use snapshots, so the listener thread never accesses
-//! app state. Linux uses MPRIS for these controls.
+//! Clients send one `fastpotify:<verb>` line and receive one reply. Commands
+//! enter the same action queue as tray and media-key events. Read commands
+//! use snapshots, so the listener thread never accesses app state.
 //!
 //! The Stream Deck plugin uses the same channel. It can set shuffle and repeat,
 //! save the current track, play a URI, list devices, and transfer playback.
 //! Clients poll the current snapshot; the app does not push updates.
 //!
-//! Any local process can reach the port, so `play-uri`, `open-link`, and
-//! `transfer` validate their free-text arguments here.
-//!
-//! A Spotify link the desktop hands to a second launch reaches the running
-//! instance the same way: `open-link` over the socket, or on Linux the
-//! `Open` method of the `rocks.fastpotify.Instance` interface the guard
-//! serves on its own name.
+//! Any local process can reach the port, so `play-uri` and `transfer` validate
+//! their free-text arguments here.
 
 /// The name held for the lifetime of the running instance.
 #[cfg(target_os = "linux")]
@@ -39,10 +34,6 @@ const INSTANCE_NAME: &str = "rocks.fastpotify.Instance";
 /// The MPRIS player to ask when another instance already holds the name.
 #[cfg(target_os = "linux")]
 const MPRIS_NAME: &str = "org.mpris.MediaPlayer2.fastpotify";
-
-/// Where the running instance answers `Open` for links, on [`INSTANCE_NAME`].
-#[cfg(target_os = "linux")]
-const INSTANCE_PATH: &str = "/rocks/fastpotify/Instance";
 
 pub enum Outcome {
     /// This process is the only instance. Hold the guard until it exits.
@@ -80,14 +71,13 @@ pub enum ControlCommand {
     ToggleSaved,
     /// Play a `spotify:` URI: a track, album, playlist, artist, or show.
     PlayUri(String),
-    /// Open the page for a Spotify link the desktop or another launch
-    /// handed over, and bring the window forward.
-    OpenLink(String),
     /// Move playback to a Spotify Connect device, by id.
     Transfer(String),
     /// Refresh the device list. Sent by the `devices` read, which answers
     /// from a snapshot that is only as fresh as the app's last look.
     RefreshDevices,
+    /// Reload colour schemes from disk and reapply the active one.
+    ReloadTheme,
 }
 
 /// Marks this process as the running instance until dropped.
@@ -126,24 +116,19 @@ pub const NOTHING_PLAYING: &str = "stopped";
 /// Device snapshot used before loading and when Spotify reports no devices.
 pub const NO_DEVICES: &str = "[]";
 
-/// Loopback port that marks a running instance on platforms without a bus.
+/// Loopback port that marks a running instance on platforms without a bus,
+/// and carries control commands on all platforms.
 /// Registered to nothing; chosen high and out of the ephemeral range.
-#[cfg(not(target_os = "linux"))]
 const INSTANCE_PORT: u16 = 47_113;
 
 /// Every request and reply starts with this, so a foreign program that
 /// happens to hold the port is never mistaken for Fastpotify.
-#[cfg(not(target_os = "linux"))]
 const PREFIX: &str = "fastpotify:";
-#[cfg(not(target_os = "linux"))]
 const OK_REPLY: &str = "fastpotify:ok";
-#[cfg(not(target_os = "linux"))]
 const NOW_REPLY: &str = "fastpotify:now ";
-#[cfg(not(target_os = "linux"))]
 const DEVICES_REPLY: &str = "fastpotify:devices ";
 
 /// What the running instance said back.
-#[cfg(not(target_os = "linux"))]
 pub enum Reply {
     /// The command was accepted.
     Ok,
@@ -158,12 +143,10 @@ pub enum Reply {
 }
 
 /// Sends one verb to the running instance and reads its reply.
-#[cfg(not(target_os = "linux"))]
 pub fn send(verb: &str) -> std::io::Result<Reply> {
     send_to(INSTANCE_PORT, verb)
 }
 
-#[cfg(not(target_os = "linux"))]
 fn send_to(port: u16, verb: &str) -> std::io::Result<Reply> {
     use std::io::{Read, Write};
     use std::net::{Ipv4Addr, TcpStream};
@@ -191,11 +174,8 @@ fn send_to(port: u16, verb: &str) -> std::io::Result<Reply> {
     }
 }
 
-/// Claims the running-instance role, or hands `link` (a canonical
-/// `spotify:` URI, see [`crate::link::parse`]) to the instance that has it
-/// and asks that one to come forward.
 #[cfg(not(target_os = "linux"))]
-pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
+pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
     use std::net::{Ipv4Addr, TcpListener};
     use std::sync::{Arc, Mutex};
 
@@ -208,17 +188,8 @@ pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
     let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, INSTANCE_PORT)) {
         Ok(listener) => listener,
         Err(_) => {
-            // Raise the existing instance only if the port answers as
-            // Fastpotify. A link goes with the request; an instance from
-            // before links does not answer that verb, so a plain show
-            // follows and the link is dropped rather than the launch.
-            let accepted = |reply: Reply| matches!(reply, Reply::Ok);
-            let opened =
-                link.is_some_and(|uri| send(&format!("open-link {uri}")).is_ok_and(accepted));
-            if link.is_some() && !opened {
-                log::warn!("the running Fastpotify does not take links; asking it to show");
-            }
-            let answered = opened || send("show").is_ok_and(accepted);
+            // Raise the existing instance only if the port answers as Fastpotify.
+            let answered = send("show").is_ok_and(|reply| matches!(reply, Reply::Ok));
             if answered {
                 return Outcome::Surfaced;
             }
@@ -243,7 +214,6 @@ pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
 
 /// Answers control clients until the listener closes. One request line and
 /// one reply line per connection.
-#[cfg(not(target_os = "linux"))]
 fn serve(
     listener: std::net::TcpListener,
     commands: &std::sync::Mutex<Vec<ControlCommand>>,
@@ -295,14 +265,12 @@ fn serve(
 
 /// A parsed request line: a command for the app, or a read the listener
 /// answers itself.
-#[cfg(not(target_os = "linux"))]
 enum Request {
     Command(ControlCommand),
     NowPlaying,
     Devices,
 }
 
-#[cfg(not(target_os = "linux"))]
 fn parse(line: &str) -> Option<Request> {
     let verb = line.trim_end().strip_prefix(PREFIX)?;
     let (verb, argument) = match verb.split_once(' ') {
@@ -336,8 +304,8 @@ fn parse(line: &str) -> Option<Request> {
         }
         ("save-toggle", None) => ControlCommand::ToggleSaved,
         ("play-uri", Some(uri)) => ControlCommand::PlayUri(spotify_uri(uri)?),
-        ("open-link", Some(link)) => ControlCommand::OpenLink(crate::link::parse(link)?),
         ("transfer", Some(id)) => ControlCommand::Transfer(device_id(id)?),
+        ("scheme", Some("reload")) | ("scheme-reload", None) => ControlCommand::ReloadTheme,
         ("nowplaying", None) => return Some(Request::NowPlaying),
         ("devices", None) => return Some(Request::Devices),
         _ => return None,
@@ -347,7 +315,6 @@ fn parse(line: &str) -> Option<Request> {
 
 /// Validates the scheme, length, and characters of a Spotify URI received over
 /// the local control port.
-#[cfg(not(target_os = "linux"))]
 fn spotify_uri(text: &str) -> Option<String> {
     let shaped = text.starts_with("spotify:")
         && text.len() <= 128
@@ -359,7 +326,6 @@ fn spotify_uri(text: &str) -> Option<String> {
 
 /// A Spotify Connect device id: the opaque hex-ish string the Web API hands
 /// out. Checked for the same reason as [`spotify_uri`].
-#[cfg(not(target_os = "linux"))]
 fn device_id(text: &str) -> Option<String> {
     let shaped = !text.is_empty()
         && text.len() <= 64
@@ -371,7 +337,6 @@ fn device_id(text: &str) -> Option<String> {
 
 /// Reads up to the first newline. A line too long to be one of ours, or any
 /// read error, disqualifies the client.
-#[cfg(not(target_os = "linux"))]
 fn read_line(stream: &mut std::net::TcpStream) -> Option<String> {
     use std::io::Read;
     let mut buffer = [0u8; 256];
@@ -395,45 +360,36 @@ fn read_line(stream: &mut std::net::TcpStream) -> Option<String> {
     String::from_utf8(line.to_vec()).ok()
 }
 
-/// What the running instance answers on its own name, for the launch the
-/// desktop makes when a Spotify link is opened.
 #[cfg(target_os = "linux")]
-struct Instance {
-    commands: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>>,
-    waker: crate::backend::Waker,
-}
-
-#[cfg(target_os = "linux")]
-#[zbus::interface(name = "rocks.fastpotify.Instance")]
-impl Instance {
-    /// Opens the page for a Spotify link and brings the window forward. A
-    /// link that is not a page the app has is refused, so the caller can
-    /// fall back to showing the window.
-    fn open(&self, link: &str) -> zbus::fdo::Result<()> {
-        let uri = crate::link::parse(link)
-            .ok_or_else(|| zbus::fdo::Error::InvalidArgs(format!("not a Spotify link: {link}")))?;
-        self.commands
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .push(ControlCommand::OpenLink(uri));
-        self.waker.wake();
-        Ok(())
-    }
-}
-
-/// Claims the running-instance role, or hands `link` (a canonical
-/// `spotify:` URI, see [`crate::link::parse`]) to the instance that has it
-/// and asks that one to come forward.
-#[cfg(target_os = "linux")]
-pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
+pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
     use mpris_server::zbus::blocking::Connection;
     use mpris_server::zbus::fdo::{RequestNameFlags, RequestNameReply};
 
-    let guard = |connection: Option<Connection>| Guard {
-        _connection: connection,
-        commands: Default::default(),
-        now_playing: std::sync::Arc::new(std::sync::Mutex::new(NOTHING_PLAYING.to_owned())),
-        devices: std::sync::Arc::new(std::sync::Mutex::new(NO_DEVICES.to_owned())),
+    let make_guard = |connection: Option<Connection>| {
+        let guard = Guard {
+            _connection: connection,
+            commands: Default::default(),
+            now_playing: std::sync::Arc::new(std::sync::Mutex::new(NOTHING_PLAYING.to_owned())),
+            devices: std::sync::Arc::new(std::sync::Mutex::new(NO_DEVICES.to_owned())),
+        };
+        match std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, INSTANCE_PORT)) {
+            Ok(listener) => {
+                let commands = std::sync::Arc::clone(&guard.commands);
+                let now_playing = std::sync::Arc::clone(&guard.now_playing);
+                let devices = std::sync::Arc::clone(&guard.devices);
+                let waker = waker.clone();
+                let spawned = std::thread::Builder::new()
+                    .name("fastpotify-instance".to_owned())
+                    .spawn(move || serve(listener, &commands, &now_playing, &devices, &waker));
+                if let Err(error) = spawned {
+                    log::warn!("cannot listen for control commands: {error}");
+                }
+            }
+            Err(error) => {
+                log::warn!("cannot bind control port {INSTANCE_PORT}: {error}");
+            }
+        }
+        guard
     };
 
     let connection = match Connection::session() {
@@ -441,7 +397,7 @@ pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
         Err(error) => {
             // No session bus at all: nothing to coordinate through, so run.
             log::debug!("no session bus, running unguarded: {error}");
-            return Outcome::Only(guard(None));
+            return Outcome::Only(make_guard(None));
         }
     };
 
@@ -449,21 +405,10 @@ pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
     // `NameTaken` is the normal second-launch result.
     match connection.request_name_with_flags(INSTANCE_NAME, RequestNameFlags::DoNotQueue.into()) {
         Ok(RequestNameReply::PrimaryOwner | RequestNameReply::AlreadyOwner) => {
-            let guard = guard(Some(connection.clone()));
-            // Links from later launches arrive on the name just taken.
-            // Registered before anything else, so a launch that follows
-            // this one closely finds it.
-            let instance = Instance {
-                commands: std::sync::Arc::clone(&guard.commands),
-                waker: waker.clone(),
-            };
-            if let Err(error) = serve_links(connection, instance) {
-                log::warn!("cannot take links from other launches: {error}");
-            }
-            Outcome::Only(guard)
+            Outcome::Only(make_guard(Some(connection)))
         }
         Ok(_) | Err(mpris_server::zbus::Error::NameTaken) => {
-            if !raise_running_instance(&connection, link) {
+            if !raise_running_instance(&connection) {
                 log::warn!(
                     "Fastpotify is already running but did not answer; not starting a second copy"
                 );
@@ -472,111 +417,18 @@ pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
         }
         Err(error) => {
             log::warn!("cannot check for a running instance, starting anyway: {error}");
-            Outcome::Only(guard(None))
+            Outcome::Only(make_guard(None))
         }
     }
 }
 
-/// Serves `instance` on `connection` for the rest of the process, from a
-/// thread of its own: with tokio behind zbus, an interface's dispatch task
-/// runs on whichever runtime registers it, and outside one there is no
-/// registering it at all. This runtime is never dropped. Returns once the
-/// interface answers, or with what went wrong.
+/// Asks the running instance to show its window, retrying briefly because it
+/// may still be registering MPRIS when this launch arrives.
 #[cfg(target_os = "linux")]
-fn serve_links(connection: zbus::blocking::Connection, instance: Instance) -> Result<(), String> {
-    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
-    let spawned = std::thread::Builder::new()
-        .name("fastpotify-links".to_owned())
-        .spawn(move || {
-            let runtime = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(runtime) => runtime,
-                Err(error) => {
-                    let _ = ready_tx.send(Err(error.to_string()));
-                    return;
-                }
-            };
-            runtime.block_on(async move {
-                let served = connection
-                    .inner()
-                    .object_server()
-                    .at(INSTANCE_PATH, instance)
-                    .await;
-                match served {
-                    Ok(_) => {
-                        let _ = ready_tx.send(Ok(()));
-                        // The interface's dispatch task lives on this
-                        // runtime; so does the thread.
-                        std::future::pending::<()>().await;
-                    }
-                    Err(error) => {
-                        let _ = ready_tx.send(Err(error.to_string()));
-                    }
-                }
-            });
-        });
-    if let Err(error) = spawned {
-        return Err(error.to_string());
-    }
-    match ready_rx.recv_timeout(std::time::Duration::from_secs(5)) {
-        Ok(result) => result,
-        Err(_) => Err("the link interface did not come up in time".to_owned()),
-    }
-}
-
-/// Calls `Open` on the running instance, giving up after two seconds. An
-/// instance from before links has no object server on its connection, so
-/// it never answers at all, rather than with an error, and the bus's own
-/// timeout is a long twenty-five seconds. The call is made from a thread
-/// so a late answer costs the launch nothing.
-#[cfg(target_os = "linux")]
-fn open_in_running_instance(
-    connection: zbus::blocking::Connection,
-    uri: String,
-) -> Result<(), String> {
-    let (answer_tx, answer_rx) = std::sync::mpsc::channel();
-    let spawned = std::thread::Builder::new()
-        .name("fastpotify-open-link".to_owned())
-        .spawn(move || {
-            let opened = connection.call_method(
-                Some(INSTANCE_NAME),
-                INSTANCE_PATH,
-                Some("rocks.fastpotify.Instance"),
-                "Open",
-                &(uri.as_str(),),
-            );
-            let _ = answer_tx.send(opened.map(drop).map_err(|error| error.to_string()));
-        });
-    if let Err(error) = spawned {
-        return Err(error.to_string());
-    }
-    match answer_rx.recv_timeout(std::time::Duration::from_secs(2)) {
-        Ok(answer) => answer,
-        Err(_) => Err("no answer in time".to_owned()),
-    }
-}
-
-/// Hands `link` to the running instance, or without one asks it to show
-/// its window, retrying briefly because it may still be registering when
-/// this launch arrives. An instance from before links refuses `Open`, in
-/// which case its window is raised and the link dropped rather than the
-/// launch.
-#[cfg(target_os = "linux")]
-fn raise_running_instance(
-    connection: &mpris_server::zbus::blocking::Connection,
-    link: Option<&str>,
-) -> bool {
+fn raise_running_instance(connection: &mpris_server::zbus::blocking::Connection) -> bool {
     for attempt in 0..10 {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(150));
-        }
-        if let Some(uri) = link {
-            match open_in_running_instance(connection.clone(), uri.to_owned()) {
-                Ok(()) => return true,
-                Err(error) => log::debug!("the running instance did not take the link: {error}"),
-            }
         }
         let raised = connection.call_method(
             Some(MPRIS_NAME),
@@ -586,67 +438,13 @@ fn raise_running_instance(
             &(),
         );
         if raised.is_ok() {
-            if link.is_some() {
-                log::warn!("the running Fastpotify does not take links; asked it to show");
-            }
             return true;
         }
     }
     false
 }
 
-#[cfg(all(test, target_os = "linux"))]
-mod bus_tests {
-    use super::*;
-
-    /// A link handed to the running instance's `Open` lands on its command
-    /// queue as the one URI the app navigates by; what is not a link is
-    /// refused, so the caller knows to fall back to showing the window.
-    #[test]
-    fn a_link_reaches_the_running_instance_over_the_bus() {
-        use zbus::blocking::Connection;
-
-        // #given an instance answering on its own connection, not the
-        // shared name, so a Fastpotify already running is left alone
-        let Ok(server) = Connection::session() else {
-            eprintln!("no session bus here; nothing to test");
-            return;
-        };
-        let commands: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> = Default::default();
-        let instance = Instance {
-            commands: std::sync::Arc::clone(&commands),
-            waker: crate::backend::Waker::default(),
-        };
-        serve_links(server.clone(), instance).expect("the interface is served");
-        let name = server.unique_name().expect("a unique name").to_string();
-        let client = Connection::session().expect("a second connection");
-        let open = |link: &str| {
-            client.call_method(
-                Some(name.as_str()),
-                INSTANCE_PATH,
-                Some("rocks.fastpotify.Instance"),
-                "Open",
-                &(link,),
-            )
-        };
-
-        // #when
-        let opened = open("https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3?si=x");
-        let refused = open("https://example.com/album/1DFixLWuPkv3KT3TnV35m3");
-
-        // #then
-        assert!(opened.is_ok(), "{opened:?}");
-        assert!(refused.is_err());
-        assert_eq!(
-            *commands.lock().expect("the queue"),
-            vec![ControlCommand::OpenLink(
-                "spotify:album:1DFixLWuPkv3KT3TnV35m3".to_owned()
-            )]
-        );
-    }
-}
-
-#[cfg(all(test, not(target_os = "linux")))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::player::RepeatMode;
@@ -732,15 +530,13 @@ mod tests {
             command("fastpotify:transfer a1b2c3d4e5"),
             Some(ControlCommand::Transfer("a1b2c3d4e5".to_owned()))
         );
-        // A link arrives in whatever shape the desktop had it and leaves
-        // as the one URI the app navigates by.
         assert_eq!(
-            command(
-                "fastpotify:open-link https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3?si=x"
-            ),
-            Some(ControlCommand::OpenLink(
-                "spotify:album:1DFixLWuPkv3KT3TnV35m3".to_owned()
-            ))
+            command("fastpotify:scheme reload"),
+            Some(ControlCommand::ReloadTheme)
+        );
+        assert_eq!(
+            command("fastpotify:scheme-reload"),
+            Some(ControlCommand::ReloadTheme)
         );
         assert!(matches!(
             parse("fastpotify:nowplaying"),
@@ -759,6 +555,8 @@ mod tests {
         assert!(parse("fastpotify:seek-by soon").is_none());
         assert!(parse("fastpotify:volume-set 999").is_none());
         assert!(parse("fastpotify:next please").is_none());
+        assert!(parse("fastpotify:scheme unknown").is_none());
+        assert!(parse("fastpotify:scheme").is_none());
         assert!(parse("").is_none());
     }
 
@@ -773,9 +571,6 @@ mod tests {
         assert!(command(&format!("fastpotify:play-uri spotify:{}", "x".repeat(200))).is_none());
         assert!(command("fastpotify:transfer ../secrets").is_none());
         assert!(command("fastpotify:transfer").is_none());
-        assert!(command("fastpotify:open-link https://example.com/track/x").is_none());
-        assert!(command("fastpotify:open-link spotify:user:someone").is_none());
-        assert!(command("fastpotify:open-link").is_none());
         // A word that is not one of the three is refused rather than read
         // as `off`, which is what `RepeatMode::from_api` would have done.
         assert!(command("fastpotify:repeat-set sometimes").is_none());
@@ -809,6 +604,7 @@ mod tests {
         let accepted = send_to(port, "next").expect("a reply");
         let volume = send_to(port, "volume-by -5").expect("a reply");
         let liked = send_to(port, "save-toggle").expect("a reply");
+        let reloaded = send_to(port, "scheme reload").expect("a reply");
         let snapshot = send_to(port, "nowplaying").expect("a reply");
         let listed = send_to(port, "devices").expect("a reply");
         let refused = send_to(port, "frobnicate");
@@ -817,6 +613,7 @@ mod tests {
         assert!(matches!(accepted, Reply::Ok));
         assert!(matches!(volume, Reply::Ok));
         assert!(matches!(liked, Reply::Ok));
+        assert!(matches!(reloaded, Reply::Ok));
         match snapshot {
             Reply::NowPlaying(line) => assert_eq!(line, "playing\tGo\tThe Band"),
             _ => panic!("nowplaying answered with something else"),
@@ -836,6 +633,7 @@ mod tests {
                 ControlCommand::Next,
                 ControlCommand::VolumeBy(-5),
                 ControlCommand::ToggleSaved,
+                ControlCommand::ReloadTheme,
                 ControlCommand::RefreshDevices,
             ]
         );

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -573,8 +573,8 @@ fn open_in_running_instance(
 /// the method was accepted, or an error string on failure or timeout.
 #[cfg(target_os = "linux")]
 pub fn reload_theme_in_running_instance() -> Result<(), String> {
-    let connection = mpris_server::zbus::blocking::Connection::session()
-        .map_err(|error| error.to_string())?;
+    let connection =
+        mpris_server::zbus::blocking::Connection::session().map_err(|error| error.to_string())?;
     let (answer_tx, answer_rx) = std::sync::mpsc::channel();
     let spawned = std::thread::Builder::new()
         .name("fastpotify-reload-theme".to_owned())

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -13,19 +13,24 @@
 //!
 //! macOS and Windows use an exclusive loopback socket for the guard and
 //! control channel. The operating system releases the port when the process
-//! ends. On Linux, the running instance is guarded by D-Bus and also listens
-//! on the loopback socket for control commands (such as scheme reloading).
+//! ends.
 //!
-//! Clients send one `fastpotify:<verb>` line and receive one reply. Commands
-//! enter the same action queue as tray and media-key events. Read commands
-//! use snapshots, so the listener thread never accesses app state.
+//! On macOS and Windows, clients send one `fastpotify:<verb>` line and receive
+//! one reply. Commands enter the same action queue as tray and media-key
+//! events. Read commands use snapshots, so the listener thread never accesses
+//! app state. Linux uses MPRIS for these controls.
 //!
 //! The Stream Deck plugin uses the same channel. It can set shuffle and repeat,
 //! save the current track, play a URI, list devices, and transfer playback.
 //! Clients poll the current snapshot; the app does not push updates.
 //!
-//! Any local process can reach the port, so `play-uri` and `transfer` validate
-//! their free-text arguments here.
+//! Any local process can reach the port, so `play-uri`, `open-link`, and
+//! `transfer` validate their free-text arguments here.
+//!
+//! A Spotify link the desktop hands to a second launch reaches the running
+//! instance the same way: `open-link` over the socket, or on Linux the
+//! `Open` method of the `rocks.fastpotify.Instance` interface the guard
+//! serves on its own name.
 
 /// The name held for the lifetime of the running instance.
 #[cfg(target_os = "linux")]
@@ -34,6 +39,10 @@ const INSTANCE_NAME: &str = "rocks.fastpotify.Instance";
 /// The MPRIS player to ask when another instance already holds the name.
 #[cfg(target_os = "linux")]
 const MPRIS_NAME: &str = "org.mpris.MediaPlayer2.fastpotify";
+
+/// Where the running instance answers `Open` for links, on [`INSTANCE_NAME`].
+#[cfg(target_os = "linux")]
+const INSTANCE_PATH: &str = "/rocks/fastpotify/Instance";
 
 pub enum Outcome {
     /// This process is the only instance. Hold the guard until it exits.
@@ -71,6 +80,9 @@ pub enum ControlCommand {
     ToggleSaved,
     /// Play a `spotify:` URI: a track, album, playlist, artist, or show.
     PlayUri(String),
+    /// Open the page for a Spotify link the desktop or another launch
+    /// handed over, and bring the window forward.
+    OpenLink(String),
     /// Move playback to a Spotify Connect device, by id.
     Transfer(String),
     /// Refresh the device list. Sent by the `devices` read, which answers
@@ -116,19 +128,24 @@ pub const NOTHING_PLAYING: &str = "stopped";
 /// Device snapshot used before loading and when Spotify reports no devices.
 pub const NO_DEVICES: &str = "[]";
 
-/// Loopback port that marks a running instance on platforms without a bus,
-/// and carries control commands on all platforms.
+/// Loopback port that marks a running instance on platforms without a bus.
 /// Registered to nothing; chosen high and out of the ephemeral range.
+#[cfg(not(target_os = "linux"))]
 const INSTANCE_PORT: u16 = 47_113;
 
 /// Every request and reply starts with this, so a foreign program that
 /// happens to hold the port is never mistaken for Fastpotify.
+#[cfg(not(target_os = "linux"))]
 const PREFIX: &str = "fastpotify:";
+#[cfg(not(target_os = "linux"))]
 const OK_REPLY: &str = "fastpotify:ok";
+#[cfg(not(target_os = "linux"))]
 const NOW_REPLY: &str = "fastpotify:now ";
+#[cfg(not(target_os = "linux"))]
 const DEVICES_REPLY: &str = "fastpotify:devices ";
 
 /// What the running instance said back.
+#[cfg(not(target_os = "linux"))]
 pub enum Reply {
     /// The command was accepted.
     Ok,
@@ -143,10 +160,12 @@ pub enum Reply {
 }
 
 /// Sends one verb to the running instance and reads its reply.
+#[cfg(not(target_os = "linux"))]
 pub fn send(verb: &str) -> std::io::Result<Reply> {
     send_to(INSTANCE_PORT, verb)
 }
 
+#[cfg(not(target_os = "linux"))]
 fn send_to(port: u16, verb: &str) -> std::io::Result<Reply> {
     use std::io::{Read, Write};
     use std::net::{Ipv4Addr, TcpStream};
@@ -174,8 +193,11 @@ fn send_to(port: u16, verb: &str) -> std::io::Result<Reply> {
     }
 }
 
+/// Claims the running-instance role, or hands `link` (a canonical
+/// `spotify:` URI, see [`crate::link::parse`]) to the instance that has it
+/// and asks that one to come forward.
 #[cfg(not(target_os = "linux"))]
-pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
+pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
     use std::net::{Ipv4Addr, TcpListener};
     use std::sync::{Arc, Mutex};
 
@@ -188,8 +210,17 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
     let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, INSTANCE_PORT)) {
         Ok(listener) => listener,
         Err(_) => {
-            // Raise the existing instance only if the port answers as Fastpotify.
-            let answered = send("show").is_ok_and(|reply| matches!(reply, Reply::Ok));
+            // Raise the existing instance only if the port answers as
+            // Fastpotify. A link goes with the request; an instance from
+            // before links does not answer that verb, so a plain show
+            // follows and the link is dropped rather than the launch.
+            let accepted = |reply: Reply| matches!(reply, Reply::Ok);
+            let opened =
+                link.is_some_and(|uri| send(&format!("open-link {uri}")).is_ok_and(accepted));
+            if link.is_some() && !opened {
+                log::warn!("the running Fastpotify does not take links; asking it to show");
+            }
+            let answered = opened || send("show").is_ok_and(accepted);
             if answered {
                 return Outcome::Surfaced;
             }
@@ -214,6 +245,7 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
 
 /// Answers control clients until the listener closes. One request line and
 /// one reply line per connection.
+#[cfg(not(target_os = "linux"))]
 fn serve(
     listener: std::net::TcpListener,
     commands: &std::sync::Mutex<Vec<ControlCommand>>,
@@ -265,12 +297,14 @@ fn serve(
 
 /// A parsed request line: a command for the app, or a read the listener
 /// answers itself.
+#[cfg(not(target_os = "linux"))]
 enum Request {
     Command(ControlCommand),
     NowPlaying,
     Devices,
 }
 
+#[cfg(not(target_os = "linux"))]
 fn parse(line: &str) -> Option<Request> {
     let verb = line.trim_end().strip_prefix(PREFIX)?;
     let (verb, argument) = match verb.split_once(' ') {
@@ -304,6 +338,7 @@ fn parse(line: &str) -> Option<Request> {
         }
         ("save-toggle", None) => ControlCommand::ToggleSaved,
         ("play-uri", Some(uri)) => ControlCommand::PlayUri(spotify_uri(uri)?),
+        ("open-link", Some(link)) => ControlCommand::OpenLink(crate::link::parse(link)?),
         ("transfer", Some(id)) => ControlCommand::Transfer(device_id(id)?),
         ("scheme", Some("reload")) | ("scheme-reload", None) => ControlCommand::ReloadTheme,
         ("nowplaying", None) => return Some(Request::NowPlaying),
@@ -315,6 +350,7 @@ fn parse(line: &str) -> Option<Request> {
 
 /// Validates the scheme, length, and characters of a Spotify URI received over
 /// the local control port.
+#[cfg(not(target_os = "linux"))]
 fn spotify_uri(text: &str) -> Option<String> {
     let shaped = text.starts_with("spotify:")
         && text.len() <= 128
@@ -326,6 +362,7 @@ fn spotify_uri(text: &str) -> Option<String> {
 
 /// A Spotify Connect device id: the opaque hex-ish string the Web API hands
 /// out. Checked for the same reason as [`spotify_uri`].
+#[cfg(not(target_os = "linux"))]
 fn device_id(text: &str) -> Option<String> {
     let shaped = !text.is_empty()
         && text.len() <= 64
@@ -337,6 +374,7 @@ fn device_id(text: &str) -> Option<String> {
 
 /// Reads up to the first newline. A line too long to be one of ours, or any
 /// read error, disqualifies the client.
+#[cfg(not(target_os = "linux"))]
 fn read_line(stream: &mut std::net::TcpStream) -> Option<String> {
     use std::io::Read;
     let mut buffer = [0u8; 256];
@@ -360,36 +398,53 @@ fn read_line(stream: &mut std::net::TcpStream) -> Option<String> {
     String::from_utf8(line.to_vec()).ok()
 }
 
+/// What the running instance answers on its own name, for the launch the
+/// desktop makes when a Spotify link is opened.
 #[cfg(target_os = "linux")]
-pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
+struct Instance {
+    commands: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>>,
+    waker: crate::backend::Waker,
+}
+
+#[cfg(target_os = "linux")]
+#[zbus::interface(name = "rocks.fastpotify.Instance")]
+impl Instance {
+    /// Opens the page for a Spotify link and brings the window forward. A
+    /// link that is not a page the app has is refused, so the caller can
+    /// fall back to showing the window.
+    fn open(&self, link: &str) -> zbus::fdo::Result<()> {
+        let uri = crate::link::parse(link)
+            .ok_or_else(|| zbus::fdo::Error::InvalidArgs(format!("not a Spotify link: {link}")))?;
+        self.commands
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(ControlCommand::OpenLink(uri));
+        self.waker.wake();
+        Ok(())
+    }
+
+    fn reload_theme(&self) {
+        self.commands
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(ControlCommand::ReloadTheme);
+        self.waker.wake();
+    }
+}
+
+/// Claims the running-instance role, or hands `link` (a canonical
+/// `spotify:` URI, see [`crate::link::parse`]) to the instance that has it
+/// and asks that one to come forward.
+#[cfg(target_os = "linux")]
+pub fn acquire(waker: &crate::backend::Waker, link: Option<&str>) -> Outcome {
     use mpris_server::zbus::blocking::Connection;
     use mpris_server::zbus::fdo::{RequestNameFlags, RequestNameReply};
 
-    let make_guard = |connection: Option<Connection>| {
-        let guard = Guard {
-            _connection: connection,
-            commands: Default::default(),
-            now_playing: std::sync::Arc::new(std::sync::Mutex::new(NOTHING_PLAYING.to_owned())),
-            devices: std::sync::Arc::new(std::sync::Mutex::new(NO_DEVICES.to_owned())),
-        };
-        match std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, INSTANCE_PORT)) {
-            Ok(listener) => {
-                let commands = std::sync::Arc::clone(&guard.commands);
-                let now_playing = std::sync::Arc::clone(&guard.now_playing);
-                let devices = std::sync::Arc::clone(&guard.devices);
-                let waker = waker.clone();
-                let spawned = std::thread::Builder::new()
-                    .name("fastpotify-instance".to_owned())
-                    .spawn(move || serve(listener, &commands, &now_playing, &devices, &waker));
-                if let Err(error) = spawned {
-                    log::warn!("cannot listen for control commands: {error}");
-                }
-            }
-            Err(error) => {
-                log::warn!("cannot bind control port {INSTANCE_PORT}: {error}");
-            }
-        }
-        guard
+    let guard = |connection: Option<Connection>| Guard {
+        _connection: connection,
+        commands: Default::default(),
+        now_playing: std::sync::Arc::new(std::sync::Mutex::new(NOTHING_PLAYING.to_owned())),
+        devices: std::sync::Arc::new(std::sync::Mutex::new(NO_DEVICES.to_owned())),
     };
 
     let connection = match Connection::session() {
@@ -397,7 +452,7 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
         Err(error) => {
             // No session bus at all: nothing to coordinate through, so run.
             log::debug!("no session bus, running unguarded: {error}");
-            return Outcome::Only(make_guard(None));
+            return Outcome::Only(guard(None));
         }
     };
 
@@ -405,10 +460,21 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
     // `NameTaken` is the normal second-launch result.
     match connection.request_name_with_flags(INSTANCE_NAME, RequestNameFlags::DoNotQueue.into()) {
         Ok(RequestNameReply::PrimaryOwner | RequestNameReply::AlreadyOwner) => {
-            Outcome::Only(make_guard(Some(connection)))
+            let guard = guard(Some(connection.clone()));
+            // Links from later launches arrive on the name just taken.
+            // Registered before anything else, so a launch that follows
+            // this one closely finds it.
+            let instance = Instance {
+                commands: std::sync::Arc::clone(&guard.commands),
+                waker: waker.clone(),
+            };
+            if let Err(error) = serve_links(connection, instance) {
+                log::warn!("cannot take links from other launches: {error}");
+            }
+            Outcome::Only(guard)
         }
         Ok(_) | Err(mpris_server::zbus::Error::NameTaken) => {
-            if !raise_running_instance(&connection) {
+            if !raise_running_instance(&connection, link) {
                 log::warn!(
                     "Fastpotify is already running but did not answer; not starting a second copy"
                 );
@@ -417,18 +483,139 @@ pub fn acquire(waker: &crate::backend::Waker) -> Outcome {
         }
         Err(error) => {
             log::warn!("cannot check for a running instance, starting anyway: {error}");
-            Outcome::Only(make_guard(None))
+            Outcome::Only(guard(None))
         }
     }
 }
 
-/// Asks the running instance to show its window, retrying briefly because it
-/// may still be registering MPRIS when this launch arrives.
+/// Serves `instance` on `connection` for the rest of the process, from a
+/// thread of its own: with tokio behind zbus, an interface's dispatch task
+/// runs on whichever runtime registers it, and outside one there is no
+/// registering it at all. This runtime is never dropped. Returns once the
+/// interface answers, or with what went wrong.
 #[cfg(target_os = "linux")]
-fn raise_running_instance(connection: &mpris_server::zbus::blocking::Connection) -> bool {
+fn serve_links(connection: zbus::blocking::Connection, instance: Instance) -> Result<(), String> {
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("fastpotify-links".to_owned())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    let _ = ready_tx.send(Err(error.to_string()));
+                    return;
+                }
+            };
+            runtime.block_on(async move {
+                let served = connection
+                    .inner()
+                    .object_server()
+                    .at(INSTANCE_PATH, instance)
+                    .await;
+                match served {
+                    Ok(_) => {
+                        let _ = ready_tx.send(Ok(()));
+                        // The interface's dispatch task lives on this
+                        // runtime; so does the thread.
+                        std::future::pending::<()>().await;
+                    }
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error.to_string()));
+                    }
+                }
+            });
+        });
+    if let Err(error) = spawned {
+        return Err(error.to_string());
+    }
+    match ready_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(result) => result,
+        Err(_) => Err("the link interface did not come up in time".to_owned()),
+    }
+}
+
+/// Calls `Open` on the running instance, giving up after two seconds. An
+/// instance from before links has no object server on its connection, so
+/// it never answers at all, rather than with an error, and the bus's own
+/// timeout is a long twenty-five seconds. The call is made from a thread
+/// so a late answer costs the launch nothing.
+#[cfg(target_os = "linux")]
+fn open_in_running_instance(
+    connection: zbus::blocking::Connection,
+    uri: String,
+) -> Result<(), String> {
+    let (answer_tx, answer_rx) = std::sync::mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("fastpotify-open-link".to_owned())
+        .spawn(move || {
+            let opened = connection.call_method(
+                Some(INSTANCE_NAME),
+                INSTANCE_PATH,
+                Some("rocks.fastpotify.Instance"),
+                "Open",
+                &(uri.as_str(),),
+            );
+            let _ = answer_tx.send(opened.map(drop).map_err(|error| error.to_string()));
+        });
+    if let Err(error) = spawned {
+        return Err(error.to_string());
+    }
+    match answer_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(answer) => answer,
+        Err(_) => Err("no answer in time".to_owned()),
+    }
+}
+
+/// Calls `ReloadTheme` on the running instance via D-Bus. Returns `Ok` when
+/// the method was accepted, or an error string on failure or timeout.
+#[cfg(target_os = "linux")]
+pub fn reload_theme_in_running_instance() -> Result<(), String> {
+    let connection = mpris_server::zbus::blocking::Connection::session()
+        .map_err(|error| error.to_string())?;
+    let (answer_tx, answer_rx) = std::sync::mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("fastpotify-reload-theme".to_owned())
+        .spawn(move || {
+            let result = connection.call_method(
+                Some(INSTANCE_NAME),
+                INSTANCE_PATH,
+                Some("rocks.fastpotify.Instance"),
+                "ReloadTheme",
+                &(),
+            );
+            let _ = answer_tx.send(result.map(drop).map_err(|error| error.to_string()));
+        });
+    if let Err(error) = spawned {
+        return Err(error.to_string());
+    }
+    match answer_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(answer) => answer,
+        Err(_) => Err("no answer in time".to_owned()),
+    }
+}
+
+/// Hands `link` to the running instance, or without one asks it to show
+/// its window, retrying briefly because it may still be registering when
+/// this launch arrives. An instance from before links refuses `Open`, in
+/// which case its window is raised and the link dropped rather than the
+/// launch.
+#[cfg(target_os = "linux")]
+fn raise_running_instance(
+    connection: &mpris_server::zbus::blocking::Connection,
+    link: Option<&str>,
+) -> bool {
     for attempt in 0..10 {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(150));
+        }
+        if let Some(uri) = link {
+            match open_in_running_instance(connection.clone(), uri.to_owned()) {
+                Ok(()) => return true,
+                Err(error) => log::debug!("the running instance did not take the link: {error}"),
+            }
         }
         let raised = connection.call_method(
             Some(MPRIS_NAME),
@@ -438,13 +625,67 @@ fn raise_running_instance(connection: &mpris_server::zbus::blocking::Connection)
             &(),
         );
         if raised.is_ok() {
+            if link.is_some() {
+                log::warn!("the running Fastpotify does not take links; asked it to show");
+            }
             return true;
         }
     }
     false
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
+mod bus_tests {
+    use super::*;
+
+    /// A link handed to the running instance's `Open` lands on its command
+    /// queue as the one URI the app navigates by; what is not a link is
+    /// refused, so the caller knows to fall back to showing the window.
+    #[test]
+    fn a_link_reaches_the_running_instance_over_the_bus() {
+        use zbus::blocking::Connection;
+
+        // #given an instance answering on its own connection, not the
+        // shared name, so a Fastpotify already running is left alone
+        let Ok(server) = Connection::session() else {
+            eprintln!("no session bus here; nothing to test");
+            return;
+        };
+        let commands: std::sync::Arc<std::sync::Mutex<Vec<ControlCommand>>> = Default::default();
+        let instance = Instance {
+            commands: std::sync::Arc::clone(&commands),
+            waker: crate::backend::Waker::default(),
+        };
+        serve_links(server.clone(), instance).expect("the interface is served");
+        let name = server.unique_name().expect("a unique name").to_string();
+        let client = Connection::session().expect("a second connection");
+        let open = |link: &str| {
+            client.call_method(
+                Some(name.as_str()),
+                INSTANCE_PATH,
+                Some("rocks.fastpotify.Instance"),
+                "Open",
+                &(link,),
+            )
+        };
+
+        // #when
+        let opened = open("https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3?si=x");
+        let refused = open("https://example.com/album/1DFixLWuPkv3KT3TnV35m3");
+
+        // #then
+        assert!(opened.is_ok(), "{opened:?}");
+        assert!(refused.is_err());
+        assert_eq!(
+            *commands.lock().expect("the queue"),
+            vec![ControlCommand::OpenLink(
+                "spotify:album:1DFixLWuPkv3KT3TnV35m3".to_owned()
+            )]
+        );
+    }
+}
+
+#[cfg(all(test, not(target_os = "linux")))]
 mod tests {
     use super::*;
     use crate::player::RepeatMode;
@@ -530,6 +771,16 @@ mod tests {
             command("fastpotify:transfer a1b2c3d4e5"),
             Some(ControlCommand::Transfer("a1b2c3d4e5".to_owned()))
         );
+        // A link arrives in whatever shape the desktop had it and leaves
+        // as the one URI the app navigates by.
+        assert_eq!(
+            command(
+                "fastpotify:open-link https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3?si=x"
+            ),
+            Some(ControlCommand::OpenLink(
+                "spotify:album:1DFixLWuPkv3KT3TnV35m3".to_owned()
+            ))
+        );
         assert_eq!(
             command("fastpotify:scheme reload"),
             Some(ControlCommand::ReloadTheme)
@@ -571,6 +822,9 @@ mod tests {
         assert!(command(&format!("fastpotify:play-uri spotify:{}", "x".repeat(200))).is_none());
         assert!(command("fastpotify:transfer ../secrets").is_none());
         assert!(command("fastpotify:transfer").is_none());
+        assert!(command("fastpotify:open-link https://example.com/track/x").is_none());
+        assert!(command("fastpotify:open-link spotify:user:someone").is_none());
+        assert!(command("fastpotify:open-link").is_none());
         // A word that is not one of the three is refused rather than read
         // as `off`, which is what `RepeatMode::from_api` would have done.
         assert!(command("fastpotify:repeat-set sometimes").is_none());

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,7 @@
 //! consistent.
 
 use egui::{Color32, CornerRadius, Response, Sense, Stroke, Vec2};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Palette {
@@ -90,6 +91,144 @@ impl Palette {
             )
         };
         Color32::from_rgb((r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
+    }
+}
+
+/// A serializable colour scheme that can be saved to and loaded from a JSON
+/// file.  Hex strings like `"#1ed760"` are accepted for each colour; missing
+/// fields fall back to the built-in dark palette so partial overrides work.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ColorScheme {
+    /// Human-readable name (stored in the file, not derived from the filename).
+    pub name: String,
+    pub dark: bool,
+    pub window: String,
+    pub panel: String,
+    pub surface: String,
+    pub surface_hover: String,
+    pub surface_active: String,
+    pub outline: String,
+    pub text: String,
+    pub secondary: String,
+    pub dim: String,
+    pub accent: String,
+    pub accent_hover: String,
+    pub on_accent: String,
+    pub danger: String,
+    pub warning: String,
+    pub overlay: String,
+    pub shadow: String,
+}
+
+impl Default for ColorScheme {
+    fn default() -> Self {
+        let p = Palette::dark();
+        Self {
+            name: String::new(),
+            dark: true,
+            window: hex(p.window),
+            panel: hex(p.panel),
+            surface: hex(p.surface),
+            surface_hover: hex(p.surface_hover),
+            surface_active: hex(p.surface_active),
+            outline: hex(p.outline),
+            text: hex(p.text),
+            secondary: hex(p.secondary),
+            dim: hex(p.dim),
+            accent: hex(p.accent),
+            accent_hover: hex(p.accent_hover),
+            on_accent: hex(p.on_accent),
+            danger: hex(p.danger),
+            warning: hex(p.warning),
+            overlay: hex(p.overlay),
+            shadow: hex_shadow(p.shadow),
+        }
+    }
+}
+
+impl ColorScheme {
+    /// Build a [`Palette`] from this scheme.
+    pub fn to_palette(&self) -> Palette {
+        Palette {
+            dark: self.dark,
+            window: parse_color(&self.window),
+            panel: parse_color(&self.panel),
+            surface: parse_color(&self.surface),
+            surface_hover: parse_color(&self.surface_hover),
+            surface_active: parse_color(&self.surface_active),
+            outline: parse_color(&self.outline),
+            text: parse_color(&self.text),
+            secondary: parse_color(&self.secondary),
+            dim: parse_color(&self.dim),
+            accent: parse_color(&self.accent),
+            accent_hover: parse_color(&self.accent_hover),
+            on_accent: parse_color(&self.on_accent),
+            danger: parse_color(&self.danger),
+            warning: parse_color(&self.warning),
+            overlay: parse_color(&self.overlay),
+            shadow: parse_color_alpha(&self.shadow),
+        }
+    }
+
+    /// Create a scheme from an existing palette and a name.
+    pub fn from_palette(name: impl Into<String>, p: &Palette) -> Self {
+        Self {
+            name: name.into(),
+            dark: p.dark,
+            window: hex(p.window),
+            panel: hex(p.panel),
+            surface: hex(p.surface),
+            surface_hover: hex(p.surface_hover),
+            surface_active: hex(p.surface_active),
+            outline: hex(p.outline),
+            text: hex(p.text),
+            secondary: hex(p.secondary),
+            dim: hex(p.dim),
+            accent: hex(p.accent),
+            accent_hover: hex(p.accent_hover),
+            on_accent: hex(p.on_accent),
+            danger: hex(p.danger),
+            warning: hex(p.warning),
+            overlay: hex(p.overlay),
+            shadow: hex_shadow(p.shadow),
+        }
+    }
+}
+
+fn hex(c: Color32) -> String {
+    format!("#{:02x}{:02x}{:02x}", c.r(), c.g(), c.b())
+}
+
+fn hex_shadow(c: Color32) -> String {
+    format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
+}
+
+fn parse_color(s: &str) -> Color32 {
+    let s = s.trim_start_matches('#');
+    match s.len() {
+        6 => {
+            let r = u8::from_str_radix(&s[0..2], 16).unwrap_or(0);
+            let g = u8::from_str_radix(&s[2..4], 16).unwrap_or(0);
+            let b = u8::from_str_radix(&s[4..6], 16).unwrap_or(0);
+            Color32::from_rgb(r, g, b)
+        }
+        _ => parse_color_alpha(s),
+    }
+}
+
+fn parse_color_alpha(s: &str) -> Color32 {
+    let s = s.trim_start_matches('#');
+    match s.len() {
+        8 => {
+            let r = u8::from_str_radix(&s[0..2], 16).unwrap_or(0);
+            let g = u8::from_str_radix(&s[2..4], 16).unwrap_or(0);
+            let b = u8::from_str_radix(&s[4..6], 16).unwrap_or(0);
+            let a = u8::from_str_radix(&s[6..8], 16).unwrap_or(255);
+            Color32::from_rgba_premultiplied(r, g, b, a)
+        }
+        6 => parse_color(s),
+        _ => Color32::BLACK,
     }
 }
 
@@ -853,5 +992,52 @@ mod tests {
             assert!(galley.rows[0].glyphs.len() >= 5);
         });
         output.textures_delta.clear();
+    }
+
+    #[test]
+    fn color_scheme_default_matches_dark_palette() {
+        let scheme = ColorScheme::default();
+        let palette = scheme.to_palette();
+        assert_eq!(palette, Palette::dark());
+    }
+
+    #[test]
+    fn color_scheme_from_palette_round_trip() {
+        let original = Palette::light();
+        let scheme = ColorScheme::from_palette("test", &original);
+        assert_eq!(scheme.name, "test");
+        assert!(!scheme.dark);
+        let restored = scheme.to_palette();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn color_scheme_partial_json_uses_defaults() {
+        let json = r##"{"name":"partial","accent":"#ff0000"}"##;
+        let scheme: ColorScheme = serde_json::from_str(json).unwrap();
+        assert_eq!(scheme.name, "partial");
+        assert_eq!(scheme.accent, "#ff0000");
+        // Other fields fall back to defaults
+        assert_eq!(scheme.window, hex(Palette::dark().window));
+    }
+
+    #[test]
+    fn color_scheme_parse_hex_6() {
+        let c = parse_color("#1ed760");
+        assert_eq!(c, Color32::from_rgb(0x1e, 0xd7, 0x60));
+    }
+
+    #[test]
+    fn color_scheme_parse_hex_8() {
+        let c = parse_color_alpha("#0000008c");
+        assert_eq!(c, Color32::from_rgba_premultiplied(0, 0, 0, 0x8c));
+    }
+
+    #[test]
+    fn color_scheme_serde_round_trip() {
+        let scheme = ColorScheme::default();
+        let json = serde_json::to_string(&scheme).unwrap();
+        let restored: ColorScheme = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.to_palette(), scheme.to_palette());
     }
 }

--- a/src/ui/keys.rs
+++ b/src/ui/keys.rs
@@ -13,6 +13,7 @@ pub(super) const SIDEBAR_SHORTCUT: &str = platform_shortcut("Ctrl+B", "Cmd+B");
 pub(super) const QUIT_SHORTCUT: &str = platform_shortcut("Ctrl+Q", "Cmd+Q");
 pub(super) const WINAMP_SHORTCUT: &str = platform_shortcut("Ctrl+M", "Cmd+Shift+M");
 pub(super) const MILKDROP_SHORTCUT: &str = platform_shortcut("Ctrl+Shift+K", "Cmd+Shift+K");
+pub(super) const RELOAD_THEME_SHORTCUT: &str = platform_shortcut("Ctrl+Shift+R", "Cmd+Shift+R");
 
 pub fn handle(app: &mut App, ctx: &egui::Context) {
     let typing = ctx.memory(|memory| memory.focused().is_some());
@@ -58,6 +59,11 @@ pub fn handle(app: &mut App, ctx: &egui::Context) {
             Modifiers::COMMAND | Modifiers::SHIFT,
             Key::K,
             Action::ToggleWinampMilkdrop,
+        );
+        key(
+            Modifiers::COMMAND | Modifiers::SHIFT,
+            Key::R,
+            Action::ReloadTheme,
         );
         key(
             Modifiers::COMMAND,
@@ -188,6 +194,7 @@ pub const SHORTCUTS: &[(&str, &str)] = &[
     ),
     (WINAMP_SHORTCUT, "Winamp mini player"),
     (MILKDROP_SHORTCUT, "MilkDrop, under the mini player"),
+    (RELOAD_THEME_SHORTCUT, "Reload colour scheme"),
     ("F  or  double-click", "MilkDrop: fill the screen"),
     ("→  /  N", "MilkDrop: next preset"),
     ("←  /  P", "MilkDrop: previous preset"),

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -447,6 +447,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     });
 
     section(ui, &palette, "Appearance", |ui| {
+        let is_custom = matches!(&app.settings.theme, ThemeChoice::Custom(_));
         widgets::setting_row(ui, &palette, "Theme", "", |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 6.0;
@@ -456,7 +457,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         &palette,
                         None,
                         choice.label(),
-                        app.settings.theme == *choice,
+                        !is_custom && app.settings.theme == *choice,
                     )
                     .clicked()
                         && app.settings.theme != *choice
@@ -465,34 +466,54 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         changed = true;
                     }
                 }
-                for (stem, scheme) in &app.available_schemes {
-                    let display = if scheme.name.is_empty() {
-                        stem
-                    } else {
-                        &scheme.name
-                    };
-                    let choice = ThemeChoice::Custom(stem.clone());
-                    if theme::soft_button(ui, &palette, None, display, app.settings.theme == choice)
-                        .clicked()
-                        && app.settings.theme != choice
-                    {
-                        app.settings.theme = choice;
-                        changed = true;
-                    }
-                }
             });
         });
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Colour from album art",
-            "Use the current cover's colour on pages and the player bar.",
-            |ui| {
-                if widgets::switch(ui, &palette, &mut app.settings.accent_from_art).changed() {
-                    changed = true;
-                }
-            },
-        );
+        if !app.available_schemes.is_empty() {
+            widgets::setting_row(
+                ui,
+                &palette,
+                "Colour schemes",
+                "Overrides the theme and album-art colour settings above.",
+                |ui| {
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        for (stem, scheme) in &app.available_schemes {
+                            let display = if scheme.name.is_empty() {
+                                stem
+                            } else {
+                                &scheme.name
+                            };
+                            let choice = ThemeChoice::Custom(stem.clone());
+                            if theme::soft_button(
+                                ui,
+                                &palette,
+                                None,
+                                display,
+                                app.settings.theme == choice,
+                            )
+                            .clicked()
+                            {
+                                app.settings.theme = choice;
+                                changed = true;
+                            }
+                        }
+                    });
+                },
+            );
+        }
+        if !is_custom {
+            widgets::setting_row(
+                ui,
+                &palette,
+                "Colour from album art",
+                "Use the current cover's colour on pages and the player bar.",
+                |ui| {
+                    if widgets::switch(ui, &palette, &mut app.settings.accent_from_art).changed() {
+                        changed = true;
+                    }
+                },
+            );
+        }
         widgets::setting_row(
             ui,
             &palette,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -450,15 +450,30 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         widgets::setting_row(ui, &palette, "Theme", "", |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 6.0;
-                for choice in ThemeChoice::ALL {
+                for choice in &ThemeChoice::BUILTINS {
                     if theme::soft_button(
                         ui,
                         &palette,
                         None,
                         choice.label(),
-                        app.settings.theme == choice,
+                        app.settings.theme == *choice,
                     )
                     .clicked()
+                        && app.settings.theme != *choice
+                    {
+                        app.settings.theme = choice.clone();
+                        changed = true;
+                    }
+                }
+                for (stem, scheme) in &app.available_schemes {
+                    let display = if scheme.name.is_empty() {
+                        stem
+                    } else {
+                        &scheme.name
+                    };
+                    let choice = ThemeChoice::Custom(stem.clone());
+                    if theme::soft_button(ui, &palette, None, display, app.settings.theme == choice)
+                        .clicked()
                         && app.settings.theme != choice
                     {
                         app.settings.theme = choice;


### PR DESCRIPTION
## Why

No way to use custom colour schemes. Users who theme their desktop (e.g. Caelestia) couldn't match Fastpotify.

## What changed

- `ColorScheme` struct: JSON-serialisable palette with hex fields, partial overrides supported
- `ThemeChoice::Custom(String)` variant, keyed by file stem
- Schemes loaded from `~/.config/fastpotify/schemes/*.json`
- Settings UI: separate "Colour schemes" row with toggle buttons
- `Ctrl+Shift+R` / `Cmd+Shift+R` reloads the active scheme live
- "Colour from album art" hidden when a scheme is active
- 6 unit tests, README updated

## Verification

- [x] `cargo fmt`, `clippy`, `test` — all pass (256 tests)
- [x] Linux: created scheme, selected in Settings, toggled between Dark/Custom/Light, reloaded with keybind

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.