### PR TITLE
Add startup options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,8 +119,9 @@ objc2-app-kit = { version = "0.3", default-features = false, features = ["std", 
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSDate", "NSObjCRuntime", "NSRunLoop", "NSString"] }
 
 [target.'cfg(windows)'.dependencies]
-# A hidden window for the media controls to belong to, and message loops.
-windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_Com", "Win32_System_LibraryLoader", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+# A hidden window for the media controls to belong to, message loops, and the
+# per-user registry entry used by automatic startup.
+windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_Com", "Win32_System_LibraryLoader", "Win32_System_Registry", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ksni = { version = "0.3", features = ["blocking"] }

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -24,6 +24,7 @@ Fastpotify follows each platform's conventions. On Linux:
 | Account-scoped playlist cache | `~/.cache/fastpotify/playlists/<account-id>/` | Always |
 | Last run's log | `~/.local/state/fastpotify/fastpotify.log` | Always |
 | Crash log | `~/.local/state/fastpotify/panic.log` | Always |
+| Automatic startup | `~/.config/autostart/fastpotify.desktop` | Turn it off in Settings first |
 
 Clearing caches never signs you out; credentials live in *state*, not
 *cache*. Web API token files are written with owner-only permissions.
@@ -32,10 +33,12 @@ playback credential.
 
 On macOS, settings, state, and the logs are in
 `~/Library/Application Support/me.paolino.fastpotify` and the caches in
-`~/Library/Caches/me.paolino.fastpotify`. On Windows, settings are in
+`~/Library/Caches/me.paolino.fastpotify`. Automatic startup uses
+`~/Library/LaunchAgents/me.paolino.fastpotify.plist`. On Windows, settings are in
 `%APPDATA%\paolino\fastpotify\config`, state and the logs in
 `%LOCALAPPDATA%\paolino\fastpotify\data`, and the caches in
 `%LOCALAPPDATA%\paolino\fastpotify\cache`.
+Automatic startup on Windows uses the current user's Run registry key.
 
 ## settings.json
 
@@ -77,6 +80,7 @@ main fields are:
 | `milkdrop_fullscreen` | `false` | The MilkDrop window fills the screen |
 | `milkdrop_size` | `640, 480` | The MilkDrop window's size in points |
 | `keep_playing_in_background` | `true` | Close to tray |
+| `automatic_startup` | `no` | Start at sign-in: `no`, `minimized`, or `yes` |
 | `check_for_updates` | `true` | Ask GitHub once a day for a newer release |
 | `web_client_id` | none | Optional personal Spotify app id used alongside shared coverage |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4873,6 +4873,19 @@ impl App {
                     ThemeChoice::System => egui::ThemePreference::System,
                 });
             }
