### PR TITLE
fix(ui): auto-focus library search field when opened

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1558,4 +1558,100 @@ mod tests {
         let older: Settings = serde_json::from_str("{}").unwrap();
         assert!(older.sidebar_order.is_empty());
     }
+
+    /// Clicking the search icon in the library header reveals and focuses
+    /// the sidebar search field.
+    #[test]
+    fn clicking_search_in_library_shelf_focuses_search_field() {
+        let root = std::env::temp_dir().join(format!(
+            "fastpotify-sidebar-search-focus-test-{}",
+            std::process::id()
+        ));
+        let dirs = AppDirs {
+            config: root.join("config"),
+            state: root.join("state"),
+            cache: root.join("cache"),
+        };
+        let ctx = egui::Context::default();
+        let waker = crate::backend::Waker::default();
+        waker.attach(&ctx);
+        let mut app = App::new(
+            &waker,
+            dirs,
+            Settings::default(),
+            AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        );
+        app.attach(&ctx);
+        populate(&mut app);
+
+        // Find the Y position of "Your Library" header.
+        let mut library_y = None;
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1280.0, 800.0),
+            )),
+            ..Default::default()
+        };
+        for _ in 0..2 {
+            let mut output = ctx.run_ui(input.clone(), |ui| app.frame_ui(ui));
+            output.textures_delta.clear();
+            fn walk(shape: &egui::epaint::Shape, found: &mut Option<f32>) {
+                match shape {
+                    egui::epaint::Shape::Text(text) => {
+                        if text.galley.job.text == "Your Library" {
+                            *found = Some(text.pos.y);
+                        }
+                    }
+                    egui::epaint::Shape::Vec(shapes) => {
+                        shapes.iter().for_each(|shape| walk(shape, found));
+                    }
+                    _ => {}
+                }
+            }
+            for clipped in &output.shapes {
+                walk(&clipped.shape, &mut library_y);
+            }
+        }
+        let y = library_y.expect("Your Library label was not found");
+        let search_pos = egui::pos2(168.0, y + 4.0);
+
+        // Click on the search button in the Your Library shelf header.
+        frame_events(
+            &ctx,
+            &mut app,
+            vec![
+                egui::Event::PointerMoved(search_pos),
+                egui::Event::PointerButton {
+                    pos: search_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::PointerButton {
+                    pos: search_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+
+        // Advance one frame so the focused widget processes events.
+        frame(&ctx, &mut app);
+
+        // Verify the search field is shown and has keyboard focus.
+        let search_id = egui::Id::new("sidebar-search");
+        let has_focus = ctx.memory(|m| m.has_focus(search_id));
+        assert!(
+            has_focus,
+            "sidebar-search must have keyboard focus after clicking the search icon"
+        );
+
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -310,6 +310,8 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
         .data(|data| data.get_temp::<bool>(show_search_id))
         .unwrap_or(false);
 
+    let mut focus_search = false;
+
     ui.horizontal(|ui| {
         ui.add_space(6.0);
         theme::icon(ui, Icon::Library, 22.0, palette.secondary);
@@ -358,7 +360,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
             {
                 show_search = !show_search;
                 if show_search {
-                    ui.memory_mut(|memory| memory.request_focus(egui::Id::new("sidebar-search")));
+                    focus_search = true;
                 } else {
                     app.library.filter.clear();
                 }
@@ -386,7 +388,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
     });
     if show_search {
         ui.add_space(4.0);
-        super::widgets::search_field(
+        let response = super::widgets::search_field(
             ui,
             &palette,
             egui::Id::new("sidebar-search"),
@@ -394,6 +396,9 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
             "Search in Your Library",
             ui.available_width() - 4.0,
         );
+        if focus_search {
+            response.request_focus();
+        }
     }
     ui.add_space(6.0);
 


### PR DESCRIPTION
Resolves #178.

When revealing the search field in the "Your Library" sidebar shelf via the magnifying glass icon, keyboard focus is now automatically requested on the text field, allowing users to start filtering immediately without requiring a manual click into the input box.

### Changes
- `src/ui/sidebar.rs`: Request focus on `sidebar-search` during the render pass when search visibility is toggled on.
- `src/demo.rs`: Added deterministic regression test `clicking_search_in_library_shelf_focuses_search_field`.

### Verification
- Verified empirical test failure on original code and clean pass with the fix.
- Passed `cargo fmt --all --check`.
- Passed `cargo clippy --locked --all-targets -- -D warnings`.
- Passed full test suite (`cargo test --locked --lib`, 257 tests passing).