### PR TITLE
Put minus on the left of Interface Zoom

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -937,6 +937,85 @@ mod tests {
         app.backend.shutdown();
     }
 
+    /// Rule: the interface zoom control puts minus on the left and plus
+    /// on the right. The setting row's control is right-to-left, which
+    /// used to reverse the two buttons.
+    #[test]
+    fn interface_zoom_puts_minus_on_the_left() {
+        let root =
+            std::env::temp_dir().join(format!("fastpotify-zoom-order-test-{}", std::process::id()));
+        let dirs = AppDirs {
+            config: root.join("config"),
+            state: root.join("state"),
+            cache: root.join("cache"),
+        };
+        let ctx = egui::Context::default();
+        let waker = crate::backend::Waker::default();
+        waker.attach(&ctx);
+        let mut app = App::new(
+            &waker,
+            dirs,
+            Settings::default(),
+            AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        );
+        app.attach(&ctx);
+        populate(&mut app);
+        app.settings.zoom = 1.0;
+        app.open(Page::Settings);
+
+        let mut placed: Vec<(String, f32, f32)> = Vec::new();
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1280.0, 4000.0),
+            )),
+            ..Default::default()
+        };
+        for _ in 0..2 {
+            placed.clear();
+            let mut output = ctx.run_ui(input.clone(), |ui| app.frame_ui(ui));
+            output.textures_delta.clear();
+            fn walk(shape: &egui::epaint::Shape, placed: &mut Vec<(String, f32, f32)>) {
+                match shape {
+                    egui::epaint::Shape::Text(text) => {
+                        placed.push((text.galley.job.text.clone(), text.pos.x, text.pos.y))
+                    }
+                    egui::epaint::Shape::Vec(shapes) => {
+                        shapes.iter().for_each(|shape| walk(shape, placed))
+                    }
+                    _ => {}
+                }
+            }
+            for clipped in &output.shapes {
+                walk(&clipped.shape, &mut placed);
+            }
+        }
+        let percent = placed
+            .iter()
+            .find(|(text, _, _)| text == "100%")
+            .unwrap_or_else(|| panic!("the zoom percent was never drawn: {placed:?}"));
+        let on_row = |label: &str| -> f32 {
+            placed
+                .iter()
+                .filter(|(text, _, y)| text == label && (y - percent.2).abs() < 8.0)
+                .min_by(|a, b| (a.1 - percent.1).abs().total_cmp(&(b.1 - percent.1).abs()))
+                .unwrap_or_else(|| panic!("{label} was never drawn next to 100%: {placed:?}"))
+                .1
+        };
+        let minus = on_row("-");
+        let plus = on_row("+");
+        assert!(
+            minus < percent.1 && percent.1 < plus,
+            "zoom control should read minus, percent, plus; got - at {minus}, 100% at {}, + at {plus}",
+            percent.1
+        );
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     /// The frame rate is a dial with detents: it stops at the rates
     /// worth having, names the one it is on, and moving it one notch
     /// lands on the next of them rather than somewhere in between.

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -512,8 +512,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 6.0;
                     let mut zoom = app.settings.zoom;
-                    if theme::soft_button(ui, &palette, None, "-", false).clicked() {
-                        zoom = (zoom - 0.1).max(0.5);
+                    // The setting row lays controls out right-to-left, so plus
+                    // is added first: visual order is minus, percent, plus.
+                    if theme::soft_button(ui, &palette, None, "+", false).clicked() {
+                        zoom = (zoom + 0.1).min(2.5);
                     }
                     theme::text(
                         ui,
@@ -521,8 +523,8 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         theme::medium(13.5),
                         palette.text,
                     );
-                    if theme::soft_button(ui, &palette, None, "+", false).clicked() {
-                        zoom = (zoom + 0.1).min(2.5);
+                    if theme::soft_button(ui, &palette, None, "-", false).clicked() {
+                        zoom = (zoom - 0.1).max(0.5);
                     }
                     if (zoom - app.settings.zoom).abs() > 0.001 {
                         app.settings.zoom = zoom;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -512,8 +512,6 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 6.0;
                     let mut zoom = app.settings.zoom;
-                    // The setting row lays controls out right-to-left, so plus
-                    // is added first: visual order is minus, percent, plus.
                     if theme::soft_button(ui, &palette, None, "+", false).clicked() {
                         zoom = (zoom + 0.1).min(2.5);
                     }


### PR DESCRIPTION
## Why

The Interface Zoom control in Settings → Appearance currently has minus on the right and plus on the left. Zoom widgets almost everywhere else (browsers, VS Code, Spotify, system volume) put minus on the left and plus on the right, so the current layout fights muscle memory.

Fixes #227.

## What changed

Settings rows lay their control out right-to-left. Adding minus first therefore put it on the right. Plus is added first now, so the control reads minus, percent, plus.

A demo-mode test draws the Settings page and checks that `-`, `100%`, and `+` sit in that order on the same row.

## Verification

- `cargo fmt --all --check` passed.
- I did not finish Clippy or the test suite locally; a compile of `interface_zoom_puts_minus_on_the_left` was started and then stopped. CI will run the full checks.
- No screenshots: I did not run the app. The new test is the visual check I have.
- No documentation change: this restores the usual button order of an existing control; it does not add a setting, file, or network behaviour.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [ ] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access. (None needed.)
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.