### PR TITLE
Add HTTP and SOCKS5 proxy settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,8 @@ dependencies = [
  "glutin",
  "glutin-winit",
  "hmac",
+ "http",
+ "hyper-util",
  "image",
  "jiff",
  "ksni",
@@ -2233,40 +2235,17 @@ dependencies = [
 [[package]]
 name = "hyper-proxy2"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9043b7b23fb0bc4a1c7014c27b50a4fc42cc76206f71d34fc0dfe5b28ddc3faf"
 dependencies = [
  "bytes",
  "futures-util",
  "headers",
  "http",
  "hyper",
- "hyper-rustls 0.26.0",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls 0.25.0",
- "tower-service",
- "webpki",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "log",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.3",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2279,10 +2258,10 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.43",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
@@ -2903,7 +2882,7 @@ dependencies = [
  "httparse",
  "hyper",
  "hyper-proxy2",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "librespot-oauth",
  "librespot-protocol",
@@ -3794,12 +3773,6 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -4280,7 +4253,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.3",
- "rustls 0.23.43",
+ "rustls",
  "socket2",
  "thiserror 2.0.20",
  "tokio",
@@ -4301,7 +4274,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash 2.1.3",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.20",
@@ -4546,22 +4519,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -4709,20 +4682,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -4730,22 +4689,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.15",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -4754,19 +4700,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
@@ -4777,17 +4714,6 @@ checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -4854,19 +4780,6 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -5664,22 +5577,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.43",
+ "rustls",
  "tokio",
 ]
 
@@ -5702,11 +5604,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.43",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -5912,7 +5814,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.20",
@@ -6393,16 +6295,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,11 @@ raw-window-handle = { version = "0.6", optional = true }
 # Spotify playback and Connect. rustls everywhere so the client links one TLS
 # stack and builds without OpenSSL on every platform.
 #
-# librespot-core depends on hyper-proxy2 for HTTP proxy support, whose only
-# published release (0.1.0) pins rustls 0.22 and so drags in rustls-webpki
-# 0.102, which carries advisories against its CRL and name-constraint
-# handling. Fastpotify never configures a proxy (SessionConfig.proxy stays
-# None), so that TLS client is compiled in but never used to verify anything.
-# Every connection this app actually makes (the Web API through reqwest, and
-# librespot's own sessions) goes through rustls 0.23 with a patched
-# rustls-webpki. Removing the old copy needs a release of hyper-proxy2, or a
-# librespot that stops depending on it.
+# librespot-core depends on hyper-proxy2 for HTTP proxy support. The
+# published 0.1.0 release pins rustls 0.22 / rustls-webpki 0.102; we patch
+# it (see [patch.crates-io]) onto rustls 0.23 so CONNECT-then-TLS uses the
+# same stack as the rest of the client. SOCKS5 still covers the Web API but
+# not the engine: librespot only speaks HTTP CONNECT.
 librespot-core = { version = "0.8", default-features = false, features = ["rustls-tls-native-roots"] }
 librespot-playback = { version = "0.8", default-features = false, features = ["rodio-backend", "rustls-tls-native-roots"] }
 librespot-connect = { version = "0.8", default-features = false }
@@ -84,11 +80,19 @@ protobuf = "3"
 # so nothing new is compiled.
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
 cpal = "0.16"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "gzip", "http2", "blocking"] }
+# `socks` is SOCKS5 proxy support for the Web API, artwork, lyrics, and
+# update checks. HTTP proxies work without it. `system-proxy` reads the OS
+# proxy on macOS and Windows when the mode is System; Linux uses environment
+# variables either way.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "gzip", "http2", "blocking", "socks", "system-proxy"] }
+# Same System-proxy matcher reqwest uses, so local playback follows the same
+# HTTP proxy (environment, and the OS proxy on macOS and Windows).
+hyper-util = { version = "0.1", default-features = false, features = ["client-proxy", "client-proxy-system"] }
+http = "1"
 # `fs` is used by the playlist cache in `backend.rs`. On Linux the
 # mpris-server dependency happens to turn it on, which is why leaving it out
-# built there and nowhere else.
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "fs"] }
+# built there and nowhere else. `net` is the local HTTP-proxy tests.
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "fs", "net", "io-util"] }
 sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"
@@ -171,6 +175,9 @@ opt-level = 0
 # explicit CMAKE_GENERATOR win. Drop when upstream takes the change.
 [patch.crates-io]
 projectm-sys = { git = "https://github.com/crmne/projectm-rs", branch = "respect-cmake-generator" }
+# hyper-proxy2 0.1.0 still verifies proxied HTTPS with rustls 0.22. Drop when
+# a release, or a librespot that no longer depends on it, uses rustls 0.23.
+hyper-proxy2 = { path = "vendor/hyper-proxy2" }
 # librespot 0.8.0 plus the small patches Fastpotify needs: queue controls,
 # normalisation-factor reporting for the visualisers, and a distinct event
 # when Spotify refuses an audio key. Every librespot crate comes from the

--- a/README.md
+++ b/README.md
@@ -243,8 +243,13 @@ Settings live in one readable JSON file (`~/.config/fastpotify/settings.json`
 on Linux). They include the Connect device name, bitrate, normalisation,
 autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
-from artwork, and the mini player's skin and size.
-Playback settings apply when you press **Apply and restart playback**.
+from artwork, the mini player's skin and size, and the proxy (off, system,
+HTTP, or SOCKS5). Playback settings apply when you press **Apply and restart
+playback**. Off and System proxies apply immediately. HTTP and SOCKS5 apply
+when you press **Apply settings**, and can also be set on the sign-in screen.
+A proxy password is stored next to the Spotify grants, not in settings.json.
+Proxy authentication covers Web requests. Local playback can use only an
+unauthenticated HTTP proxy; with proxy login or SOCKS5 it connects directly.
 
 Caches (audio, artwork) live under the cache directory and can be deleted at
 any time without signing you out.

--- a/docs/_guide/getting-started.md
+++ b/docs/_guide/getting-started.md
@@ -52,6 +52,15 @@ Fastpotify stores a refresh token in your platform's state directory
 (`~/.local/state/fastpotify` on Linux). You normally need the browser only
 once per machine.
 
+If Spotify is only reachable through a proxy, set it on the sign-in screen
+before you grant access: Off, System, HTTP, or SOCKS5. A manual HTTP or
+SOCKS5 proxy needs a host and a port; username and password are optional.
+The password is stored with owner-only permissions in the state directory,
+not in settings.json. Authentication applies to Web requests; local playback
+uses only an unauthenticated HTTP proxy and otherwise connects directly.
+SOCKS5 resolves Spotify hostnames at the proxy. After sign-in, the same choice
+lives in Settings → Proxy.
+
 ## Enable playback on this computer
 
 Playing music *on this machine* needs a second browser approval because

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -32,7 +32,8 @@ adds a separate Development Mode quota. See
 
 - Shared and personal Web API refresh tokens, plus librespot's credential, in
   the state directory with owner-only permissions
-  ([file locations](/settings-and-files/)).
+  ([file locations](/settings-and-files/)). An optional proxy password is
+  stored the same way, not in settings.json.
 - Downloaded audio and artwork, in the cache directory, within the budget
   you set.
 - The first time MilkDrop opens with an empty preset folder, the two projectM
@@ -83,3 +84,32 @@ The engine discovers access points through `apresolve.spotify.com` and
 connects over TCP in the resolver's preference order: port 4070 first,
 falling back to 443 and 80. Only outbound connections are needed; no
 inbound ports have to be open.
+
+## Proxy
+
+Settings → Proxy has four modes:
+
+- **Off**: a direct connection. Environment proxy variables are ignored.
+- **System**: `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`, and on macOS and
+  Windows the OS proxy. This is the default.
+- **HTTP**: a configured HTTP proxy: host, port, and optional login.
+- **SOCKS5**: a configured SOCKS5 proxy: host, port, and optional login.
+  Spotify hostnames are resolved by that proxy.
+
+The mode selects the protocol. Host and port are separate fields.
+
+The Web API, artwork, lyrics, update checks, and MilkDrop preset downloads
+follow that mode. Local receivers on the LAN are never sent through a proxy.
+
+Local playback can only use an unauthenticated, plaintext HTTP proxy: that is
+what librespot's CONNECT client supports. Proxy login still covers catalogue
+and control, but the engine then connects to Spotify directly. SOCKS5 behaves
+the same way for local playback. System uses the same proxy reqwest would
+(environment variables, and the OS proxy on macOS and Windows) only when it
+is an unauthenticated `http://` endpoint; authenticated, `https://`, and SOCKS
+system proxies are ignored by the engine. Changing the HTTP proxy the engine
+would actually use restarts local playback.
+
+Off and System apply immediately. HTTP and SOCKS5 apply when you press
+**Apply settings**. The same choice is on the sign-in screen, so it can be
+set before the first grant.

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -16,6 +16,7 @@ Fastpotify follows each platform's conventions. On Linux:
 | Shared Web API sign-in | `~/.local/state/fastpotify/shared_web_api_token.json` | Yes, you sign in again |
 | Personal Web API sign-in | `~/.local/state/fastpotify/personal_web_api_token.json` | Yes, the personal app is disabled |
 | Playback credential | `~/.local/state/fastpotify/credentials/` | Yes, you approve playback again |
+| Proxy password | `~/.local/state/fastpotify/proxy_password` | Yes, you type it again |
 | Last session | `~/.local/state/fastpotify/session.json` | Yes |
 | Play history | `~/.local/state/fastpotify/history.json` | Yes |
 | Audio cache | `~/.cache/fastpotify/audio/` | Always |
@@ -26,9 +27,9 @@ Fastpotify follows each platform's conventions. On Linux:
 | Crash log | `~/.local/state/fastpotify/panic.log` | Always |
 
 Clearing caches never signs you out; credentials live in *state*, not
-*cache*. Web API token files are written with owner-only permissions.
-Signing out from Settings deletes both Web API grants and the separate
-playback credential.
+*cache*. Web API token files and the proxy password are written with
+owner-only permissions. Signing out from Settings deletes both Web API
+grants and the separate playback credential; the proxy password stays.
 
 Progress through a playlist is periodically cached as a contiguous prefix.
 When the playlist has not changed on Spotify, reopening it resumes from that
@@ -89,6 +90,10 @@ main fields are:
 | `keep_playing_in_background` | `true` | Close to tray |
 | `check_for_updates` | `true` | Ask GitHub once a day for a newer release |
 | `web_client_id` | none | Optional personal Spotify app id used alongside shared coverage |
+| `proxy_mode` | `system` | `off`, `system`, `http`, or `socks`. Older files without this field stay on `system` |
+| `proxy_host` | none | Host of a manual HTTP or SOCKS5 proxy. Ignored when the mode is `off` or `system` |
+| `proxy_port` | none | Port of a manual HTTP or SOCKS5 proxy |
+| `proxy_username` | none | Optional proxy login for Web requests; authenticated local playback proxying is not supported |
 
 ## Command line
 

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
               pname = "fastpotify";
               version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
               src = self;
-              hash = "sha256-l2pWMz/X2RpWaAHMjOZrmQ8v1Ux+JECdh+/aQn/pzjM=";
+              hash = "sha256-rTG8cfy3tHeNL9VS558i5ugEMRhQqPSBaJBjtWAV6kQ=";
             };
 
             nativeBuildInputs =
@@ -153,6 +153,14 @@
             # projectm-sys expects CMake to install into lib/, while CMake
             # defaults to lib64/ on NixOS.
             env.CMAKE = "${cmakeWithLibdir}";
+
+            # Nix's Rust check hook deliberately points SSL_CERT_FILE at a
+            # missing path. The librespot proxy regression test constructs a
+            # TLS connector before asserting its CONNECT request, so give the
+            # test an explicit, sandboxed trust store.
+            preCheck = ''
+              export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            '';
 
             # The GUI dlopens its Wayland, X11 and GL libraries at run time.
             postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -16,6 +16,7 @@ use tokio::sync::Semaphore;
 
 use super::ApiSource;
 use super::models::*;
+use crate::http::Http;
 
 const BASE_URL: &str = "https://api.spotify.com/v1";
 const MAX_IN_FLIGHT: usize = 6;