+            Action::SetAutomaticStartup(mode) => {
+                if self.settings.automatic_startup == mode {
+                    return;
+                }
+                if !self.offline
+                    && let Err(error) = crate::startup::configure(mode)
+                {
+                    self.toast_error(format!("Couldn't set automatic startup: {error}"));
+                    return;
+                }
+                self.settings.automatic_startup = mode;
+                self.settings_dirty = true;
+            }
             Action::RestartEngine => {
                 self.save_settings();
                 let config = engine_config(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod settings;
 pub mod single_instance;
 pub mod sink;
 pub mod skin;
+pub mod startup;
 pub mod system_fonts;
 pub mod theme;
 #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use fastpotify::{app, backend, paths, settings, single_instance, util};
+use fastpotify::{app, backend, paths, settings, single_instance, startup, util};
 
 use clap::Parser;
 
@@ -21,6 +21,10 @@ struct Cli {
     /// Log more from librespot and the Web API client.
     #[arg(short, long)]
     verbose: bool,
+
+    /// Start the window minimized (used by automatic startup).
+    #[arg(long, hide = true)]
+    start_minimized: bool,
 
     /// Start with sample data and no Spotify connection (for screenshots).
     #[cfg(feature = "demo")]
@@ -275,6 +279,8 @@ fn main() -> eframe::Result<()> {
     }
 
     let cli = Cli::parse();
+    #[cfg(feature = "demo")]
+    let demo = cli.demo || cli.demo_shot.is_some();
     // A control launch is a client, not a second app: talk to the running
     // instance and exit before touching the log file it is writing to.
     if let Some(control) = cli.control {
@@ -306,6 +312,14 @@ fn main() -> eframe::Result<()> {
     if let Some(name) = cli.device_name {
         settings.device_name = name;
     }
+    #[cfg(feature = "demo")]
+    if !demo && let Err(error) = startup::configure(settings.automatic_startup) {
+        log::warn!("unable to configure automatic startup: {error}");
+    }
+    #[cfg(not(feature = "demo"))]
+    if let Err(error) = startup::configure(settings.automatic_startup) {
+        log::warn!("unable to configure automatic startup: {error}");
+    }
 
     // The application (audio engine, Web API, MPRIS, tray) outlives any
     // window. Closing to the tray destroys the window and this loop creates
@@ -315,8 +329,6 @@ fn main() -> eframe::Result<()> {
 
     // A second launch surfaces the instance already running instead of
     // starting a rival one. Held for the lifetime of the process.
-    #[cfg(feature = "demo")]
-    let demo = cli.demo || cli.demo_shot.is_some();
     #[cfg(feature = "demo")]
     let guarded = !demo;
     #[cfg(not(feature = "demo"))]
@@ -361,6 +373,7 @@ fn main() -> eframe::Result<()> {
         asked: false,
     });
     let slot = std::sync::Arc::new(std::sync::Mutex::new(Some(app)));
+    let mut start_minimized = cli.start_minimized;
 
     loop {
         let creator_slot = std::sync::Arc::clone(&slot);
@@ -371,6 +384,8 @@ fn main() -> eframe::Result<()> {
             let guard = slot.lock().unwrap_or_else(|p| p.into_inner());
             MiniWindow::wanted(guard.as_ref().expect("application state present"))
         };
+        let creator_start_minimized = start_minimized;
+        start_minimized = false;
         #[cfg(feature = "demo")]
         let options = native_options(shot.is_some() && mini.is_none(), mini);
         #[cfg(not(feature = "demo"))]
@@ -400,6 +415,7 @@ fn main() -> eframe::Result<()> {
                     slot: std::sync::Arc::clone(&creator_slot),
                     #[cfg(feature = "demo")]
                     shot: creator_shot.clone(),
+                    start_minimized: creator_start_minimized,
                 }))
             }),
         )?;
@@ -585,6 +601,7 @@ fn native_options(fullscreen: bool, mini: Option<MiniWindow>) -> eframe::NativeO
 struct Shell {
     app: Option<app::App>,
     slot: std::sync::Arc<std::sync::Mutex<Option<app::App>>>,
+    start_minimized: bool,
     /// A pending `--demo-shot` capture, if this is a screenshot run.
     #[cfg(feature = "demo")]
     shot: Option<Shot>,
@@ -649,6 +666,10 @@ impl Shell {
 
 impl eframe::App for Shell {
     fn logic(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        if self.start_minimized {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+            self.start_minimized = false;
+        }
         if let Some(app) = self.app.as_mut() {
             #[cfg(target_os = "macos")]
             for command in fastpotify::mac_menu::drain_commands() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -669,6 +669,8 @@ pub enum Action {
     ToggleLyricsPanel,
     ToggleDevicesPopup,
     SettingsChanged,
+    /// Set whether Fastpotify starts when the user signs in.
+    SetAutomaticStartup(crate::settings::StartupMode),
     RestartEngine,
     EnablePlayback,
     ShowWindow,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -46,6 +46,28 @@ impl ThemeChoice {
     }
 }
 
+/// Whether Fastpotify starts when the user signs in.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StartupMode {
+    #[default]
+    No,
+    Minimized,
+    Yes,
+}
+
+impl StartupMode {
+    pub const ALL: [StartupMode; 3] = [Self::No, Self::Minimized, Self::Yes];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::No => "No",
+            Self::Minimized => "Minimized",
+            Self::Yes => "Yes",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
@@ -92,6 +114,8 @@ pub struct Settings {
     pub playback_authorized: bool,
     /// Closing the window hides to the tray and keeps the music playing.
     pub keep_playing_in_background: bool,
+    /// Start when the user signs in, optionally minimized.
+    pub automatic_startup: StartupMode,
     /// Ask GitHub once a day whether a newer release exists.
     pub check_for_updates: bool,
     /// Context URIs pinned to the top of the sidebar, in pin order.
@@ -179,6 +203,7 @@ impl Default for Settings {
             web_client_id: None,
             playback_authorized: false,
             keep_playing_in_background: true,
+            automatic_startup: StartupMode::No,
             check_for_updates: true,
             pinned_contexts: Vec::new(),
             sidebar_order: Vec::new(),
@@ -273,6 +298,25 @@ mod tests {
     fn older_settings_keep_the_sidebar_visible() {
         let settings: Settings = serde_json::from_str("{}").unwrap();
         assert!(settings.sidebar_visible);
+    }
+
+    #[test]
+    fn older_settings_do_not_start_automatically() {
+        let settings: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(settings.automatic_startup, super::StartupMode::No);
+    }
+
+    #[test]
+    fn startup_modes_round_trip() {
+        for mode in super::StartupMode::ALL {
+            let settings = Settings {
+                automatic_startup: mode,
+                ..Settings::default()
+            };
+            let json = serde_json::to_string(&settings).unwrap();
+            let restored: Settings = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored.automatic_startup, mode);
+        }
     }
 
     #[test]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,240 @@
+//! Register Fastpotify to start when the user signs in.
+
+use std::io;
+use std::path::Path;
+
+use crate::settings::StartupMode;
+
+/// Updates the current user's startup entry for the current executable.
+pub fn configure(mode: StartupMode) -> io::Result<()> {
+    let executable = match mode {
+        StartupMode::No => None,
+        StartupMode::Minimized | StartupMode::Yes => Some(std::env::current_exe()?),
+    };
+    configure_for(mode, executable.as_deref())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn remove_if_present(path: &Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn write_atomic(path: &Path, text: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension("tmp");
+    std::fs::write(&temporary, text)?;
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn configure_for(mode: StartupMode, executable: Option<&Path>) -> io::Result<()> {
+    let base = directories::BaseDirs::new()
+        .map(|dirs| dirs.config_dir().to_path_buf())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "home directory not found"))?;
+    let path = base.join("autostart").join("fastpotify.desktop");
+    match mode {
+        StartupMode::No => remove_if_present(&path),
+        StartupMode::Minimized | StartupMode::Yes => {
+            let executable = executable.expect("enabled startup mode has an executable");
+            write_atomic(&path, &desktop_entry(executable, mode))
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn desktop_entry(executable: &Path, mode: StartupMode) -> String {
+    let mut text = String::from("[Desktop Entry]\nType=Application\nName=Fastpotify\nExec=");
+    text.push_str(&desktop_exec_arg(executable));
+    if mode == StartupMode::Minimized {
+        text.push_str(" --start-minimized");
+    }
+    text.push_str("\nTerminal=false\n");
+    text
+}
+
+#[cfg(target_os = "linux")]
+fn desktop_exec_arg(path: &Path) -> String {
+    let mut quoted = String::from("\"");
+    for character in path.to_string_lossy().chars() {
+        if matches!(character, '\\' | '"' | '`' | '$') {
+            quoted.push('\\');
+        }
+        quoted.push(character);
+    }
+    quoted.push('"');
+    quoted
+}
+
+#[cfg(target_os = "macos")]
+fn configure_for(mode: StartupMode, executable: Option<&Path>) -> io::Result<()> {
+    let home = directories::BaseDirs::new()
+        .map(|dirs| dirs.home_dir().to_path_buf())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "home directory not found"))?;
+    let path = home
+        .join("Library")
+        .join("LaunchAgents")
+        .join("me.paolino.fastpotify.plist");
+    match mode {
+        StartupMode::No => remove_if_present(&path),
+        StartupMode::Minimized | StartupMode::Yes => {
+            let executable = executable.expect("enabled startup mode has an executable");
+            write_atomic(&path, &launch_agent(executable, mode))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn launch_agent(executable: &Path, mode: StartupMode) -> String {
+    let mut text = String::from(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\"><dict>\n<key>Label</key><string>me.paolino.fastpotify</string>\n<key>ProgramArguments</key><array><string>",
+    );
+    text.push_str(&xml_text(executable));
+    if mode == StartupMode::Minimized {
+        text.push_str("</string><string>--start-minimized");
+    }
+    text.push_str("</string></array>\n<key>RunAtLoad</key><true/>\n</dict></plist>\n");
+    text
+}
+
+#[cfg(target_os = "macos")]
+fn xml_text(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(windows)]
+fn configure_for(mode: StartupMode, executable: Option<&Path>) -> io::Result<()> {
+    use std::ffi::OsStr;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::ERROR_FILE_NOT_FOUND;
+    use windows_sys::Win32::System::Registry::{
+        HKEY, HKEY_CURRENT_USER, KEY_SET_VALUE, REG_SZ, RegCloseKey, RegDeleteValueW,
+        RegOpenKeyExW, RegSetValueExW,
+    };
+
+    const RUN_KEY: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+    const VALUE_NAME: &str = "Fastpotify";
+
+    let key_name: Vec<u16> = OsStr::new(RUN_KEY).encode_wide().chain(once(0)).collect();
+    let value_name: Vec<u16> = OsStr::new(VALUE_NAME)
+        .encode_wide()
+        .chain(once(0))
+        .collect();
+    let mut key: HKEY = std::ptr::null_mut();
+    let status = unsafe {
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            key_name.as_ptr(),
+            0,
+            KEY_SET_VALUE,
+            &mut key,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    let result = match mode {
+        StartupMode::No => {
+            let status = unsafe { RegDeleteValueW(key, value_name.as_ptr()) };
+            if status == 0 || status == ERROR_FILE_NOT_FOUND {
+                Ok(())
+            } else {
+                Err(io::Error::from_raw_os_error(status as i32))
+            }
+        }
+        StartupMode::Minimized | StartupMode::Yes => {
+            let executable = executable.expect("enabled startup mode has an executable");
+            let mut command = vec![b'"' as u16];
+            command.extend(executable.as_os_str().encode_wide());
+            command.push(b'"' as u16);
+            if mode == StartupMode::Minimized {
+                command.extend(OsStr::new(" --start-minimized").encode_wide());
+            }
+            command.push(0);
+            let bytes = command.len() * std::mem::size_of::<u16>();
+            let status = unsafe {
+                RegSetValueExW(
+                    key,
+                    value_name.as_ptr(),
+                    0,
+                    REG_SZ,
+                    command.as_ptr().cast(),
+                    bytes as u32,
+                )
+            };
+            if status == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::from_raw_os_error(status as i32))
+            }
+        }
+    };
+    let close_status = unsafe { RegCloseKey(key) };
+    result.and(if close_status == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(close_status as i32))
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn configure_for(_mode: StartupMode, _executable: Option<&Path>) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "automatic startup is not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn desktop_entry_only_passes_the_minimize_flag_for_minimized_startup() {
+        use super::desktop_entry;
+        use crate::settings::StartupMode;
+        use std::path::Path;
+
+        let visible = desktop_entry(Path::new("/opt/Fastpotify/fastpotify"), StartupMode::Yes);
+        let minimized = desktop_entry(
+            Path::new("/opt/Fastpotify/fastpotify"),
+            StartupMode::Minimized,
+        );
+        assert!(!visible.contains("--start-minimized"));
+        assert!(minimized.contains("--start-minimized"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launch_agent_only_passes_the_minimize_flag_for_minimized_startup() {
+        use super::launch_agent;
+        use crate::settings::StartupMode;
+        use std::path::Path;
+
+        let visible = launch_agent(
+            Path::new("/Applications/Fastpotify.app/Contents/MacOS/fastpotify"),
+            StartupMode::Yes,
+        );
+        let minimized = launch_agent(
+            Path::new("/Applications/Fastpotify.app/Contents/MacOS/fastpotify"),
+            StartupMode::Minimized,
+        );
+        assert!(!visible.contains("--start-minimized"));
+        assert!(minimized.contains("--start-minimized"));
+    }
+}

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -5,7 +5,7 @@ use egui::{Align, CornerRadius, Frame, Layout, Margin, Stroke, Vec2};
 use crate::api::models::pick_image;
 use crate::app::App;
 use crate::model::{Action, Dialog};
-use crate::settings::ThemeChoice;
+use crate::settings::{StartupMode, ThemeChoice};
 use crate::theme::{self, Icon, Palette};
 
 use super::widgets;
@@ -324,6 +324,26 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     .changed()
                 {
                     changed = true;
+                }
+            },
+        );
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Automatic startup",
+            "Start Fastpotify when you sign in to your computer.",
+            |ui| {
+                let current = app.settings.automatic_startup;
+                let mut selected = current;
+                egui::ComboBox::from_id_salt("automatic-startup")
+                    .selected_text(current.label())
+                    .show_ui(ui, |ui| {
+                        for mode in StartupMode::ALL {
+                            ui.selectable_value(&mut selected, mode, mode.label());
+                        }
+                    });
+                if selected != current {
+                    app.actions.push(Action::SetAutomaticStartup(selected));
                 }
             },
         );


### PR DESCRIPTION
Setting to allow startup on user login. Default is "no"

## Why

Implements  #122 

## What changed

Added option to start Fastptofy on user login. There is a new dropdown in the settings that allows the user to choose to start the application, start minimized or not start at all. 

By default the option is "no". 

## Verification

Tested on Windows all three options. The application is correctly starting up and it is registered on the list of application on automatic startup in the Task Manager.

<img width="740" height="646" alt="image" src="https://github.com/user-attachments/assets/26e6b608-87c8-412a-9847-2a55af531afb" />

<img width="938" height="711" alt="image" src="https://github.com/user-attachments/assets/9e85cf6e-52dc-49ba-b32b-c8c80cb7f003" />


- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