@@ -94,7 +95,7 @@ impl TokenProvider {
 
 /// The Web API grant, refreshed and persisted as it ages.
 pub struct WebTokens {
-    http: reqwest::Client,
+    http: Http,
     token: tokio::sync::Mutex<crate::auth::StoredToken>,
     path: std::path::PathBuf,
     source: ApiSource,
@@ -102,13 +103,13 @@ pub struct WebTokens {
 
 impl WebTokens {
     pub fn new(
-        http: reqwest::Client,
+        http: impl Into<Http>,
         token: crate::auth::StoredToken,
         path: std::path::PathBuf,
         source: ApiSource,
     ) -> std::sync::Arc<Self> {
         std::sync::Arc::new(Self {
-            http,
+            http: http.into(),
             token: tokio::sync::Mutex::new(token),
             path,
             source,
@@ -122,7 +123,7 @@ impl WebTokens {
         if force || guard.needs_refresh() {
             let client_id = guard.client_id.clone();
             let refresh_token = guard.refresh_token.clone();
-            match crate::auth::refresh(&self.http, &client_id, &refresh_token).await {
+            match crate::auth::refresh(&self.http.client(), &client_id, &refresh_token).await {
                 Ok(response) => match crate::auth::StoredToken::from_response(
                     &client_id,
                     response,
@@ -261,7 +262,7 @@ impl Drop for ActivityGuard<'_> {
 }
 
 pub struct ApiClient {
-    http: reqwest::Client,
+    http: Http,
     tokens: Mutex<Option<TokenProvider>>,
     limiter: Semaphore,
     cooldown_until: tokio::sync::Mutex<Instant>,
@@ -273,14 +274,14 @@ pub struct ApiClient {
 
 impl ApiClient {
     pub fn new(
-        http: reqwest::Client,
+        http: impl Into<Http>,
         activity: Arc<NetActivity>,
         search_limit: u32,
         artist_albums_limit: u32,
         source: ApiSource,
     ) -> Self {
         Self {
-            http,
+            http: http.into(),
             tokens: Mutex::new(None),
             limiter: Semaphore::new(MAX_IN_FLIGHT),
             cooldown_until: tokio::sync::Mutex::new(Instant::now()),
@@ -349,6 +350,7 @@ impl ApiClient {
             let token = provider.access_token().await?;
             let mut request = self
                 .http
+                .client()
                 .request(method.clone(), &url)
                 .bearer_auth(&token)
                 .query(query);

--- a/src/api/gateway.rs
+++ b/src/api/gateway.rs
@@ -135,7 +135,7 @@ struct Session {
 }
 
 impl Session {
-    fn new(http: reqwest::Client, activity: Arc<NetActivity>, profile: ApiProfile) -> Self {
+    fn new(http: crate::http::Http, activity: Arc<NetActivity>, profile: ApiProfile) -> Self {
         Self {
             state: RwLock::new(SessionState::Unavailable),
             client: Arc::new(ApiClient::new(
@@ -167,7 +167,8 @@ pub struct ApiGateway {
 }
 
 impl ApiGateway {
-    pub fn new(http: reqwest::Client, activity: Arc<NetActivity>) -> Self {
+    pub fn new(http: impl Into<crate::http::Http>, activity: Arc<NetActivity>) -> Self {
+        let http = http.into();
         Self {
             shared: Session::new(http.clone(), activity.clone(), ApiProfile::SHARED),
             personal: Session::new(http, activity, ApiProfile::PERSONAL),

--- a/src/app.rs
+++ b/src/app.rs
@@ -136,6 +136,10 @@ struct Listening {
 pub struct App {
     pub dirs: AppDirs,
     pub settings: Settings,
+    /// Proxy policy actually handed to network workers. Manual form edits are
+    /// drafts until Apply (or Sign in), so unrelated downloads and engine
+    /// restarts must not observe them early.
+    applied_proxy: crate::settings::ProxyConfig,
     settings_dirty: bool,
     last_settings_save: Instant,
     pub backend: Backend,
@@ -412,9 +416,17 @@ impl App {
         if let Ok(mut shared) = eq.lock() {
             *shared = eq_settings(&settings);
         }
+        let applied_proxy = match settings.proxy_config() {
+            Ok(proxy) => proxy,
+            Err(error) => {
+                log::warn!("proxy setting ignored: {error}");
+                crate::settings::ProxyConfig::Off
+            }
+        };
         let engine_config = engine_config(
             &dirs,
             &settings,
+            applied_proxy.clone(),
             std::sync::Arc::clone(&tap),
             std::sync::Arc::clone(&eq),
         );
@@ -455,6 +467,7 @@ impl App {
         let mut app = Self {
             dirs,
             settings,
+            applied_proxy,
             settings_dirty: false,
             last_settings_save: Instant::now(),
             backend,
@@ -1857,6 +1870,8 @@ impl App {
             return;
         }
         self.settings.save(&self.dirs.settings_file());
+        self.settings
+            .save_proxy_secret(&self.dirs.proxy_secret_file());
     }
 
     fn apply_theme(&mut self, ctx: &egui::Context) {
@@ -5095,7 +5110,36 @@ impl App {
                 }
             }
             Action::Reload(page) => self.reload(page),
-            Action::SignIn => self.backend.send(Command::SignIn),
+            Action::SignIn => match self.settings.proxy_config() {
+                Ok(config) => {
+                    self.save_settings();
+                    self.applied_proxy = config.clone();
+                    self.backend.send(Command::RestartEngine(engine_config(
+                        &self.dirs,
+                        &self.settings,
+                        config,
+                        std::sync::Arc::clone(&self.winamp.tap),
+                        std::sync::Arc::clone(&self.winamp.eq),
+                    )));
+                    self.backend.send(Command::SignIn);
+                }
+                Err(error) => self.toast_error(error),
+            },
+            Action::ApplyProxy => match self.settings.proxy_config() {
+                Ok(config) => {
+                    self.save_settings();
+                    let restart_playback =
+                        self.applied_proxy.restarts_local_playback(&config) && self.local_ready;
+                    self.applied_proxy = config.clone();
+                    self.backend.send(Command::ApplyProxy(config));
+                    if restart_playback {
+                        self.toast("Applying proxy and restarting local playback");
+                    } else {
+                        self.toast("Settings Applied");
+                    }
+                }
+                Err(error) => self.toast_error(error),
+            },
             Action::CancelSignIn => {
                 self.backend.send(Command::CancelSignIn);
                 self.sign_in_url = None;
@@ -5153,6 +5197,7 @@ impl App {
                 let config = engine_config(
                     &self.dirs,
                     &self.settings,
+                    self.applied_proxy.clone(),
                     std::sync::Arc::clone(&self.winamp.tap),
                     std::sync::Arc::clone(&self.winamp.eq),
                 );
@@ -5349,7 +5394,11 @@ impl App {
                     if self.winamp.presets.count() == 0
                         && self.winamp.presets.downloading().is_none()
                     {
-                        self.winamp.presets.download_missing(folder, ctx.clone());
+                        self.winamp.presets.download_missing(
+                            folder,
+                            ctx.clone(),
+                            self.applied_proxy.clone(),
+                        );
                         self.toast("Downloading MilkDrop preset packs");
                     }
                 }
@@ -5376,9 +5425,12 @@ impl App {
             Action::OpenMilkdropFolder => self.open_folder(self.dirs.milkdrop_dir()),
             Action::DownloadMilkdropPack(index) => {
                 if let Some(pack) = crate::milkdrop::PACKS.get(index) {
-                    self.winamp
-                        .presets
-                        .download(pack, self.dirs.milkdrop_dir(), ctx.clone());
+                    self.winamp.presets.download(
+                        pack,
+                        self.dirs.milkdrop_dir(),
+                        ctx.clone(),
+                        self.applied_proxy.clone(),
+                    );
                     self.toast(format!("Downloading {} presets", pack.name));
                 }
             }
@@ -5799,6 +5851,7 @@ impl App {
 pub fn engine_config(
     dirs: &AppDirs,
     settings: &Settings,
+    proxy: crate::settings::ProxyConfig,
     tap: std::sync::Arc<crate::vis::AudioTap>,
     eq: crate::eq::SharedEq,
 ) -> EngineConfig {
@@ -5821,6 +5874,7 @@ pub fn engine_config(
         volume_dir: dirs.volume_dir(),
         audio_cache_dir: settings.audio_cache.then(|| dirs.audio_cache_dir()),
         audio_cache_limit: Some(settings.audio_cache_mb.max(64) * 1024 * 1024),
+        proxy,
     }
 }
 
@@ -7583,6 +7637,27 @@ mod tests {
             page.items.items[0].playable().map(PlayableItem::uri),
             Some("spotify:track:new")
         );
+    }
+
+    #[test]
+    fn manual_proxy_edits_remain_drafts_until_apply() {
+        let mut app = test_app("proxy-draft");
+        app.backend.set_offline(true);
+        let original = app.applied_proxy.clone();
+        app.settings.proxy_mode = crate::settings::ProxyMode::Http;
+        app.settings.proxy_host = "127.0.0.1".into();
+        app.settings.proxy_port = "8080".into();
+
+        app.actions.push(Action::RestartEngine);
+        app.apply_actions(&egui::Context::default());
+        assert_eq!(app.applied_proxy, original);
+
+        app.actions.push(Action::ApplyProxy);
+        app.apply_actions(&egui::Context::default());
+        assert!(matches!(
+            app.applied_proxy,
+            crate::settings::ProxyConfig::Http(_)
+        ));
     }
 
     /// Shuffle picks a random loaded track or Web API offset. Local librespot

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -389,7 +389,7 @@ impl StoredToken {
         let text = serde_json::to_string_pretty(self)?;
         let temporary = path.with_extension("json.tmp");
         write_private(&temporary, text.as_bytes())?;
-        std::fs::rename(&temporary, path)?;
+        replace_file(&temporary, path)?;
         Ok(())
     }
 
@@ -418,7 +418,7 @@ impl StoredToken {
     }
 }
 
-fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+pub(crate) fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
     let mut options = std::fs::OpenOptions::new();
     options.write(true).create(true).truncate(true);
@@ -428,8 +428,59 @@ fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
         options.mode(0o600);
     }
     let mut file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
     file.write_all(contents)?;
     file.flush()
+}
+
+/// Atomically install a temporary file, replacing an older destination on
+/// every supported platform. `std::fs::rename` cannot replace a file on
+/// Windows, so settings and credentials need the native replace flag there.
+pub(crate) fn replace_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+        };
+
+        fn wide(path: &Path) -> std::io::Result<Vec<u16>> {
+            let mut value: Vec<u16> = path.as_os_str().encode_wide().collect();
+            if value.contains(&0) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "path contains a null character",
+                ));
+            }
+            value.push(0);
+            Ok(value)
+        }
+
+        let temporary = wide(temporary)?;
+        let destination = wide(destination)?;
+        // SAFETY: both slices are nul-terminated and remain alive for the
+        // call. The paths are in the same directory, so this is a same-volume
+        // atomic replacement.
+        let moved = unsafe {
+            MoveFileExW(
+                temporary.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if moved == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::rename(temporary, destination)
+    }
 }
 
 fn now_secs() -> u64 {
@@ -562,6 +613,47 @@ mod tests {
             assert_eq!(StoredToken::load(target), Some(token));
             assert!(!legacy.exists());
         }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn atomic_replace_overwrites_an_existing_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-replace-{}-{}",
+            std::process::id(),
+            now_secs()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let destination = dir.join("secret");
+        let temporary = dir.join("secret.tmp");
+        std::fs::write(&destination, "old").unwrap();
+        std::fs::write(&temporary, "new").unwrap();
+        replace_file(&temporary, &destination).unwrap();
+        assert_eq!(std::fs::read_to_string(&destination).unwrap(), "new");
+        assert!(!temporary.exists());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_write_tightens_an_existing_files_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-private-{}-{}",
+            std::process::id(),
+            now_secs()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("secret.tmp");
+        std::fs::write(&path, "old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        write_private(&path, b"new").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -17,15 +17,37 @@ use crate::api::{
     AccountId, ApiError, ApiGateway, ApiSource, NetActivity, Operation, PlayRequest, PlaylistId,
     SessionState, TokenProvider, WebTokens,
 };
+use crate::http::Http;
 use crate::images::{ArtLoader, accent_color};
 use crate::model::PlaylistCache;
 use crate::paths::AppDirs;
 use crate::player::{Engine, EngineConfig, EngineEvent, LoadSpec, LocalState, PlayerCommand};
+use crate::settings::ProxyConfig;
 
 pub type ApiResult<T> = Result<T, ApiError>;
 
 const PREMIUM_NEEDED: &str = "Local playback needs Spotify Premium.";
 pub const PLAYLIST_PAGE_SIZE: u32 = 50;
+const RECONNECT_WINDOW: Duration = Duration::from_secs(600);
+const RECONNECT_LIMIT: usize = 6;
+
+/// True when the session has already dropped this many times in the window,
+/// so another reconnect would only flap. Callers that still reconnect must
+/// push `now` themselves.
+fn session_drops_exhausted(reconnects: &mut Vec<Instant>, now: Instant) -> bool {
+    reconnects.retain(|attempt| now.duration_since(*attempt) < RECONNECT_WINDOW);
+    reconnects.len() >= RECONNECT_LIMIT
+}
+
+/// Record a replacement requested while a connection attempt is still in
+/// flight. The finished attempt must be discarded and immediately retried
+/// with the newest config instead of installing stale state.
+fn defer_engine_replace(engine_busy: bool, restart_pending: &mut bool) -> bool {
+    if engine_busy {
+        *restart_pending = true;
+    }
+    engine_busy
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AuthStatus {
@@ -420,6 +442,9 @@ pub enum Command {
     AuthorizePlayback,
     /// Reload the engine config (audio settings changed).
     RestartEngine(EngineConfig),
+    /// Rebuild the HTTP client. Restart local playback only when its HTTP
+    /// proxy changed; Off, System, and SOCKS5 share a direct engine connection.
+    ApplyProxy(ProxyConfig),
     Player(PlayerCommand),
     Api(ApiRequest),
     Accent {
@@ -614,11 +639,7 @@ impl Backend {
             .enable_all()
             .build()
             .expect("unable to start the async runtime");
-        let http = reqwest::Client::builder()
-            .user_agent(concat!("fastpotify/", env!("CARGO_PKG_VERSION")))
-            .timeout(Duration::from_secs(30))
-            .build()
-            .expect("unable to build the HTTP client");
+        let http = Http::from_proxy(&engine_config.proxy);
         let art = ArtLoader::new(http.clone(), runtime.handle().clone(), dirs.art_cache_dir());
         let activity = Arc::new(NetActivity::default());
 
@@ -752,7 +773,7 @@ struct Worker {
     dirs: AppDirs,
     engine_config: EngineConfig,
     web_client_id: Option<String>,
-    http: reqwest::Client,
+    http: Http,
     api: Arc<ApiGateway>,
     background_api: Arc<tokio::sync::Semaphore>,
     art: ArtLoader,
@@ -763,6 +784,9 @@ struct Worker {
     /// True while a playback grant or engine connection is in flight, so a
     /// second attempt does not pile up.
     engine_busy: bool,
+    /// A user changed engine-affecting settings while the current connection
+    /// attempt was in flight. Its result is stale and must not be installed.
+    engine_restart_pending: bool,
     signed_in: bool,
     /// The plan, once the Web API has answered.
     premium: Option<bool>,
@@ -783,7 +807,7 @@ impl Worker {
         dirs: AppDirs,
         engine_config: EngineConfig,
         web_client_id: Option<String>,
-        http: reqwest::Client,
+        http: Http,
         art: ArtLoader,
         activity: Arc<NetActivity>,
         events: std::sync::mpsc::Sender<Event>,
@@ -803,6 +827,7 @@ impl Worker {
             waker,
             engine: None,
             engine_busy: false,
+            engine_restart_pending: false,
             signed_in: false,
             premium: None,
             cancel_signin: None,
@@ -817,6 +842,28 @@ impl Worker {
     fn emit(&self, event: Event) {
         let _ = self.events.send(event);
         self.waker.wake();
+    }
+
+    fn apply_proxy(&self, proxy: ProxyConfig) {
+        match crate::http::build_client(&proxy) {
+            Ok(client) => {
+                match &proxy {
+                    ProxyConfig::Off => log::info!("not using a proxy"),
+                    ProxyConfig::System => log::info!("using the system proxy"),
+                    ProxyConfig::Http(manual) => {
+                        log::info!("using HTTP proxy {}", manual.redacted())
+                    }
+                    ProxyConfig::Socks(manual) => {
+                        log::info!("using SOCKS5 proxy {}", manual.redacted())
+                    }
+                }
+                self.http.replace(client);
+            }
+            Err(error) => {
+                log::warn!("unable to apply the proxy: {error}");
+                self.emit(Event::Error(format!("Proxy could not be applied: {error}")));
+            }
+        }
     }
 
     async fn run(&mut self, mut commands: mpsc::UnboundedReceiver<Command>) {
@@ -839,8 +886,21 @@ impl Worker {
                 Command::SignOut => self.sign_out(),
                 Command::AuthorizePlayback => self.authorize_playback(),
                 Command::RestartEngine(config) => {
+                    if self.engine_config.proxy != config.proxy {
+                        self.apply_proxy(config.proxy.clone());
+                    }
                     self.engine_config = config;
-                    self.reconnect_engine();
+                    self.replace_engine();
+                }
+                Command::ApplyProxy(proxy) => {
+                    let restart = self.engine_config.proxy.restarts_local_playback(&proxy);
+                    if self.engine_config.proxy != proxy {
+                        self.apply_proxy(proxy.clone());
+                        self.engine_config.proxy = proxy;
+                    }
+                    if restart {
+                        self.replace_engine();
+                    }
                 }
                 Command::Player(command) => match &self.engine {
                     Some(engine) => {
@@ -1109,7 +1169,7 @@ impl Worker {
                 log::warn!("unable to open a browser: {error}");
             }
         });
-        let http = self.http.clone();
+        let http = self.http.client();
         let events = self.events.clone();
         let waker = self.waker.clone();
         let commands = self.commands.clone();
@@ -1220,14 +1280,50 @@ impl Worker {
         }
     }
 
-    /// Reconnect the engine after its session dropped or audio settings
-    /// changed. Whatever was playing comes back at the same spot on the new
-    /// session, so a dropped connection is a pause of a few seconds rather
-    /// than silence.
+    /// Replace the engine after a user-initiated change (audio settings or
+    /// an HTTP proxy). Does not count toward the drop limiter: flipping a
+    /// setting is not the session falling over.
+    fn replace_engine(&mut self) {
+        if !self.signed_in {
+            return;
+        }
+        if defer_engine_replace(self.engine_busy, &mut self.engine_restart_pending) {
+            return;
+        }
+        self.take_engine_for_resume();
+        self.resume_engine();
+    }
+
+    /// Reconnect the engine after its session dropped on its own. Whatever
+    /// was playing comes back at the same spot on the new session, so a
+    /// dropped connection is a pause of a few seconds rather than silence.
+    /// Six drops in ten minutes stop the loop so a flapping session cannot
+    /// sit there reconnecting forever.
     fn reconnect_engine(&mut self) {
         if !self.signed_in {
             return;
         }
+        if self.engine_busy {
+            return;
+        }
+        let now = Instant::now();
+        if session_drops_exhausted(&mut self.reconnects, now) {
+            self.take_engine_for_resume();
+            self.resume = None;
+            self.emit(Event::Playback(LocalPlayback::Failed(
+                "Local playback keeps dropping. Re-enable it from Settings.".into(),
+            )));
+            return;
+        }
+        self.reconnects.push(now);
+        log::info!(
+            "local playback session ended; reconnecting ({} of {RECONNECT_LIMIT} in ten minutes)",
+            self.reconnects.len()
+        );
+        self.replace_engine();
+    }
+
+    fn take_engine_for_resume(&mut self) {
         self.resume_verify = None;
         if let Some(engine) = self.engine.take() {
             self.resume = engine.interrupted().map(|interrupted| LoadSpec {
@@ -1238,22 +1334,6 @@ impl Worker {
             });
             engine.shutdown();
         }
-        let now = Instant::now();
-        self.reconnects
-            .retain(|attempt| now.duration_since(*attempt) < Duration::from_secs(600));
-        if self.reconnects.len() >= 6 {
-            self.resume = None;
-            self.emit(Event::Playback(LocalPlayback::Failed(
-                "Local playback keeps dropping. Re-enable it from Settings.".into(),
-            )));
-            return;
-        }
-        self.reconnects.push(now);
-        log::info!(
-            "local playback session ended; reconnecting ({} of 6 in ten minutes)",
-            self.reconnects.len()
-        );
-        self.resume_engine();
     }
 
     /// Start (or re-enter) the playback authorization in the browser. This is
@@ -1280,7 +1360,7 @@ impl Worker {
                 log::warn!("unable to open a browser: {error}");
             }
         });
-        let http = self.http.clone();
+        let http = self.http.client();
         let events = self.events.clone();
         let waker = self.waker.clone();
         let commands = self.commands.clone();
@@ -1374,6 +1454,15 @@ impl Worker {
 
     fn on_engine_connected(&mut self, engine: Option<Engine>, error: Option<String>) {
         self.engine_busy = false;
+        if std::mem::take(&mut self.engine_restart_pending) {
+            if let Some(engine) = engine {
+                engine.shutdown();
+            }
+            // Keep `resume`: it belongs to the engine which was replaced,
+            // not to this stale attempt. The newest config is already stored.
+            self.resume_engine();
+            return;
+        }
         match engine {
             Some(engine) => {
                 let device_id = engine.device_id().to_string();
@@ -1454,6 +1543,10 @@ impl Worker {
                             .to_string()
                     })?;
                 let http = reqwest::blocking::Client::builder()
+                    // Receiver endpoints are private LAN addresses. Keep
+                    // them off environment and OS proxies even when System
+                    // mode is active.
+                    .no_proxy()
                     .timeout(std::time::Duration::from_secs(8))
                     .build()
                     .map_err(|error| error.to_string())?;
@@ -1468,7 +1561,7 @@ impl Worker {
     }
 
     fn check_for_updates(&self) {
-        let http = self.http.clone();
+        let http = self.http.client();
         let events = self.events.clone();
         let waker = self.waker.clone();
         tokio::spawn(async move {
@@ -1541,7 +1634,7 @@ impl Worker {
     }
 
     fn fetch_lyrics(&self, request: LyricsRequest) {
-        let http = self.http.clone();
+        let http = self.http.client();
         let events = self.events.clone();
         let waker = self.waker.clone();
         let cache_dir = self.dirs.lyrics_cache_dir();
@@ -2249,5 +2342,48 @@ mod playlist_cache_tests {
         assert_eq!(stored.snapshot, "second");
         assert!(!path.with_extension("json.tmp").exists());
         let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn six_session_drops_in_ten_minutes_give_up() {
+        let start = Instant::now();
+        let mut reconnects = Vec::new();
+        for i in 0..RECONNECT_LIMIT {
+            let at = start + Duration::from_secs(i as u64);
+            assert!(
+                !session_drops_exhausted(&mut reconnects, at),
+                "attempt {i} should still reconnect"
+            );
+            reconnects.push(at);
+        }
+        assert!(session_drops_exhausted(
+            &mut reconnects,
+            start + Duration::from_secs(30)
+        ));
+    }
+
+    #[test]
+    fn session_drops_outside_the_window_do_not_count() {
+        let start = Instant::now();
+        let mut reconnects = vec![start; RECONNECT_LIMIT];
+        assert!(!session_drops_exhausted(
+            &mut reconnects,
+            start + RECONNECT_WINDOW + Duration::from_secs(1)
+        ));
+        assert!(reconnects.is_empty());
+    }
+
+    #[test]
+    fn an_engine_change_during_connect_is_deferred() {
+        let mut pending = false;
+        assert!(defer_engine_replace(true, &mut pending));
+        assert!(pending);
+        assert!(!defer_engine_replace(false, &mut pending));
+        assert!(pending, "finishing the attempt owns clearing the request");
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,302 @@
+//! Shared HTTP client, so a proxy change can take effect without a restart.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use crate::settings::ProxyConfig;
+
+/// A cheap-to-clone handle to the process HTTP client.
+///
+/// Replacing the inner client updates every clone: the Web API, token
+/// refresh, artwork, lyrics, and the update check all pick up a new proxy
+/// on the next request.
+#[derive(Clone)]
+pub struct Http {
+    inner: Arc<RwLock<reqwest::Client>>,
+}
+
+impl Http {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(client)),
+        }
+    }
+
+    pub fn from_proxy(proxy: &ProxyConfig) -> Self {
+        match build_client(proxy) {
+            Ok(client) => Self::new(client),
+            Err(error) => {
+                log::warn!("unable to build the HTTP client with a proxy: {error}");
+                Self::new(build_client(&ProxyConfig::Off).expect("unable to build the HTTP client"))
+            }
+        }
+    }
+
+    pub fn replace(&self, client: reqwest::Client) {
+        *self.inner.write().unwrap_or_else(|lock| lock.into_inner()) = client;
+    }
+
+    pub fn client(&self) -> reqwest::Client {
+        self.inner
+            .read()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .clone()
+    }
+}
+
+impl Default for Http {
+    fn default() -> Self {
+        Self::new(reqwest::Client::new())
+    }
+}
+
+impl From<reqwest::Client> for Http {
+    fn from(client: reqwest::Client) -> Self {
+        Self::new(client)
+    }
+}
+
+pub fn build_client(proxy: &ProxyConfig) -> Result<reqwest::Client, reqwest::Error> {
+    client_builder(proxy)?
+        .timeout(Duration::from_secs(30))
+        .build()
+}
+
+pub fn build_blocking(
+    proxy: &ProxyConfig,
+    timeout: Duration,
+) -> Result<reqwest::blocking::Client, reqwest::Error> {
+    blocking_builder(proxy)?.timeout(timeout).build()
+}
+
+fn client_builder(proxy: &ProxyConfig) -> Result<reqwest::ClientBuilder, reqwest::Error> {
+    apply_proxy(reqwest::Client::builder().user_agent(user_agent()), proxy)
+}
+
+fn blocking_builder(
+    proxy: &ProxyConfig,
+) -> Result<reqwest::blocking::ClientBuilder, reqwest::Error> {
+    apply_blocking_proxy(
+        reqwest::blocking::Client::builder().user_agent(user_agent()),
+        proxy,
+    )
+}
+
+fn apply_proxy(
+    builder: reqwest::ClientBuilder,
+    proxy: &ProxyConfig,
+) -> Result<reqwest::ClientBuilder, reqwest::Error> {
+    Ok(match proxy {
+        ProxyConfig::Off => builder.no_proxy(),
+        ProxyConfig::System => builder,
+        ProxyConfig::Http(manual) | ProxyConfig::Socks(manual) => {
+            builder.proxy(manual.reqwest_proxy()?)
+        }
+    })
+}
+
+fn apply_blocking_proxy(
+    builder: reqwest::blocking::ClientBuilder,
+    proxy: &ProxyConfig,
+) -> Result<reqwest::blocking::ClientBuilder, reqwest::Error> {
+    Ok(match proxy {
+        ProxyConfig::Off => builder.no_proxy(),
+        ProxyConfig::System => builder,
+        ProxyConfig::Http(manual) | ProxyConfig::Socks(manual) => {
+            builder.proxy(manual.reqwest_proxy()?)
+        }
+    })
+}
+
+fn user_agent() -> &'static str {
+    concat!("fastpotify/", env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replacing_the_client_is_visible_to_clones() {
+        let http = Http::default();
+        let clone = http.clone();
+        let replacement = reqwest::Client::builder()
+            .user_agent("fastpotify-test")
+            .build()
+            .unwrap();
+        http.replace(replacement.clone());
+        // Distinct Client values still share the pool after a replace; the
+        // lock is what matters, and a second replace of a dummy client
+        // must not panic.
+        clone.replace(reqwest::Client::new());
+    }
+
+    #[test]
+    fn off_system_and_socks5_each_build_a_client() {
+        build_client(&ProxyConfig::Off).unwrap();
+        build_client(&ProxyConfig::System).unwrap();
+        let settings = crate::settings::Settings {
+            proxy_mode: crate::settings::ProxyMode::Socks,
+            proxy_host: "127.0.0.1".into(),
+            proxy_port: "1080".into(),
+            proxy_username: "user".into(),
+            proxy_password: "pass".into(),
+            ..crate::settings::Settings::default()
+        };
+        let proxy = settings.proxy_config().unwrap();
+        build_client(&proxy).unwrap();
+        build_blocking(&proxy, Duration::from_secs(1)).unwrap();
+    }
+
+    #[test]
+    fn web_api_client_goes_through_an_http_proxy() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let origin = TcpListener::bind("127.0.0.1:0").unwrap();
+        let origin_addr = origin.local_addr().unwrap();
+        let origin_thread = thread::spawn(move || {
+            let (mut stream, _) = origin.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]).into_owned();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\nproxied",
+                )
+                .unwrap();
+            request
+        });
+
+        let proxy = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let proxy_thread = thread::spawn(move || {
+            let (mut client, _) = proxy.accept().unwrap();
+            client
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut buf = [0u8; 8192];
+            let n = client.read(&mut buf).unwrap();
+            let head = String::from_utf8_lossy(&buf[..n]).into_owned();
+            let mut upstream = std::net::TcpStream::connect(origin_addr).unwrap();
+            upstream.write_all(&buf[..n]).unwrap();
+            let mut response = Vec::new();
+            upstream.read_to_end(&mut response).unwrap();
+            client.write_all(&response).unwrap();
+            head
+        });
+
+        let settings = crate::settings::Settings {
+            proxy_mode: crate::settings::ProxyMode::Http,
+            proxy_host: proxy_addr.ip().to_string(),
+            proxy_port: proxy_addr.port().to_string(),
+            ..crate::settings::Settings::default()
+        };
+        let proxy_config = settings.proxy_config().unwrap();
+        let client = build_blocking(&proxy_config, Duration::from_secs(3)).unwrap();
+        let body = client
+            .get(format!("http://{origin_addr}/catalogue"))
+            .send()
+            .unwrap()
+            .text()
+            .unwrap();
+        assert_eq!(body, "proxied");
+        let seen_by_proxy = proxy_thread.join().unwrap();
+        assert!(
+            seen_by_proxy.contains("catalogue"),
+            "proxy should see the Web API request, got {seen_by_proxy:?}"
+        );
+        let seen_by_origin = origin_thread.join().unwrap();
+        assert!(seen_by_origin.contains("GET"));
+    }
+
+    #[test]
+    fn proxy_authentication_preserves_opaque_credentials() {
+        use base64::Engine;
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let proxy = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let proxy_thread = thread::spawn(move || {
+            let (mut client, _) = proxy.accept().unwrap();
+            client
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut buf = [0u8; 8192];
+            let n = client.read(&mut buf).unwrap();
+            let head = String::from_utf8_lossy(&buf[..n]).into_owned();
+            client
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .unwrap();
+            head
+        });
+
+        let username = "alice/name";
+        let password = " secret/with spaces ";
+        let settings = crate::settings::Settings {
+            proxy_mode: crate::settings::ProxyMode::Http,
+            proxy_host: proxy_addr.ip().to_string(),
+            proxy_port: proxy_addr.port().to_string(),
+            proxy_username: username.into(),
+            proxy_password: password.into(),
+            ..crate::settings::Settings::default()
+        };
+        let proxy_config = settings.proxy_config().unwrap();
+        let client = build_blocking(&proxy_config, Duration::from_secs(3)).unwrap();
+        assert_eq!(
+            client
+                .get("http://example.invalid/catalogue")
+                .send()
+                .unwrap()
+                .text()
+                .unwrap(),
+            "ok"
+        );
+        let seen = proxy_thread.join().unwrap();
+        let expected =
+            base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
+        assert!(
+            seen.lines()
+                .any(|line| line
+                    .eq_ignore_ascii_case(&format!("Proxy-Authorization: Basic {expected}"))),
+            "proxy did not receive the exact configured credentials"
+        );
+    }
+
+    #[tokio::test]
+    async fn librespot_http_client_sends_connect_through_an_http_proxy() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let proxy = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let proxy_thread = thread::spawn(move || {
+            let (mut client, _) = proxy.accept().unwrap();
+            client
+                .set_read_timeout(Some(Duration::from_secs(3)))
+                .unwrap();
+            let mut buf = [0u8; 4096];
+            let n = client.read(&mut buf).unwrap_or(0);
+            let _ = client.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n");
+            String::from_utf8_lossy(&buf[..n]).into_owned()
+        });
+
+        let proxy_url = reqwest::Url::parse(&format!("http://{proxy_addr}")).unwrap();
+        let client = librespot_core::http_client::HttpClient::new(Some(&proxy_url));
+        let request = http::Request::builder()
+            .method("GET")
+            .uri("https://apresolve.spotify.com/")
+            .body(Default::default())
+            .unwrap();
+        let _ = client.request(request).await;
+        let seen = proxy_thread.join().unwrap();
+        assert!(
+            seen.to_ascii_uppercase().contains("CONNECT") && seen.contains("apresolve.spotify.com"),
+            "librespot should CONNECT through the proxy, got {seen:?}"
+        );
+    }
+}

--- a/src/images.rs
+++ b/src/images.rs
@@ -12,6 +12,8 @@ use std::time::Instant;
 use egui::load::{Bytes, BytesLoadResult, BytesLoader, BytesPoll, LoadError};
 use sha1::{Digest, Sha1};
 
+use crate::http::Http;
+
 /// Maximum artwork bytes held in memory.
 ///
 /// Time-based eviction does not work here: after creating a texture, egui no
@@ -33,7 +35,7 @@ enum Entry {
 
 struct Inner {
     entries: Mutex<HashMap<String, Entry>>,
-    http: reqwest::Client,
+    http: Http,
     runtime: tokio::runtime::Handle,
     cache_dir: PathBuf,
 }
@@ -44,12 +46,12 @@ pub struct ArtLoader {
 }
 
 impl ArtLoader {
-    pub fn new(http: reqwest::Client, runtime: tokio::runtime::Handle, cache_dir: PathBuf) -> Self {
+    pub fn new(http: impl Into<Http>, runtime: tokio::runtime::Handle, cache_dir: PathBuf) -> Self {
         let _ = std::fs::create_dir_all(&cache_dir);
         Self {
             inner: Arc::new(Inner {
                 entries: Mutex::new(HashMap::new()),
-                http,
+                http: http.into(),
                 runtime,
                 cache_dir,
             }),
@@ -171,6 +173,7 @@ impl Inner {
             _ => {
                 let response = self
                     .http
+                    .client()
                     .get(url)
                     .send()
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod bidi;
 pub mod demo;
 pub mod eq;
 pub mod history;
+pub mod http;
 pub mod images;
 pub mod limiter;
 pub mod link;

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,6 +321,7 @@ fn main() -> eframe::Result<()> {
     }
     log_panics(dirs.panic_log());
     let mut settings = settings::Settings::load(&dirs.settings_file());
+    settings.load_proxy_secret(&dirs.proxy_secret_file());
     if let Some(name) = cli.device_name {
         settings.device_name = name;
     }

--- a/src/milkdrop.rs
+++ b/src/milkdrop.rs
@@ -230,7 +230,13 @@ impl Presets {
     }
 
     /// Downloads one preset pack on a worker thread.
-    pub fn download(&mut self, pack: &'static Pack, folder: PathBuf, ctx: egui::Context) {
+    pub fn download(
+        &mut self,
+        pack: &'static Pack,
+        folder: PathBuf,
+        ctx: egui::Context,
+        proxy: crate::settings::ProxyConfig,
+    ) {
         if self.download.is_some() {
             return;
         }
@@ -238,7 +244,7 @@ impl Presets {
         let spawned = std::thread::Builder::new()
             .name("milkdrop-presets".into())
             .spawn(move || {
-                let _ = sender.send(fetch_pack(pack, &folder));
+                let _ = sender.send(fetch_pack(pack, &folder, &proxy));
                 ctx.request_repaint();
             });
         match spawned {
@@ -249,7 +255,12 @@ impl Presets {
 
     /// Fetches every pack in one go, for a first open with nothing
     /// there; failures after the first pack still land what arrived.
-    pub fn download_missing(&mut self, folder: PathBuf, ctx: egui::Context) {
+    pub fn download_missing(
+        &mut self,
+        folder: PathBuf,
+        ctx: egui::Context,
+        proxy: crate::settings::ProxyConfig,
+    ) {
         if self.download.is_some() {
             return;
         }
@@ -260,7 +271,7 @@ impl Presets {
                 let mut total = 0usize;
                 let mut failed = None;
                 for pack in &PACKS {
-                    match fetch_pack(pack, &folder) {
+                    match fetch_pack(pack, &folder, &proxy) {
                         Ok(count) => total += count,
                         Err(error) => {
                             failed = Some(error);
@@ -339,11 +350,12 @@ pub fn is_preset(path: &Path) -> bool {
 /// Downloads a pack and unpacks its presets into the folder, flat, since
 /// the packs keep theirs in folders by style and the names do not clash.
 /// Returns how many were written.
-pub fn fetch_pack(pack: &Pack, folder: &Path) -> Result<usize, String> {
-    let http = reqwest::blocking::Client::builder()
-        .user_agent(concat!("fastpotify/", env!("CARGO_PKG_VERSION")))
-        .timeout(Duration::from_secs(300))
-        .build()
+pub fn fetch_pack(
+    pack: &Pack,
+    folder: &Path,
+    proxy: &crate::settings::ProxyConfig,
+) -> Result<usize, String> {
+    let http = crate::http::build_blocking(proxy, Duration::from_secs(300))
         .map_err(|error| error.to_string())?;
     let bytes = http
         .get(pack.url)

--- a/src/model.rs
+++ b/src/model.rs
@@ -710,6 +710,9 @@ pub enum Action {
     ToggleDevicesPopup,
     SettingsChanged,
     RestartEngine,
+    /// Rebuild the HTTP client with the proxy in settings. Local playback
+    /// restarts only when its HTTP proxy changed.
+    ApplyProxy,
     EnablePlayback,
     ShowWindow,
     HideWindow,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -90,6 +90,11 @@ impl AppDirs {
         self.state.join("credentials")
     }
 
+    /// Optional proxy password, owner-only, never written to settings.json.
+    pub fn proxy_secret_file(&self) -> PathBuf {
+        self.state.join("proxy_password")
+    }
+
     pub fn volume_dir(&self) -> PathBuf {
         self.state.join("volume")
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -55,6 +55,8 @@ pub struct EngineConfig {
     pub tap: Arc<AudioTap>,
     /// The equalizer's settings, shared with the window that sets them.
     pub eq: crate::eq::SharedEq,
+    /// Proxy used by the Web API client. Librespot only uses the HTTP form.
+    pub proxy: crate::settings::ProxyConfig,
 }
 
 impl EngineConfig {
@@ -285,6 +287,7 @@ impl Engine {
         let session_config = SessionConfig {
             device_id: device_id.clone(),
             autoplay: Some(config.autoplay),
+            proxy: config.proxy.librespot_url(),
             ..SessionConfig::default()
         };
         let normalisation_factor = Arc::new(std::sync::atomic::AtomicU64::new(1.0f64.to_bits()));
@@ -1064,6 +1067,7 @@ mod tests {
             volume_dir: PathBuf::new(),
             audio_cache_dir: None,
             audio_cache_limit: None,
+            proxy: crate::settings::ProxyConfig::Off,
         };
         let id = config.device_id();
         assert_eq!(id.len(), 40);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -46,6 +46,42 @@ impl ThemeChoice {
     }
 }
 
+/// How outbound HTTP traffic reaches the network.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProxyMode {
+    /// No proxy, ignoring environment and OS proxy settings.
+    Off,
+    /// Environment variables and, on macOS and Windows, the OS proxy.
+    #[default]
+    System,
+    /// A configured HTTP proxy.
+    Http,
+    /// A configured SOCKS5 proxy.
+    Socks,
+}
+
+impl ProxyMode {
+    pub const ALL: [ProxyMode; 4] = [Self::Off, Self::System, Self::Http, Self::Socks];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Off => "Off",
+            Self::System => "System",
+            Self::Http => "HTTP",
+            Self::Socks => "SOCKS5",
+        }
+    }
+
+    pub fn is_manual(self) -> bool {
+        matches!(self, Self::Http | Self::Socks)
+    }
+}
+
+fn proxy_mode_is_system(mode: &ProxyMode) -> bool {
+    *mode == ProxyMode::System
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
@@ -149,6 +185,27 @@ pub struct Settings {
     pub milkdrop_fullscreen: bool,
     /// The MilkDrop window's size in logical points, when not full-screen.
     pub milkdrop_size: [f32; 2],
+    /// Which proxy to use. Older files without this field stay on `system`.
+    #[serde(default, skip_serializing_if = "proxy_mode_is_system")]
+    pub proxy_mode: ProxyMode,
+    /// Combined address from older settings files. Split into host and port
+    /// on load; not written again.
+    #[serde(default, skip_serializing)]
+    pub proxy: String,
+    /// Host of a manual HTTP or SOCKS5 proxy. Ignored when the mode is Off
+    /// or System.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub proxy_host: String,
+    /// Port of a manual HTTP or SOCKS5 proxy.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub proxy_port: String,
+    /// Optional proxy login for Web requests.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub proxy_username: String,
+    /// Optional proxy password. Kept in memory and in the owner-only state
+    /// file; older settings.json copies are still read, then forgotten.
+    #[serde(default, skip_serializing)]
+    pub proxy_password: String,
 }
 
 impl Default for Settings {
@@ -206,6 +263,12 @@ impl Default for Settings {
             milkdrop_scale: 1,
             milkdrop_fullscreen: false,
             milkdrop_size: crate::milkdrop::DEFAULT_SIZE,
+            proxy_mode: ProxyMode::System,
+            proxy: String::new(),
+            proxy_host: String::new(),
+            proxy_port: String::new(),
+            proxy_username: String::new(),
+            proxy_password: String::new(),
         }
     }
 }
@@ -217,10 +280,14 @@ fn default_buffer_ms() -> u32 {
 impl Settings {
     pub fn load(path: &Path) -> Self {
         match std::fs::read_to_string(path) {
-            Ok(text) => serde_json::from_str(&text).unwrap_or_else(|error| {
-                log::warn!("settings at {} are unreadable: {error}", path.display());
-                Self::default()
-            }),
+            Ok(text) => {
+                let mut settings = serde_json::from_str(&text).unwrap_or_else(|error| {
+                    log::warn!("settings at {} are unreadable: {error}", path.display());
+                    Self::default()
+                });
+                settings.migrate_proxy(&text);
+                settings
+            }
             Err(_) => Self::default(),
         }
     }
@@ -237,10 +304,41 @@ impl Settings {
             }
         };
         let temporary = path.with_extension("json.tmp");
-        let written =
-            std::fs::write(&temporary, text).and_then(|()| std::fs::rename(&temporary, path));
+        let written = std::fs::write(&temporary, text)
+            .and_then(|()| crate::auth::replace_file(&temporary, path));
         if let Err(error) = written {
             log::warn!("unable to save settings to {}: {error}", path.display());
+        }
+    }
+
+    /// Overlay the owner-only proxy password. A leftover `proxy_password` in
+    /// settings.json stays in memory until the next save, which writes this
+    /// file and omits the field from settings.
+    pub fn load_proxy_secret(&mut self, path: &Path) {
+        match std::fs::read_to_string(path) {
+            Ok(text) => {
+                self.proxy_password = text.trim_end_matches(['\r', '\n']).to_string();
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                log::warn!("unable to read the proxy password: {error}");
+            }
+        }
+    }
+
+    pub fn save_proxy_secret(&self, path: &Path) {
+        if self.proxy_password.is_empty() {
+            let _ = std::fs::remove_file(path);
+            return;
+        }
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let temporary = path.with_extension("tmp");
+        let written = crate::auth::write_private(&temporary, self.proxy_password.as_bytes())
+            .and_then(|()| crate::auth::replace_file(&temporary, path));
+        if let Err(error) = written {
+            log::warn!("unable to save the proxy password: {error}");
         }
     }
 
@@ -262,6 +360,247 @@ impl Settings {
         self.search_history.retain(|entry| entry != query);
         self.search_history.insert(0, query.to_string());
         self.search_history.truncate(12);
+    }
+
+    fn migrate_proxy(&mut self, text: &str) {
+        if !text.contains("\"proxy_mode\"") {
+            self.proxy_mode = infer_legacy_proxy_mode(&self.proxy);
+        }
+        if self.proxy_host.is_empty() && !self.proxy.trim().is_empty() {
+            let (host, port) = split_legacy_address(&self.proxy);
+            self.proxy_host = host;
+            if self.proxy_port.is_empty() {
+                self.proxy_port = port;
+            }
+        }
+    }
+
+    /// The proxy the HTTP client should use. Off and System always succeed.
+    /// HTTP and SOCKS5 need a host and port.
+    pub fn proxy_config(&self) -> Result<ProxyConfig, String> {
+        match self.proxy_mode {
+            ProxyMode::Off => Ok(ProxyConfig::Off),
+            ProxyMode::System => Ok(ProxyConfig::System),
+            ProxyMode::Http => Ok(ProxyConfig::Http(ManualProxy::parse(
+                ManualKind::Http,
+                &self.proxy_host,
+                &self.proxy_port,
+                &self.proxy_username,
+                &self.proxy_password,
+            )?)),
+            ProxyMode::Socks => Ok(ProxyConfig::Socks(ManualProxy::parse(
+                ManualKind::Socks,
+                &self.proxy_host,
+                &self.proxy_port,
+                &self.proxy_username,
+                &self.proxy_password,
+            )?)),
+        }
+    }
+}
+
+fn infer_legacy_proxy_mode(proxy: &str) -> ProxyMode {
+    let raw = proxy.trim();
+    if raw.is_empty() {
+        return ProxyMode::System;
+    }
+    let scheme = raw.split("://").next().unwrap_or("").to_ascii_lowercase();
+    match scheme.as_str() {
+        "socks" | "socks5" | "socks5h" => ProxyMode::Socks,
+        _ => ProxyMode::Http,
+    }
+}
+
+fn validate_host(host: &str) -> Result<String, String> {
+    let host = host.trim();
+    if host.is_empty() {
+        return Err("enter a host".into());
+    }
+    let host = host
+        .split_once("://")
+        .map_or(host, |(_, rest)| rest)
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    if host.is_empty() {
+        return Err("enter a host".into());
+    }
+    if host.parse::<std::net::IpAddr>().is_ok() {
+        return Ok(host.to_string());
+    }
+    if is_hostname(host) {
+        return Ok(host.to_string());
+    }
+    Err("the host must be a hostname or IP address".into())
+}
+
+fn is_hostname(host: &str) -> bool {
+    if host.len() > 253 || host.starts_with('.') || host.ends_with('.') {
+        return false;
+    }
+    host.split('.').all(|label| {
+        (1..=63).contains(&label.len())
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    })
+}
+
+fn validate_port(port: &str) -> Result<u16, String> {
+    let port = port.trim();
+    if port.is_empty() {
+        return Err("enter a port".into());
+    }
+    if !port.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("the port must be a number between 1 and 65535".into());
+    }
+    match port.parse::<u16>() {
+        Ok(port) if port > 0 => Ok(port),
+        _ => Err("the port must be a number between 1 and 65535".into()),
+    }
+}
+
+fn split_legacy_address(raw: &str) -> (String, String) {
+    let raw = raw.trim();
+    let rest = raw.split_once("://").map_or(raw, |(_, rest)| rest);
+    let rest = rest.rsplit_once('@').map_or(rest, |(_, rest)| rest);
+    if let Some(inner) = rest.strip_prefix('[')
+        && let Some((host, port)) = inner.split_once("]:")
+    {
+        return (host.to_string(), port.trim().to_string());
+    }
+    if let Some((host, port)) = rest.rsplit_once(':')
+        && !host.contains(':')
+    {
+        return (host.to_string(), port.trim().to_string());
+    }
+    (rest.to_string(), String::new())
+}
+
+/// The resolved proxy policy used by the HTTP client and local playback.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum ProxyConfig {
+    Off,
+    #[default]
+    System,
+    Http(ManualProxy),
+    Socks(ManualProxy),
+}
+
+impl ProxyConfig {
+    /// Librespot's CONNECT client only understands unauthenticated,
+    /// plaintext HTTP proxies. Never give it a credential-bearing URL: the
+    /// upstream client logs that URL at info level and does not send proxy
+    /// authentication in either of its HTTP paths.
+    pub fn librespot_url(&self) -> Option<reqwest::Url> {
+        match self {
+            Self::Http(manual) => manual.librespot_url(),
+            Self::System => system_http_proxy(),
+            Self::Off | Self::Socks(_) => None,
+        }
+    }
+
+    /// Local playback reconnects only when its HTTP proxy actually changes.
+    pub fn restarts_local_playback(&self, other: &Self) -> bool {
+        self.librespot_url() != other.librespot_url()
+    }
+}
+
+/// The HTTP proxy System mode would hand librespot, if it can resolve one.
+/// SOCKS system proxies are ignored: the engine cannot use them.
+fn system_http_proxy() -> Option<reqwest::Url> {
+    let matcher = hyper_util::client::proxy::matcher::Matcher::from_system();
+    let dest = http::Uri::from_static("https://apresolve.spotify.com");
+    let intercept = matcher.intercept(&dest)?;
+    librespot_system_proxy(&intercept)
+}
+
+fn librespot_system_proxy(
+    intercept: &hyper_util::client::proxy::matcher::Intercept,
+) -> Option<reqwest::Url> {
+    if intercept.basic_auth().is_some() || intercept.raw_auth().is_some() {
+        return None;
+    }
+    http_proxy_from_uri(intercept.uri())
+}
+
+fn http_proxy_from_uri(uri: &http::Uri) -> Option<reqwest::Url> {
+    match uri.scheme_str() {
+        Some("http") => reqwest::Url::parse(&uri.to_string()).ok(),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ManualKind {
+    Http,
+    Socks,
+}
+
+/// A configured HTTP or SOCKS5 endpoint.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ManualProxy {
+    endpoint: reqwest::Url,
+    username: String,
+    password: String,
+}
+
+impl std::fmt::Debug for ManualProxy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ManualProxy")
+            .field("url", &self.redacted())
+            .finish()
+    }
+}
+
+impl ManualProxy {
+    fn parse(
+        kind: ManualKind,
+        host: &str,
+        port: &str,
+        username: &str,
+        password: &str,
+    ) -> Result<Self, String> {
+        let host = validate_host(host)?;
+        let port = validate_port(port)?;
+        let host = if host.contains(':') {
+            format!("[{host}]")
+        } else {
+            host
+        };
+        let scheme = match kind {
+            ManualKind::Http => "http",
+            // Resolve Spotify hostnames at the proxy, so SOCKS mode does not
+            // leak DNS queries or fail behind a proxy-only network.
+            ManualKind::Socks => "socks5h",
+        };
+        let endpoint = reqwest::Url::parse(&format!("{scheme}://{host}:{port}"))
+            .map_err(|error| format!("not a proxy address: {error}"))?;
+        Ok(Self {
+            endpoint,
+            username: username.to_string(),
+            password: password.to_string(),
+        })
+    }
+
+    /// A reqwest proxy with credentials applied separately so build errors
+    /// cannot echo a password.
+    pub fn reqwest_proxy(&self) -> Result<reqwest::Proxy, reqwest::Error> {
+        let mut proxy = reqwest::Proxy::all(self.endpoint.clone())?;
+        if !self.username.is_empty() || !self.password.is_empty() {
+            proxy = proxy.basic_auth(&self.username, &self.password);
+        }
+        Ok(proxy)
+    }
+
+    fn librespot_url(&self) -> Option<reqwest::Url> {
+        (self.username.is_empty() && self.password.is_empty()).then(|| self.endpoint.clone())
+    }
+
+    /// The credential-free endpoint, for logs and the debugger.
+    pub fn redacted(&self) -> reqwest::Url {
+        self.endpoint.clone()
     }
 }
 
@@ -360,6 +699,269 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
         assert!(restored.tracklist_compact);
+    }
+
+    #[test]
+    fn older_settings_use_the_system_proxy() {
+        let settings: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(settings.proxy_mode, super::ProxyMode::System);
+        assert!(settings.proxy_host.is_empty());
+        assert!(settings.proxy_port.is_empty());
+        assert!(settings.proxy_username.is_empty());
+        assert!(settings.proxy_password.is_empty());
+        assert_eq!(settings.proxy_config().unwrap(), super::ProxyConfig::System);
+    }
+
+    #[test]
+    fn a_proxy_round_trips_through_settings() {
+        let settings = Settings {
+            proxy_mode: super::ProxyMode::Socks,
+            proxy_host: "127.0.0.1".into(),
+            proxy_port: "1080".into(),
+            proxy_username: "alice".into(),
+            proxy_password: "secret".into(),
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.proxy_mode, settings.proxy_mode);
+        assert_eq!(restored.proxy_host, settings.proxy_host);
+        assert_eq!(restored.proxy_port, settings.proxy_port);
+        assert_eq!(restored.proxy_username, settings.proxy_username);
+        assert!(restored.proxy_password.is_empty());
+        assert!(json.contains("socks"));
+        assert!(json.contains("127.0.0.1"));
+        assert!(json.contains("1080"));
+        assert!(json.contains("alice"));
+        assert!(!json.contains("secret"));
+        assert!(!json.contains("proxy_password"));
+        assert!(!json.contains("\"proxy\":"));
+    }
+
+    #[test]
+    fn the_proxy_password_lives_in_an_owner_only_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-proxy-secret-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let settings_path = dir.join("settings.json");
+        let secret_path = dir.join("proxy_password");
+        std::fs::write(
+            &settings_path,
+            r#"{"proxy_mode":"http","proxy_host":"127.0.0.1","proxy_port":"8080","proxy_password":"from-json"}"#,
+        )
+        .unwrap();
+        let mut settings = Settings::load(&settings_path);
+        assert_eq!(settings.proxy_password, "from-json");
+        settings.load_proxy_secret(&secret_path);
+        assert_eq!(settings.proxy_password, "from-json");
+        settings.save(&settings_path);
+        settings.save_proxy_secret(&secret_path);
+        let written = std::fs::read_to_string(&settings_path).unwrap();
+        assert!(!written.contains("from-json"));
+        assert!(!written.contains("proxy_password"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&secret_path)
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+        let mut restored = Settings::load(&settings_path);
+        assert!(restored.proxy_password.is_empty());
+        restored.load_proxy_secret(&secret_path);
+        assert_eq!(restored.proxy_password, "from-json");
+        restored.proxy_password = "replacement".into();
+        restored.save_proxy_secret(&secret_path);
+        assert_eq!(
+            std::fs::read_to_string(&secret_path).unwrap(),
+            "replacement"
+        );
+        restored.proxy_password.clear();
+        restored.save_proxy_secret(&secret_path);
+        assert!(!secret_path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn an_empty_proxy_is_omitted_from_the_file() {
+        let json = serde_json::to_string(&Settings::default()).unwrap();
+        assert!(!json.contains("proxy"));
+    }
+
+    #[test]
+    fn off_is_written_and_round_trips() {
+        let settings = Settings {
+            proxy_mode: super::ProxyMode::Off,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("\"off\""));
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.proxy_mode, super::ProxyMode::Off);
+        assert_eq!(restored.proxy_config().unwrap(), super::ProxyConfig::Off);
+    }
+
+    #[test]
+    fn a_legacy_socks_url_becomes_socks_mode() {
+        let dir = std::env::temp_dir().join(format!("fastpotify-proxy-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"proxy":"socks5://127.0.0.1:1080","proxy_username":"alice"}"#,
+        )
+        .unwrap();
+        let settings = Settings::load(&path);
+        assert_eq!(settings.proxy_mode, super::ProxyMode::Socks);
+        assert_eq!(settings.proxy_host, "127.0.0.1");
+        assert_eq!(settings.proxy_port, "1080");
+        let super::ProxyConfig::Socks(manual) = settings.proxy_config().unwrap() else {
+            panic!("expected a SOCKS proxy");
+        };
+        assert_eq!(manual.redacted().scheme(), "socks5h");
+        assert_eq!(manual.redacted().host_str(), Some("127.0.0.1"));
+        assert_eq!(manual.redacted().port(), Some(1080));
+        assert!(manual.redacted().username().is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn http_and_socks_parse_a_host_and_port() {
+        let http = super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "7890", "", "")
+            .unwrap();
+        assert_eq!(http.redacted().as_str(), "http://127.0.0.1:7890/");
+        assert!(
+            super::ProxyConfig::Http(http.clone())
+                .librespot_url()
+                .is_some()
+        );
+
+        let socks =
+            super::ManualProxy::parse(super::ManualKind::Socks, "127.0.0.1", "1080", "", "")
+                .unwrap();
+        assert_eq!(socks.redacted().scheme(), "socks5h");
+        assert_eq!(socks.redacted().port(), Some(1080));
+        assert_eq!(super::ProxyConfig::Socks(socks).librespot_url(), None);
+    }
+
+    #[test]
+    fn off_system_and_socks_do_not_restart_local_playback() {
+        let off = super::ProxyConfig::Off;
+        let system = super::ProxyConfig::System;
+        let http = super::ProxyConfig::Http(
+            super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "7890", "", "")
+                .unwrap(),
+        );
+        let http_other = super::ProxyConfig::Http(
+            super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "7891", "", "")
+                .unwrap(),
+        );
+        let socks = super::ProxyConfig::Socks(
+            super::ManualProxy::parse(super::ManualKind::Socks, "127.0.0.1", "1080", "", "")
+                .unwrap(),
+        );
+        assert_eq!(off.librespot_url(), None);
+        assert_eq!(socks.librespot_url(), None);
+        assert!(!off.restarts_local_playback(&socks));
+        assert!(off.restarts_local_playback(&http));
+        assert!(http.restarts_local_playback(&socks));
+        assert!(http.restarts_local_playback(&http_other));
+        assert!(!http.restarts_local_playback(&http));
+        assert_eq!(
+            off.restarts_local_playback(&system),
+            system.librespot_url().is_some(),
+            "System restarts local playback only when an HTTP proxy is resolved"
+        );
+        let http_uri: http::Uri = "http://127.0.0.1:8080".parse().unwrap();
+        let https_uri: http::Uri = "https://127.0.0.1:8080".parse().unwrap();
+        let socks_uri: http::Uri = "socks5://127.0.0.1:1080".parse().unwrap();
+        assert!(super::http_proxy_from_uri(&http_uri).is_some());
+        assert!(super::http_proxy_from_uri(&https_uri).is_none());
+        assert!(super::http_proxy_from_uri(&socks_uri).is_none());
+    }
+
+    #[test]
+    fn proxy_credentials_stay_opaque_and_out_of_urls() {
+        let proxy = super::ManualProxy::parse(
+            super::ManualKind::Http,
+            "127.0.0.1",
+            "7890",
+            "alice/name",
+            " secret/with spaces ",
+        )
+        .unwrap();
+        let redacted = proxy.redacted();
+        assert!(redacted.username().is_empty());
+        assert_eq!(redacted.password(), None);
+        assert_eq!(proxy.username, "alice/name");
+        assert_eq!(proxy.password, " secret/with spaces ");
+        assert_eq!(
+            super::ProxyConfig::Http(proxy.clone()).librespot_url(),
+            None
+        );
+        let debug = format!("{proxy:?}");
+        assert!(!debug.contains("alice"));
+        assert!(!debug.contains("secret"));
+    }
+
+    #[test]
+    fn system_proxy_authentication_and_tls_endpoints_stay_out_of_librespot() {
+        let authenticated = hyper_util::client::proxy::matcher::Matcher::builder()
+            .all("http://alice:secret@127.0.0.1:8080")
+            .build();
+        let destination = http::Uri::from_static("https://apresolve.spotify.com");
+        let intercept = authenticated.intercept(&destination).unwrap();
+        assert!(super::librespot_system_proxy(&intercept).is_none());
+
+        let tls = hyper_util::client::proxy::matcher::Matcher::builder()
+            .all("https://127.0.0.1:8080")
+            .build();
+        let intercept = tls.intercept(&destination).unwrap();
+        assert!(super::librespot_system_proxy(&intercept).is_none());
+    }
+
+    #[test]
+    fn proxy_parse_rejects_a_missing_host_or_port() {
+        assert!(
+            super::ManualProxy::parse(super::ManualKind::Http, "", "8080", "", "")
+                .unwrap_err()
+                .contains("host")
+        );
+        assert!(
+            super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "", "", "")
+                .unwrap_err()
+                .contains("port")
+        );
+        assert!(
+            super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "abc", "", "")
+                .unwrap_err()
+                .contains("number")
+        );
+        assert!(
+            super::ManualProxy::parse(super::ManualKind::Http, "not a host", "1080", "", "")
+                .unwrap_err()
+                .contains("hostname")
+        );
+        assert!(
+            super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "0", "", "")
+                .unwrap_err()
+                .contains("65535")
+        );
+        assert!(
+            super::ManualProxy::parse(super::ManualKind::Http, "127.0.0.1", "65536", "", "")
+                .unwrap_err()
+                .contains("65535")
+        );
+        super::ManualProxy::parse(super::ManualKind::Http, "localhost", "8080", "", "").unwrap();
+        super::ManualProxy::parse(super::ManualKind::Http, "::1", "8080", "", "").unwrap();
     }
 }
 

--- a/src/ui/login.rs
+++ b/src/ui/login.rs
@@ -1,10 +1,11 @@
 //! The sign-in screen.
 
-use egui::{Align, CornerRadius, Frame, Layout, Margin, Stroke, Vec2};
+use egui::{Align, CornerRadius, Frame, Layout, Margin, Rect, Stroke, Vec2, pos2};
 
 use crate::app::App;
 use crate::backend::AuthStatus;
 use crate::model::Action;
+use crate::settings::ProxyMode;
 use crate::theme;
 
 pub fn show(app: &mut App, ui: &mut egui::Ui, connecting: bool) {
@@ -18,8 +19,22 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, connecting: bool) {
             let top = super::blend(palette.window, palette.accent, 0.10);
             super::widgets::paint_vertical_gradient(ui, rect, top, palette.window);
             let card_width = 440.0;
-            let card_height = 380.0;
-            let card = egui::Rect::from_center_size(rect.center() - Vec2::new(0.0, 20.0), Vec2::new(card_width, card_height));
+            let proxy_id = egui::Id::new("login-proxy-open");
+            let proxy_open = ui
+                .ctx()
+                .data(|data| data.get_temp::<bool>(proxy_id))
+                .unwrap_or(false);
+            let card_height = if !proxy_open {
+                400.0
+            } else if app.settings.proxy_mode.is_manual() {
+                680.0
+            } else {
+                500.0
+            };
+            let card = Rect::from_center_size(
+                rect.center() - Vec2::new(0.0, 20.0),
+                Vec2::new(card_width, card_height),
+            );
             let mut card_ui = ui.new_child(egui::UiBuilder::new().max_rect(card).layout(Layout::top_down(Align::Center)));
             Frame::new()
                 .fill(palette.panel)
@@ -126,15 +141,101 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, connecting: bool) {
                             }
                         }
                     }
+                    let mut proxy_open = ui.data(|data| data.get_temp::<bool>(proxy_id)).unwrap_or(false);
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            if theme::link(
+                                ui,
+                                "Proxy Settings",
+                                theme::regular(13.0),
+                                palette.secondary,
+                            )
+                            .clicked()
+                            {
+                                proxy_open = !proxy_open;
+                            }
+                        });
+                    });
+                    ui.add_space(4.0);
+                    if proxy_open {
+                        proxy_fields(ui, app);
+                    }
+                    ui.data_mut(|data| data.insert_temp(proxy_id, proxy_open));
                 });
             ui.painter().text(
-                egui::pos2(rect.center().x, rect.bottom() - 24.0),
+                pos2(rect.center().x, rect.bottom() - 24.0),
                 egui::Align2::CENTER_BOTTOM,
                 format!("Fastpotify {} • not affiliated with Spotify", env!("CARGO_PKG_VERSION")),
                 theme::regular(11.5),
                 palette.dim,
             );
         });
+}
+
+fn proxy_fields(ui: &mut egui::Ui, app: &mut App) {
+    let palette = app.palette;
+    let mut changed = false;
+    let mut apply = false;
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
+        let row_width: f32 = ProxyMode::ALL
+            .iter()
+            .map(|choice| {
+                let galley = ui.painter().layout_no_wrap(
+                    choice.label().to_string(),
+                    theme::medium(13.0),
+                    palette.text,
+                );
+                galley.size().x + 24.0
+            })
+            .sum::<f32>()
+            + 6.0 * (ProxyMode::ALL.len() - 1) as f32;
+        ui.add_space((ui.available_width() - row_width).max(0.0) / 2.0);
+        for choice in ProxyMode::ALL {
+            if theme::soft_button(
+                ui,
+                &palette,
+                None,
+                choice.label(),
+                app.settings.proxy_mode == choice,
+            )
+            .clicked()
+                && app.settings.proxy_mode != choice
+            {
+                app.settings.proxy_mode = choice;
+                changed = true;
+                apply = !choice.is_manual();
+            }
+        }
+    });
+    if app.settings.proxy_mode.is_manual() {
+        ui.add_space(10.0);
+        if super::widgets::proxy_manual_form(
+            ui,
+            &palette,
+            &mut app.settings.proxy_host,
+            &mut app.settings.proxy_port,
+            &mut app.settings.proxy_username,
+            &mut app.settings.proxy_password,
+        ) {
+            changed = true;
+        }
+        ui.add_space(6.0);
+        super::widgets::proxy_scope_note(ui, &palette, app.settings.proxy_mode);
+        ui.add_space(8.0);
+        ui.horizontal(|ui| {
+            if theme::pill_button(ui, &palette, "Apply settings", true).clicked() {
+                apply = true;
+            }
+        });
+    }
+    if changed {
+        app.mark_settings_dirty();
+    }
+    if apply {
+        app.actions.push(Action::ApplyProxy);
+    }
 }
 
 fn big_button(ui: &mut egui::Ui, app: &App, label: &str) -> bool {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -5,12 +5,13 @@ use egui::{Align, CornerRadius, Frame, Layout, Margin, Stroke, Vec2};
 use crate::api::models::pick_image;
 use crate::app::App;
 use crate::model::{Action, Dialog};
-use crate::settings::ThemeChoice;
+use crate::settings::{ProxyMode, ThemeChoice};
 use crate::theme::{self, Icon, Palette};
 
 use super::widgets;
 
 const PLAYBACK_DIRTY_ID: &str = "playback-settings-dirty";
+const PROXY_DIRTY_ID: &str = "proxy-settings-dirty";
 
 fn section(
     ui: &mut egui::Ui,
@@ -45,6 +46,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     let dirty_id = egui::Id::new(PLAYBACK_DIRTY_ID);
     let mut playback_dirty = ui
         .data(|data| data.get_temp::<bool>(dirty_id))
+        .unwrap_or(false);
+    let proxy_dirty_id = egui::Id::new(PROXY_DIRTY_ID);
+    let mut proxy_dirty = ui
+        .data(|data| data.get_temp::<bool>(proxy_dirty_id))
         .unwrap_or(false);
     let mut changed = false;
 
@@ -534,6 +539,79 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         );
     });
 
+    section(ui, &palette, "Proxy", |ui| {
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Mode",
+            "Off ignores environment variables. System uses them, and the OS proxy on macOS and Windows.",
+            |_| {},
+        );
+        // The row's control slot is right-to-left and too narrow for four
+        // choices; they sit on this line so they read Off, System, HTTP, SOCKS5.
+        ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = 6.0;
+            for choice in ProxyMode::ALL {
+                if theme::soft_button(
+                    ui,
+                    &palette,
+                    None,
+                    choice.label(),
+                    app.settings.proxy_mode == choice,
+                )
+                .clicked()
+                    && app.settings.proxy_mode != choice
+                {
+                    app.settings.proxy_mode = choice;
+                    changed = true;
+                    if choice.is_manual() {
+                        proxy_dirty = true;
+                    } else {
+                        proxy_dirty = false;
+                        app.actions.push(Action::ApplyProxy);
+                    }
+                }
+            }
+        });
+        ui.add_space(10.0);
+        if app.settings.proxy_mode.is_manual() {
+            if widgets::proxy_manual_form(
+                ui,
+                &palette,
+                &mut app.settings.proxy_host,
+                &mut app.settings.proxy_port,
+                &mut app.settings.proxy_username,
+                &mut app.settings.proxy_password,
+            ) {
+                changed = true;
+                proxy_dirty = true;
+            }
+            ui.add_space(6.0);
+            widgets::proxy_scope_note(ui, &palette, app.settings.proxy_mode);
+            ui.add_space(10.0);
+        }
+        if app.settings.proxy_mode.is_manual() {
+            ui.horizontal(|ui| {
+                if theme::pill_button(ui, &palette, "Apply settings", true).clicked() {
+                    app.actions.push(Action::ApplyProxy);
+                    if app.settings.proxy_config().is_ok() {
+                        proxy_dirty = false;
+                    }
+                }
+            });
+        } else {
+            theme::subtle(
+                ui,
+                &palette,
+                match app.settings.proxy_mode {
+                    ProxyMode::Off => "Not using a proxy.",
+                    ProxyMode::System => "Using the system proxy.",
+                    ProxyMode::Http | ProxyMode::Socks => "",
+                },
+            );
+        }
+    });
+
     section(ui, &palette, "Winamp skins", |ui| {
         widgets::setting_row(
             ui,
@@ -928,6 +1006,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     });
 
     ui.data_mut(|data| data.insert_temp(dirty_id, playback_dirty));
+    ui.data_mut(|data| data.insert_temp(proxy_dirty_id, proxy_dirty));
     if changed {
         app.actions.push(Action::SettingsChanged);
     }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,7 +1,8 @@
 //! Widgets shared by every view: covers, cards, track rows, menus, sliders.
 
 use egui::{
-    Align, Color32, CornerRadius, Layout, Rect, Sense, Stroke, Ui, UiBuilder, Vec2, pos2, vec2,
+    Align, Color32, CornerRadius, Frame, Layout, Margin, Rect, Sense, Stroke, Ui, UiBuilder, Vec2,
+    pos2, vec2,
 };
 
 use crate::api::models::*;
@@ -1910,4 +1911,94 @@ pub fn setting_row(
         ui.with_layout(Layout::right_to_left(Align::Center), control);
     });
     ui.add_space(10.0);
+}
+
+/// A labelled text field: the caption sits above the box.
+pub fn labeled_field(
+    ui: &mut Ui,
+    palette: &Palette,
+    label: &str,
+    value: &mut String,
+    hint: &str,
+    password: bool,
+) -> egui::Response {
+    ui.vertical(|ui| {
+        theme::text(ui, label, theme::medium(13.0), palette.text);
+        ui.add_space(6.0);
+        Frame::new()
+            .fill(palette.surface)
+            .corner_radius(CornerRadius::same(8))
+            .inner_margin(Margin::symmetric(12, 10))
+            .show(ui, |ui| {
+                ui.add(
+                    egui::TextEdit::singleline(value)
+                        .hint_text(egui::RichText::new(hint).color(palette.dim))
+                        .font(theme::regular(14.0))
+                        .password(password)
+                        .frame(egui::Frame::NONE)
+                        .desired_width(ui.available_width()),
+                )
+            })
+            .inner
+    })
+    .inner
+}
+
+/// Host, port, username, and password in two columns.
+pub fn proxy_manual_form(
+    ui: &mut Ui,
+    palette: &Palette,
+    host: &mut String,
+    port: &mut String,
+    username: &mut String,
+    password: &mut String,
+) -> bool {
+    let mut changed = false;
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 12.0;
+        let half = ((ui.available_width() - 12.0) / 2.0).max(80.0);
+        ui.vertical(|ui| {
+            ui.set_width(half);
+            if labeled_field(ui, palette, "Host", host, "127.0.0.1", false).changed() {
+                changed = true;
+            }
+        });
+        ui.vertical(|ui| {
+            ui.set_width(half);
+            if labeled_field(ui, palette, "Port", port, "1080", false).changed() {
+                changed = true;
+            }
+        });
+    });
+    ui.add_space(10.0);
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 12.0;
+        let half = ((ui.available_width() - 12.0) / 2.0).max(80.0);
+        ui.vertical(|ui| {
+            ui.set_width(half);
+            if labeled_field(ui, palette, "Username", username, "Username", false).changed() {
+                changed = true;
+            }
+        });
+        ui.vertical(|ui| {
+            ui.set_width(half);
+            if labeled_field(ui, palette, "Password", password, "Password", true).changed() {
+                changed = true;
+            }
+        });
+    });
+    changed
+}
+
+pub fn proxy_scope_note(ui: &mut Ui, palette: &Palette, mode: crate::settings::ProxyMode) {
+    let note = match mode {
+        crate::settings::ProxyMode::Http => {
+            "Proxy login applies to Web requests. Local playback uses this proxy only without a login."
+        }
+        crate::settings::ProxyMode::Socks => {
+            "Spotify hostnames are resolved by the proxy. Local playback connects directly."
+        }
+        crate::settings::ProxyMode::Off | crate::settings::ProxyMode::System => return,
+    };
+    theme::subtle(ui, palette, note);
 }

--- a/vendor/hyper-proxy2/Cargo.toml
+++ b/vendor/hyper-proxy2/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "hyper-proxy2"
+version = "0.1.0"
+authors = ["Natsuki Ikeguchi <me@s6n.jp>"]
+description = "A proxy connector for Hyper-based applications"
+documentation = "https://docs.rs/hyper-proxy2"
+repository = "https://github.com/siketyan/hyper-proxy2"
+readme = "README.md"
+keywords = ["hyper", "proxy", "tokio", "ssl"]
+categories = ["web-programming::http-client", "asynchronous", "authentication"]
+license = "MIT"
+edition = "2021"
+rust-version = "1.70.0"
+
+[dependencies]
+tokio = { version = "1.35", features = ["io-std", "io-util"] }
+hyper = { version = "1.0", features = ["client"] }
+hyper-util = { version = "0.1.2", features = ["client", "client-legacy", "tokio"] }
+
+tower-service = "0.3.2"
+http = "1.0"
+futures-util = { version = "0.3.30", default-features = false }
+bytes = "1.5"
+pin-project-lite = "0.2.13"
+hyper-tls = { version = "0.6.0", optional = true }
+tokio-native-tls = { version = "0.3.1", optional = true }
+native-tls = { version = "0.2.11", optional = true }
+openssl = { version = "0.10.62", optional = true }
+tokio-openssl = { version = "0.6.4", optional = true }
+# rustls 0.23 / hyper-rustls 0.27: the crates.io 0.1.0 release pins rustls 0.22
+# and rustls-webpki 0.102, which carry RUSTSEC-2026-0049/0098/0099/0104.
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"], optional = true }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "ring"], optional = true }
+
+headers = "0.4"
+
+[dev-dependencies]
+tokio = { version = "1.35", features = ["full"] }
+hyper = { version = "1.0", features = ["client", "http1"] }
+hyper-util = { version = "0.1.2", features = ["client", "client-legacy", "http1", "tokio"] }
+http-body-util = "0.1.0"
+futures = "0.3.30"
+
+[features]
+openssl-tls = ["openssl", "tokio-openssl"]
+tls = ["tokio-native-tls", "hyper-tls", "native-tls"]
+rustls-base = ["tokio-rustls", "hyper-rustls"]
+rustls = ["rustls-base", "hyper-rustls/native-tokio"]
+rustls-webpki = ["rustls-base", "hyper-rustls/webpki-tokio"]
+default = ["tls"]

--- a/vendor/hyper-proxy2/LICENSE-MIT.md
+++ b/vendor/hyper-proxy2/LICENSE-MIT.md
@@ -1,0 +1,24 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Johann Tuffe
+Copyright (c) 2024 Natsuki Ikeguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/hyper-proxy2/README.md
+++ b/vendor/hyper-proxy2/README.md
@@ -1,0 +1,8 @@
+# hyper-proxy2 (patched)
+
+Vendored from [hyper-proxy2 0.1.0](https://github.com/siketyan/hyper-proxy2)
+with TLS dependencies moved to rustls 0.23 / hyper-rustls 0.27 so the
+CONNECT-then-TLS path does not use rustls-webpki 0.102.
+
+Drop this directory when a hyper-proxy2 release, or a librespot that no
+longer depends on it, uses rustls 0.23.

--- a/vendor/hyper-proxy2/src/lib.rs
+++ b/vendor/hyper-proxy2/src/lib.rs
@@ -1,0 +1,563 @@
+//! A Proxy Connector crate for Hyper based applications
+//!
+//! # Example
+//! ```rust,no_run
+//! use hyper::{Request, Uri, body::Body};
+//! use hyper_util::client::legacy::Client;
+//! use hyper_util::client::legacy::connect::HttpConnector;
+//! use hyper_util::rt::TokioExecutor;
+//! use bytes::Bytes;
+//! use futures_util::{TryFutureExt, TryStreamExt};
+//! use http_body_util::{BodyExt, Empty};
+//! use hyper_proxy2::{Proxy, ProxyConnector, Intercept};
+//! use headers::Authorization;
+//! use std::error::Error;
+//! use tokio::io::{stdout, AsyncWriteExt as _};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn Error>> {
+//! let proxy = {
+//!         let proxy_uri = "http://my-proxy:8080".parse().unwrap();
+//!         let mut proxy = Proxy::new(Intercept::All, proxy_uri);
+//!         proxy.set_authorization(Authorization::basic("John Doe", "Agent1234"));
+//!         let connector = HttpConnector::new();
+//!         # #[cfg(not(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls")))]
+//!         # let proxy_connector = ProxyConnector::from_proxy_unsecured(connector, proxy);
+//!         # #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl"))]
+//!         let proxy_connector = ProxyConnector::from_proxy(connector, proxy).unwrap();
+//!         proxy_connector
+//!     };
+//!
+//!     // Connecting to http will trigger regular GETs and POSTs.
+//!     // We need to manually append the relevant headers to the request
+//!     let uri: Uri = "http://my-remote-website.com".parse().unwrap();
+//!     let mut req = Request::get(uri.clone()).body(Empty::<Bytes>::new()).unwrap();
+//!
+//!     if let Some(headers) = proxy.http_headers(&uri) {
+//!         req.headers_mut().extend(headers.clone().into_iter());
+//!     }
+//!
+//!     let client = Client::builder(TokioExecutor::new()).build(proxy);
+//!     let mut resp = client.request(req).await?;
+//!     println!("Response: {}", resp.status());
+//!     while let Some(chunk) = resp.body_mut().collect().await.ok().map(|c| c.to_bytes()) {
+//!         stdout().write_all(&chunk).await?;
+//!     }
+//!
+//!     // Connecting to an https uri is straightforward (uses 'CONNECT' method underneath)
+//!     let uri = "https://my-remote-websitei-secured.com".parse().unwrap();
+//!     let mut resp = client.get(uri).await?;
+//!     println!("Response: {}", resp.status());
+//!     while let Some(chunk) = resp.body_mut().collect().await.ok().map(|c| c.to_bytes()) {
+//!         stdout().write_all(&chunk).await?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+
+#![allow(missing_docs)]
+
+mod rt;
+mod stream;
+mod tunnel;
+
+use std::{fmt, io, sync::Arc};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::future::TryFutureExt;
+use headers::{authorization::Credentials, Authorization, HeaderMapExt, ProxyAuthorization};
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+use hyper::rt::{Read, Write};
+use hyper::Uri;
+use tower_service::Service;
+
+pub use stream::ProxyStream;
+
+#[cfg(feature = "tls")]
+use native_tls::TlsConnector as NativeTlsConnector;
+
+#[cfg(feature = "tls")]
+use tokio_native_tls::TlsConnector;
+
+#[cfg(feature = "rustls-base")]
+use hyper_rustls::ConfigBuilderExt;
+
+#[cfg(feature = "rustls-base")]
+use tokio_rustls::TlsConnector;
+
+#[cfg(feature = "rustls-base")]
+use tokio_rustls::rustls::pki_types::ServerName;
+
+#[cfg(feature = "openssl-tls")]
+use openssl::ssl::{SslConnector as OpenSslConnector, SslMethod};
+
+#[cfg(feature = "openssl-tls")]
+use tokio_openssl::SslStream;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The Intercept enum to filter connections
+#[derive(Debug, Clone)]
+pub enum Intercept {
+    /// All incoming connection will go through proxy
+    All,
+    /// Only http connections will go through proxy
+    Http,
+    /// Only https connections will go through proxy
+    Https,
+    /// No connection will go through this proxy
+    None,
+    /// A custom intercept
+    Custom(Custom),
+}
+
+/// A trait for matching between Destination and Uri
+pub trait Dst {
+    /// Returns the connection scheme, e.g. "http" or "https"
+    fn scheme(&self) -> Option<&str>;
+    /// Returns the host of the connection
+    fn host(&self) -> Option<&str>;
+    /// Returns the port for the connection
+    fn port(&self) -> Option<u16>;
+}
+
+impl Dst for Uri {
+    fn scheme(&self) -> Option<&str> {
+        self.scheme_str()
+    }
+
+    fn host(&self) -> Option<&str> {
+        self.host()
+    }
+
+    fn port(&self) -> Option<u16> {
+        self.port_u16()
+    }
+}
+
+#[inline]
+pub(crate) fn io_err<E: Into<Box<dyn std::error::Error + Send + Sync>>>(e: E) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, e)
+}
+
+/// A Custom struct to proxy custom uris
+#[derive(Clone)]
+pub struct Custom(Arc<dyn Fn(Option<&str>, Option<&str>, Option<u16>) -> bool + Send + Sync>);
+
+impl fmt::Debug for Custom {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "_")
+    }
+}
+
+impl<F: Fn(Option<&str>, Option<&str>, Option<u16>) -> bool + Send + Sync + 'static> From<F>
+    for Custom
+{
+    fn from(f: F) -> Custom {
+        Custom(Arc::new(f))
+    }
+}
+
+impl Intercept {
+    /// A function to check if given `Uri` is proxied
+    pub fn matches<D: Dst>(&self, uri: &D) -> bool {
+        match (self, uri.scheme()) {
+            (&Intercept::All, _)
+            | (&Intercept::Http, Some("http"))
+            | (&Intercept::Https, Some("https")) => true,
+            (&Intercept::Custom(Custom(ref f)), _) => f(uri.scheme(), uri.host(), uri.port()),
+            _ => false,
+        }
+    }
+}
+
+impl<F: Fn(Option<&str>, Option<&str>, Option<u16>) -> bool + Send + Sync + 'static> From<F>
+    for Intercept
+{
+    fn from(f: F) -> Intercept {
+        Intercept::Custom(f.into())
+    }
+}
+
+/// A Proxy struct
+#[derive(Clone, Debug)]
+pub struct Proxy {
+    intercept: Intercept,
+    force_connect: bool,
+    headers: HeaderMap,
+    uri: Uri,
+}
+
+impl Proxy {
+    /// Create a new `Proxy`
+    pub fn new<I: Into<Intercept>>(intercept: I, uri: Uri) -> Proxy {
+        Proxy {
+            intercept: intercept.into(),
+            uri: uri,
+            headers: HeaderMap::new(),
+            force_connect: false,
+        }
+    }
+
+    /// Set `Proxy` authorization
+    pub fn set_authorization<C: Credentials + Clone>(&mut self, credentials: Authorization<C>) {
+        match self.intercept {
+            Intercept::Http => {
+                self.headers.typed_insert(Authorization(credentials.0));
+            }
+            Intercept::Https => {
+                self.headers.typed_insert(ProxyAuthorization(credentials.0));
+            }
+            _ => {
+                self.headers
+                    .typed_insert(Authorization(credentials.0.clone()));
+                self.headers.typed_insert(ProxyAuthorization(credentials.0));
+            }
+        }
+    }
+
+    /// Forces the use of the CONNECT method.
+    pub fn force_connect(&mut self) {
+        self.force_connect = true;
+    }
+
+    /// Set a custom header
+    pub fn set_header(&mut self, name: HeaderName, value: HeaderValue) {
+        self.headers.insert(name, value);
+    }
+
+    /// Get current intercept
+    pub fn intercept(&self) -> &Intercept {
+        &self.intercept
+    }
+
+    /// Get current `Headers` which must be sent to proxy
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Get proxy uri
+    pub fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+/// A wrapper around `Proxy`s with a connector.
+#[derive(Clone)]
+pub struct ProxyConnector<C> {
+    proxies: Vec<Proxy>,
+    connector: C,
+
+    #[cfg(feature = "tls")]
+    tls: Option<NativeTlsConnector>,
+
+    #[cfg(feature = "rustls-base")]
+    tls: Option<TlsConnector>,
+
+    #[cfg(feature = "openssl-tls")]
+    tls: Option<OpenSslConnector>,
+
+    #[cfg(not(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls")))]
+    tls: Option<()>,
+}
+
+impl<C: fmt::Debug> fmt::Debug for ProxyConnector<C> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "ProxyConnector {}{{ proxies: {:?}, connector: {:?} }}",
+            if self.tls.is_some() {
+                ""
+            } else {
+                "(unsecured)"
+            },
+            self.proxies,
+            self.connector
+        )
+    }
+}
+
+impl<C> ProxyConnector<C> {
+    /// Create a new secured Proxies
+    #[cfg(feature = "tls")]
+    pub fn new(connector: C) -> Result<Self, io::Error> {
+        let tls = NativeTlsConnector::builder()
+            .build()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(ProxyConnector {
+            proxies: Vec::new(),
+            connector: connector,
+            tls: Some(tls),
+        })
+    }
+
+    /// Create a new secured Proxies
+    #[cfg(feature = "rustls-base")]
+    pub fn new(connector: C) -> Result<Self, io::Error> {
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+        let config = tokio_rustls::rustls::ClientConfig::builder();
+
+        #[cfg(feature = "rustls")]
+        let config = config.with_native_roots()?;
+
+        #[cfg(feature = "rustls-webpki")]
+        let config = config.with_webpki_roots();
+
+        let cfg = Arc::new(config.with_no_client_auth());
+        let tls = TlsConnector::from(cfg);
+
+        Ok(ProxyConnector {
+            proxies: Vec::new(),
+            connector,
+            tls: Some(tls),
+        })
+    }
+
+    #[allow(missing_docs)]
+    #[cfg(feature = "openssl-tls")]
+    pub fn new(connector: C) -> Result<Self, io::Error> {
+        let builder = OpenSslConnector::builder(SslMethod::tls())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let tls = builder.build();
+
+        Ok(ProxyConnector {
+            proxies: Vec::new(),
+            connector: connector,
+            tls: Some(tls),
+        })
+    }
+
+    /// Create a new unsecured Proxy
+    pub fn unsecured(connector: C) -> Self {
+        ProxyConnector {
+            proxies: Vec::new(),
+            connector: connector,
+            tls: None,
+        }
+    }
+
+    /// Create a proxy connector and attach a particular proxy
+    #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls"))]
+    pub fn from_proxy(connector: C, proxy: Proxy) -> Result<Self, io::Error> {
+        let mut c = ProxyConnector::new(connector)?;
+        c.proxies.push(proxy);
+        Ok(c)
+    }
+
+    /// Create a proxy connector and attach a particular proxy
+    pub fn from_proxy_unsecured(connector: C, proxy: Proxy) -> Self {
+        let mut c = ProxyConnector::unsecured(connector);
+        c.proxies.push(proxy);
+        c
+    }
+
+    /// Change proxy connector
+    pub fn with_connector<CC>(self, connector: CC) -> ProxyConnector<CC> {
+        ProxyConnector {
+            connector: connector,
+            proxies: self.proxies,
+            tls: self.tls,
+        }
+    }
+
+    /// Set or unset tls when tunneling
+    #[cfg(any(feature = "tls"))]
+    pub fn set_tls(&mut self, tls: Option<NativeTlsConnector>) {
+        self.tls = tls;
+    }
+
+    /// Set or unset tls when tunneling
+    #[cfg(any(feature = "rustls-base"))]
+    pub fn set_tls(&mut self, tls: Option<TlsConnector>) {
+        self.tls = tls;
+    }
+
+    /// Set or unset tls when tunneling
+    #[cfg(any(feature = "openssl-tls"))]
+    pub fn set_tls(&mut self, tls: Option<OpenSslConnector>) {
+        self.tls = tls;
+    }
+
+    /// Get the current proxies
+    pub fn proxies(&self) -> &[Proxy] {
+        &self.proxies
+    }
+
+    /// Add a new additional proxy
+    pub fn add_proxy(&mut self, proxy: Proxy) {
+        self.proxies.push(proxy);
+    }
+
+    /// Extend the list of proxies
+    pub fn extend_proxies<I: IntoIterator<Item = Proxy>>(&mut self, proxies: I) {
+        self.proxies.extend(proxies)
+    }
+
+    /// Get http headers for a matching uri
+    ///
+    /// These headers must be appended to the hyper Request for the proxy to work properly.
+    /// This is needed only for http requests.
+    pub fn http_headers(&self, uri: &Uri) -> Option<&HeaderMap> {
+        if uri.scheme_str().map_or(true, |s| s != "http") {
+            return None;
+        }
+
+        self.match_proxy(uri).map(|p| &p.headers)
+    }
+
+    fn match_proxy<D: Dst>(&self, uri: &D) -> Option<&Proxy> {
+        self.proxies.iter().find(|p| p.intercept.matches(uri))
+    }
+}
+
+macro_rules! mtry {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => break Err(e.into()),
+        }
+    };
+}
+
+impl<C> Service<Uri> for ProxyConnector<C>
+where
+    C: Service<Uri>,
+    C::Response: Read + Write + Send + Unpin + 'static,
+    C::Future: Send + 'static,
+    C::Error: Into<BoxError>,
+{
+    type Response = ProxyStream<C::Response>;
+    type Error = io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.connector.poll_ready(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(io_err(e.into()))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        if let (Some(p), Some(host)) = (self.match_proxy(&uri), uri.host()) {
+            if uri.scheme() == Some(&http::uri::Scheme::HTTPS) || p.force_connect {
+                let host = host.to_owned();
+                let port =
+                    uri.port_u16()
+                        .unwrap_or(if uri.scheme() == Some(&http::uri::Scheme::HTTP) {
+                            80
+                        } else {
+                            443
+                        });
+
+                let tunnel = tunnel::new(&host, port, &p.headers);
+                let connection =
+                    proxy_dst(&uri, &p.uri).map(|proxy_url| self.connector.call(proxy_url));
+                let tls = if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
+                    self.tls.clone()
+                } else {
+                    None
+                };
+
+                Box::pin(async move {
+                    loop {
+                        // this hack will gone once `try_blocks` will eventually stabilized
+                        let proxy_stream = mtry!(mtry!(connection).await.map_err(io_err));
+                        let tunnel_stream = mtry!(tunnel.with_stream(proxy_stream).await);
+
+                        break match tls {
+                            #[cfg(feature = "tls")]
+                            Some(tls) => {
+                                use hyper_util::rt::TokioIo;
+                                let tls = TlsConnector::from(tls);
+                                let secure_stream = mtry!(tls
+                                    .connect(&host, TokioIo::new(tunnel_stream))
+                                    .await
+                                    .map_err(io_err));
+
+                                Ok(ProxyStream::Secured(TokioIo::new(secure_stream)))
+                            }
+
+                            #[cfg(feature = "rustls-base")]
+                            Some(tls) => {
+                                use hyper_util::rt::TokioIo;
+                                let server_name =
+                                    mtry!(ServerName::try_from(host.to_string()).map_err(io_err));
+                                let tls = TlsConnector::from(tls);
+                                let secure_stream = mtry!(tls
+                                    .connect(server_name, TokioIo::new(tunnel_stream))
+                                    .await
+                                    .map_err(io_err));
+
+                                Ok(ProxyStream::Secured(TokioIo::new(secure_stream)))
+                            }
+
+                            #[cfg(feature = "openssl-tls")]
+                            Some(tls) => {
+                                use hyper_util::rt::TokioIo;
+                                let config = tls.configure().map_err(io_err)?;
+                                let ssl = config.into_ssl(&host).map_err(io_err)?;
+
+                                let mut stream =
+                                    mtry!(SslStream::new(ssl, TokioIo::new(tunnel_stream)));
+                                mtry!(Pin::new(&mut stream).connect().await.map_err(io_err));
+
+                                Ok(ProxyStream::Secured(TokioIo::new(stream)))
+                            }
+
+                            #[cfg(not(any(
+                                feature = "tls",
+                                feature = "rustls-base",
+                                feature = "openssl-tls"
+                            )))]
+                            Some(_) => panic!("hyper-proxy was not built with TLS support"),
+
+                            None => Ok(ProxyStream::Regular(tunnel_stream)),
+                        };
+                    }
+                })
+            } else {
+                match proxy_dst(&uri, &p.uri) {
+                    Ok(proxy_uri) => Box::pin(
+                        self.connector
+                            .call(proxy_uri)
+                            .map_ok(ProxyStream::Regular)
+                            .map_err(|err| io_err(err.into())),
+                    ),
+                    Err(err) => Box::pin(futures_util::future::err(io_err(err))),
+                }
+            }
+        } else {
+            Box::pin(
+                self.connector
+                    .call(uri)
+                    .map_ok(ProxyStream::NoProxy)
+                    .map_err(|err| io_err(err.into())),
+            )
+        }
+    }
+}
+
+fn proxy_dst(dst: &Uri, proxy: &Uri) -> io::Result<Uri> {
+    Uri::builder()
+        .scheme(
+            proxy
+                .scheme_str()
+                .ok_or_else(|| io_err(format!("proxy uri missing scheme: {}", proxy)))?,
+        )
+        .authority(
+            proxy
+                .authority()
+                .ok_or_else(|| io_err(format!("proxy uri missing host: {}", proxy)))?
+                .clone(),
+        )
+        .path_and_query(dst.path_and_query().unwrap().clone())
+        .build()
+        .map_err(|err| io_err(format!("other error: {}", err)))
+}

--- a/vendor/hyper-proxy2/src/rt.rs
+++ b/vendor/hyper-proxy2/src/rt.rs
@@ -1,0 +1,140 @@
+use std::future::Future;
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, BufMut};
+use futures_util::ready;
+use hyper::rt;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct ReadBuf<'a, R: ?Sized, B: ?Sized> {
+        reader: &'a mut R,
+        buf: &'a mut B,
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+impl<R, B> Future for ReadBuf<'_, R, B>
+where
+    R: rt::Read + Unpin + ?Sized,
+    B: BufMut + ?Sized,
+{
+    type Output = std::io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        use hyper::rt::{Read as _, ReadBuf};
+        use std::mem::MaybeUninit;
+
+        let me = self.project();
+
+        if !me.buf.has_remaining_mut() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let n = {
+            let dst = me.buf.chunk_mut();
+            let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
+            let mut buf = ReadBuf::uninit(dst);
+            let ptr = buf.filled().as_ptr();
+            ready!(Pin::new(me.reader).poll_read(cx, buf.unfilled())?);
+
+            // Ensure the pointer does not change from under us
+            assert_eq!(ptr, buf.filled().as_ptr());
+            buf.filled().len()
+        };
+
+        // Safety: This is guaranteed to be the number of initialized (and read)
+        // bytes due to the invariants provided by `ReadBuf::filled`.
+        unsafe {
+            me.buf.advance_mut(n);
+        }
+
+        Poll::Ready(Ok(n))
+    }
+}
+
+pub(crate) fn read_buf<'a, R, B>(reader: &'a mut R, buf: &'a mut B) -> ReadBuf<'a, R, B>
+where
+    R: rt::Read + Unpin + ?Sized,
+    B: BufMut + ?Sized,
+{
+    ReadBuf {
+        reader,
+        buf,
+        _pin: PhantomPinned,
+    }
+}
+
+pin_project! {
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct WriteBuf<'a, W, B> {
+        writer: &'a mut W,
+        buf: &'a mut B,
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+impl<W, B> Future for WriteBuf<'_, W, B>
+where
+    W: rt::Write + Unpin,
+    B: Buf,
+{
+    type Output = std::io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        use rt::Write as _;
+
+        let me = self.project();
+
+        if !me.buf.has_remaining() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let n = ready!(Pin::new(me.writer).poll_write(cx, me.buf.chunk()))?;
+        me.buf.advance(n);
+        Poll::Ready(Ok(n))
+    }
+}
+
+pub(crate) fn write_buf<'a, W, B>(writer: &'a mut W, buf: &'a mut B) -> WriteBuf<'a, W, B>
+where
+    W: rt::Write + Unpin,
+    B: Buf,
+{
+    WriteBuf {
+        writer,
+        buf,
+        _pin: PhantomPinned,
+    }
+}
+
+pub(crate) trait ReadExt: rt::Read {
+    fn read_buf<'a, B>(&'a mut self, buf: &'a mut B) -> ReadBuf<'a, Self, B>
+    where
+        Self: Unpin,
+        B: BufMut + ?Sized,
+    {
+        read_buf(self, buf)
+    }
+}
+
+impl<T> ReadExt for T where T: rt::Read {}
+
+pub(crate) trait WriteExt: rt::Write {
+    fn write_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteBuf<'a, Self, B>
+    where
+        Self: Sized + Unpin,
+        B: Buf,
+    {
+        write_buf(self, src)
+    }
+}
+
+impl<T> WriteExt for T where T: rt::Write {}

--- a/vendor/hyper-proxy2/src/stream.rs
+++ b/vendor/hyper-proxy2/src/stream.rs
@@ -1,0 +1,125 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use hyper::rt::{Read, ReadBufCursor, Write};
+use hyper_util::client::legacy::connect::{Connected, Connection};
+
+#[cfg(any(feature = "rustls-base", feature = "tls", feature = "openssl-tls"))]
+use hyper_util::rt::TokioIo;
+
+#[cfg(feature = "rustls-base")]
+use tokio_rustls::client::TlsStream as RustlsStream;
+
+#[cfg(feature = "tls")]
+use tokio_native_tls::TlsStream as TokioNativeTlsStream;
+
+#[cfg(feature = "openssl-tls")]
+use tokio_openssl::SslStream as OpenSslStream;
+
+#[cfg(feature = "rustls-base")]
+pub type TlsStream<R> = TokioIo<RustlsStream<TokioIo<R>>>;
+
+#[cfg(feature = "tls")]
+pub type TlsStream<R> = TokioIo<TokioNativeTlsStream<TokioIo<R>>>;
+
+#[cfg(feature = "openssl-tls")]
+pub type TlsStream<R> = TokioIo<OpenSslStream<TokioIo<R>>>;
+
+/// A Proxy Stream wrapper
+pub enum ProxyStream<R> {
+    NoProxy(R),
+    Regular(R),
+    #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls"))]
+    Secured(TlsStream<R>),
+}
+
+macro_rules! match_fn_pinned {
+    ($self:expr, $fn:ident, $ctx:expr, $buf:expr) => {
+        match $self.get_mut() {
+            ProxyStream::NoProxy(s) => Pin::new(s).$fn($ctx, $buf),
+            ProxyStream::Regular(s) => Pin::new(s).$fn($ctx, $buf),
+            #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls"))]
+            ProxyStream::Secured(s) => Pin::new(s).$fn($ctx, $buf),
+        }
+    };
+
+    ($self:expr, $fn:ident, $ctx:expr) => {
+        match $self.get_mut() {
+            ProxyStream::NoProxy(s) => Pin::new(s).$fn($ctx),
+            ProxyStream::Regular(s) => Pin::new(s).$fn($ctx),
+            #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls"))]
+            ProxyStream::Secured(s) => Pin::new(s).$fn($ctx),
+        }
+    };
+}
+
+impl<R: Read + Write + Unpin> Read for ProxyStream<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: ReadBufCursor<'_>,
+    ) -> Poll<io::Result<()>> {
+        match_fn_pinned!(self, poll_read, cx, buf)
+    }
+}
+
+impl<R: Read + Write + Unpin> Write for ProxyStream<R> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match_fn_pinned!(self, poll_write, cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        match_fn_pinned!(self, poll_write_vectored, cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            ProxyStream::NoProxy(s) => s.is_write_vectored(),
+            ProxyStream::Regular(s) => s.is_write_vectored(),
+            #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls"))]
+            ProxyStream::Secured(s) => s.is_write_vectored(),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match_fn_pinned!(self, poll_flush, cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match_fn_pinned!(self, poll_shutdown, cx)
+    }
+}
+
+impl<R: Read + Write + Connection + Unpin> Connection for ProxyStream<R> {
+    fn connected(&self) -> Connected {
+        match self {
+            ProxyStream::NoProxy(s) => s.connected(),
+
+            ProxyStream::Regular(s) => s.connected().proxy(true),
+            #[cfg(feature = "tls")]
+            ProxyStream::Secured(s) => s
+                .inner()
+                .get_ref()
+                .get_ref()
+                .get_ref()
+                .inner()
+                .connected()
+                .proxy(true),
+
+            #[cfg(feature = "rustls-base")]
+            ProxyStream::Secured(s) => s.inner().get_ref().0.inner().connected().proxy(true),
+
+            #[cfg(feature = "openssl-tls")]
+            ProxyStream::Secured(s) => s.inner().get_ref().inner().connected().proxy(true),
+        }
+    }
+}

--- a/vendor/hyper-proxy2/src/tunnel.rs
+++ b/vendor/hyper-proxy2/src/tunnel.rs
@@ -1,0 +1,221 @@
+use std::fmt::{self, Display, Formatter};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::{buf::Buf, BytesMut};
+use http::HeaderMap;
+use hyper::rt::{Read, Write};
+
+use crate::io_err;
+use crate::rt::{ReadExt as _, WriteExt as _};
+
+macro_rules! try_ready {
+    ($x:expr) => {
+        match $x {
+            core::task::Poll::Ready(Ok(x)) => x,
+            core::task::Poll::Ready(Err(e)) => return core::task::Poll::Ready(Err(e.into())),
+            core::task::Poll::Pending => return core::task::Poll::Pending,
+        }
+    };
+}
+
+pub(crate) struct TunnelConnect {
+    buf: BytesMut,
+}
+
+impl TunnelConnect {
+    /// Change stream
+    pub fn with_stream<S>(self, stream: S) -> Tunnel<S> {
+        Tunnel {
+            buf: self.buf,
+            stream: Some(stream),
+            state: TunnelState::Writing,
+        }
+    }
+}
+
+pub(crate) struct Tunnel<S> {
+    buf: BytesMut,
+    stream: Option<S>,
+    state: TunnelState,
+}
+
+#[derive(Debug)]
+enum TunnelState {
+    Writing,
+    Reading,
+}
+
+struct HeadersDisplay<'a>(&'a HeaderMap);
+
+impl<'a> Display for HeadersDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        for (key, value) in self.0 {
+            let value_str = value.to_str().map_err(|_| fmt::Error)?;
+            write!(f, "{}: {}\r\n", key.as_str(), value_str)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Creates a new tunnel through proxy
+pub(crate) fn new(host: &str, port: u16, headers: &HeaderMap) -> TunnelConnect {
+    let buf = format!(
+        "CONNECT {0}:{1} HTTP/1.1\r\n\
+         Host: {0}:{1}\r\n\
+         {2}\
+         \r\n",
+        host,
+        port,
+        HeadersDisplay(headers)
+    )
+    .into_bytes();
+
+    TunnelConnect {
+        buf: buf.as_slice().into(),
+    }
+}
+
+impl<S: Read + Write + Unpin> Future for Tunnel<S> {
+    type Output = Result<S, io::Error>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.stream.is_none() {
+            panic!("must not poll after future is complete")
+        }
+
+        let this = self.get_mut();
+
+        loop {
+            if let TunnelState::Writing = &this.state {
+                let fut = this.stream.as_mut().unwrap().write_buf(&mut this.buf);
+                futures_util::pin_mut!(fut);
+                let n = try_ready!(fut.poll(ctx));
+
+                if !this.buf.has_remaining() {
+                    this.state = TunnelState::Reading;
+                    this.buf.truncate(0);
+                } else if n == 0 {
+                    return Poll::Ready(Err(io_err("unexpected EOF while tunnel writing")));
+                }
+            } else {
+                let fut = this.stream.as_mut().unwrap().read_buf(&mut this.buf);
+                futures_util::pin_mut!(fut);
+                let n = try_ready!(fut.poll(ctx));
+
+                if n == 0 {
+                    return Poll::Ready(Err(io_err("unexpected EOF while tunnel reading")));
+                } else {
+                    let read = &this.buf[..];
+                    if read.len() > 12 {
+                        if read.starts_with(b"HTTP/1.1 200") || read.starts_with(b"HTTP/1.0 200") {
+                            if read.ends_with(b"\r\n\r\n") {
+                                return Poll::Ready(Ok(this.stream.take().unwrap()));
+                            }
+                        // else read more
+                        } else {
+                            let len = read.len().min(16);
+                            return Poll::Ready(Err(io_err(format!(
+                                "unsuccessful tunnel ({})",
+                                String::from_utf8_lossy(&read[0..len])
+                            ))));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HeaderMap, Tunnel};
+    use futures_util::future::TryFutureExt;
+    use hyper_util::rt::TokioIo;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use tokio::net::TcpStream;
+    use tokio::runtime::Runtime;
+
+    fn tunnel<S>(conn: S, host: String, port: u16) -> Tunnel<S> {
+        super::new(&host, port, &HeaderMap::new()).with_stream(conn)
+    }
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    macro_rules! mock_tunnel {
+        () => {{
+            mock_tunnel!(
+                b"\
+                HTTP/1.1 200 OK\r\n\
+                \r\n\
+                "
+            )
+        }};
+        ($write:expr) => {{
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let connect_expected = format!(
+                "\
+                 CONNECT {0}:{1} HTTP/1.1\r\n\
+                 Host: {0}:{1}\r\n\
+                 \r\n\
+                 ",
+                addr.ip(),
+                addr.port()
+            ).into_bytes();
+
+            thread::spawn(move || {
+                let (mut sock, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 4096];
+                let n = sock.read(&mut buf).unwrap();
+                assert_eq!(&buf[..n], &connect_expected[..]);
+
+                sock.write_all($write).unwrap();
+            });
+            addr
+        }};
+    }
+
+    #[test]
+    fn test_tunnel() {
+        let addr = mock_tunnel!();
+
+        let core = Runtime::new().unwrap();
+        let work = TcpStream::connect(&addr);
+        let host = addr.ip().to_string();
+        let port = addr.port();
+        let work = work.and_then(|tcp| tunnel(TokioIo::new(tcp), host, port));
+
+        core.block_on(work).unwrap();
+    }
+
+    #[test]
+    fn test_tunnel_eof() {
+        let addr = mock_tunnel!(b"HTTP/1.1 200 OK");
+
+        let core = Runtime::new().unwrap();
+        let work = TcpStream::connect(&addr);
+        let host = addr.ip().to_string();
+        let port = addr.port();
+        let work = work.and_then(|tcp| tunnel(TokioIo::new(tcp), host, port));
+
+        core.block_on(work).unwrap_err();
+    }
+
+    #[test]
+    fn test_tunnel_bad_response() {
+        let addr = mock_tunnel!(b"foo bar baz hallo");
+
+        let core = Runtime::new().unwrap();
+        let work = TcpStream::connect(&addr);
+        let host = addr.ip().to_string();
+        let port = addr.port();
+        let work = work.and_then(|tcp| tunnel(TokioIo::new(tcp), host, port));
+
+        core.block_on(work).unwrap_err();
+    }
+}


### PR DESCRIPTION
## Why

Spotify is sometimes reachable only through an HTTP or SOCKS5 proxy.
Fastpotify had no proxy setting, so browser grants, Web API requests, and
local playback connections could not follow that network policy.

## What changed

Settings > Proxy and the sign-in screen now offer four modes: **Off**,
**System**, **HTTP**, and **SOCKS5**. Manual modes take a host, port, and
optional login. Off and System apply immediately. Manual settings wait for
**Apply settings** and validate the host and port first.

The Web API, token refresh, artwork, lyrics, update checks, and MilkDrop
preset downloads use one replaceable proxy-aware HTTP client. SOCKS5 resolves
Spotify hostnames at the proxy. Spotify Connect receiver activation stays
direct because those endpoints are on the LAN.

Local playback follows only an unauthenticated `http://` proxy. This is the
subset librespot currently supports safely. SOCKS5, authenticated HTTP,
authenticated System proxies, and `https://` proxy endpoints still cover Web
traffic, while librespot connects directly. The UI and documentation state
that boundary. Proxy changes discard any in-flight stale engine connection
and reconnect only when the proxy librespot can actually use changes.

The optional proxy password is not written to `settings.json`. It is stored
in the state directory through the owner-only secret path. Older settings
files containing the field migrate on their next save. Existing Unix secret
files are tightened to mode 0600, and atomic replacement uses the Windows
replace-file API where `std::fs::rename` cannot overwrite a destination.
Proxy usernames and passwords are excluded from Fastpotify and librespot
logs.

The vendored `hyper-proxy2` patch moves its active CONNECT TLS path to rustls
0.23 and removes the older advised `rustls-webpki` copy. The Nix vendor hash
is updated from the CI-produced value for the current `main` merge result.

## Verification

Run locally on macOS aarch64 after rebasing onto current `main`:

```text
cargo fmt --all --check
cargo test --locked --all-targets                 # 316 passed
cargo test --locked --all-targets --all-features  # 316 passed
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
```

Focused tests exercise exact opaque proxy authentication, HTTP forwarding,
librespot CONNECT routing, credential-free librespot configuration, System
proxy restrictions, atomic secret replacement, Unix permission tightening,
and proxy changes during an in-flight engine connection.

Local Clippy currently stops on the unchanged `src/mac_links.rs:41`
`type_complexity` lint introduced on current `main`. I did not suppress or
fold that unrelated fix into this PR. The previous PR CI passed quality,
Linux, macOS, Windows, and docs; the Nix job supplied the corrected hash used
here. The new CI run will compile and execute the Windows replacement path.

I could not run `bundle exec jekyll build` locally because the machine lacks
the locked Bundler 4.0.16. I also have not claimed a signed-in playback test
through a real external HTTP proxy: no proxy service is available on this
machine. The tests use real local TCP proxy listeners, but they do not replace
that final live-network check.

### Platform coverage

Runtime testing was on macOS aarch64. CI covers Linux, macOS, and Windows.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I updated documentation for user-visible behaviour, settings, files,
  and network access.
- [x] I understand and take responsibility for every submitted line,
  including AI-assisted code.
