### PR TITLE
Follow Omarchy colors and fonts on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ everyday use, and connection details.
   starts.
 - **Album-art colour.** Pages and the player bar take a tint from the cover
   of what you are looking at or listening to. Turn it off in Settings.
-- **Light and dark**, or follow the system.
+- **Light and dark**, follow the system, or follow the active Omarchy palette
+  on Linux.
 - **Winamp mini player.** `Ctrl+M` opens a small player for classic `.wsz`
   skins, drawn at 1x to 4x scale. It includes a spectrum analyser, playlist,
-  and equalizer. Drop a skin from the
+  and equalizer. The built-in skin follows the app palette, including live
+  Omarchy theme changes. Drop a skin from the
   [Winamp Skin Museum](https://skins.webamp.org) on either window to add it.
 
   ![The mini player wearing the built-in skin](docs/assets/images/winamp.png)
@@ -245,7 +247,9 @@ Settings live in one readable JSON file (`~/.config/fastpotify/settings.json`
 on Linux). They include the Connect device name, bitrate, normalisation,
 autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
-from artwork, and the mini player's skin and size.
+from artwork, and the mini player's skin and size. On Omarchy, choosing the
+**Omarchy** theme follows the active desktop palette, including theme changes
+made while Fastpotify is open.
 Playback settings apply when you press **Apply and restart playback**.
 
 Caches (audio, artwork) live under the cache directory and can be deleted at

--- a/docs/_guide/what-is-fastpotify.md
+++ b/docs/_guide/what-is-fastpotify.md
@@ -36,8 +36,8 @@ cannot play music through Fastpotify on this computer or another device.
   episodes, with artist pages, discographies, and related artists.
 - **Background playback.** Closing the window keeps the music playing from
   the system tray. On Linux, MPRIS supports media keys and `playerctl`.
-- **Themes.** Use light, dark, or system mode. Pages can take a colour from
-  album art.
+- **Themes.** Use light, dark, system mode, or the active Omarchy palette on
+  Linux. Pages can take a colour from album art.
 
 ## What it does not do
 

--- a/docs/_guide/winamp.md
+++ b/docs/_guide/winamp.md
@@ -16,7 +16,9 @@ the shortcut again, to return to the main window.
 ## Skins and window size
 
 Drop a `.wsz` file on either window to install and use it. Settings lists the
-installed skins and can open the skins folder.
+installed skins and can open the skins folder. The built-in Fastpotify skin
+follows the selected app palette, including Omarchy theme changes while the
+mini player is open. Installed classic skins retain their original artwork.
 
 The mini player uses whole-number scaling to keep pixels sharp. Right-click
 the title bar, or click **O**, to choose 1x to 4x and set always-on-top. **D**

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -61,12 +61,12 @@ main fields are:
 | `gapless` | `true` | Gapless playback |
 | `audio_backend` | platform | `pulseaudio` or `rodio` on Linux |
 | `audio_cache_mb` | `1024` | On-disk audio cache budget |
-| `theme` | `dark` | `dark`, `light`, or `system` |
+| `theme` | `dark` | `dark`, `light`, `system`, or `omarchy` |
 | `accent_from_art` | `true` | Tint pages with album art |
 | `sidebar_compact` | `false` | Names only in the library sidebar, no covers |
 | `tracklist_compact` | `false` | One-line track rows without covers |
 | `winamp_window` | `false` | The window is the Winamp mini player |
-| `skin` | none | File or folder name in the skins folder; blank uses the built-in skin |
+| `skin` | none | File or folder name in the skins folder; blank uses the palette-aware built-in skin |
 | `skin_scale` | by display | Screen pixels per skin pixel, 1 to 4 |
 | `winamp_on_top` | `false` | Keep the mini player above other windows |
 | `vis` | `bars` | The mini player's visualiser: `bars`, `scope`, or `off` |
@@ -90,6 +90,17 @@ main fields are:
 | `check_for_updates` | `true` | Ask GitHub once a day for a newer release |
 | `web_client_id` | none | Optional personal Spotify app id used alongside shared coverage |
 | `personal_app_nudge_at` | none | Last slow-Spotify personal-app reminder, so it appears at most once a day |
+
+On Linux, the **Omarchy** choice appears when Fastpotify finds Omarchy's
+resolved palette at `~/.local/state/omarchy/current/theme/colors.toml`.
+Fastpotify only reads this file and follows changes to it while the window is
+open. Older themes whose generated palette does not declare light or dark mode
+are classified from their background color. Fastpotify also reads the font
+selected in Omarchy's user Fontconfig file, resolves its closest installed
+medium, semibold, and bold faces, and follows
+`omarchy font set` changes. Bundled Inter remains the fallback if that font
+cannot be resolved. Fastpotify does not install a theme hook or change
+Omarchy's configuration.
 
 ## Command line
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,6 +157,12 @@ struct Listening {
     recorded: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AppliedInterfaceFont {
+    Bundled,
+    Omarchy(u64),
+}
+
 pub struct App {
     pub dirs: AppDirs,
     pub settings: Settings,
@@ -193,7 +199,13 @@ pub struct App {
     /// Sample data is loaded; Spotify requests are disabled.
     pub offline: bool,
     pub palette: Palette,
-    applied_dark: Option<bool>,
+    applied_palette: Option<Palette>,
+    pub omarchy_theme_available: bool,
+    omarchy_palette: Option<Palette>,
+    omarchy_font: Option<theme::InterfaceFont>,
+    omarchy_font_revision: u64,
+    applied_interface_font: Option<AppliedInterfaceFont>,
+    omarchy_watcher: Option<crate::omarchy::ThemeWatcher>,
 
     pub auth: AuthStatus,
     pub user: Option<User>,
@@ -428,6 +440,14 @@ const GLIDE_DECAY: f32 = 0.35;
 const GLIDE_START: f32 = 120.0;
 const GLIDE_STOP: f32 = 40.0;
 
+fn theme_preference(choice: ThemeChoice) -> egui::ThemePreference {
+    match choice {
+        ThemeChoice::Dark => egui::ThemePreference::Dark,
+        ThemeChoice::Light => egui::ThemePreference::Light,
+        ThemeChoice::System | ThemeChoice::Omarchy => egui::ThemePreference::System,
+    }
+}
+
 impl App {
     pub fn new(waker: &Waker, dirs: AppDirs, settings: Settings, options: AppOptions) -> Self {
         let plays = crate::history::History::load(&dirs.history_file());
@@ -476,6 +496,30 @@ impl App {
             .filter(|page| !matches!(page, Page::Settings | Page::Queue))
             .unwrap_or(Page::Home);
 
+        let omarchy_palette = crate::omarchy::load_palette();
+        if settings.theme == ThemeChoice::Omarchy
+            && let Err(error) = &omarchy_palette
+        {
+            log::warn!("unable to load the selected Omarchy theme: {error}");
+        }
+        let omarchy_theme_available = omarchy_palette.is_ok();
+        let omarchy_palette = omarchy_palette.ok();
+        let omarchy_font = if settings.theme == ThemeChoice::Omarchy {
+            match crate::omarchy::load_font() {
+                Ok(font) => {
+                    log::info!("using Omarchy interface font {}", font.family);
+                    Some(font)
+                }
+                Err(error) => {
+                    log::warn!("unable to load the selected Omarchy font: {error}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let omarchy_font_revision = u64::from(omarchy_font.is_some());
+
         let mut app = Self {
             dirs,
             settings,
@@ -495,7 +539,13 @@ impl App {
             control_devices_stale: true,
             offline: false,
             palette: Palette::dark(),
-            applied_dark: None,
+            applied_palette: None,
+            omarchy_theme_available,
+            omarchy_palette,
+            omarchy_font,
+            omarchy_font_revision,
+            applied_interface_font: None,
+            omarchy_watcher: None,
             auth: AuthStatus::Starting,
             user: None,
             local_device_id: None,
@@ -649,14 +699,22 @@ impl App {
     /// Per-window setup: fonts, icons, loaders, theme. Called every time a
     /// window is (re)created around this long-lived application state.
     pub fn attach(&mut self, ctx: &egui::Context) {
-        theme::install(ctx);
+        let applied_font =
+            if self.settings.theme == ThemeChoice::Omarchy && self.omarchy_font.is_some() {
+                AppliedInterfaceFont::Omarchy(self.omarchy_font_revision)
+            } else {
+                AppliedInterfaceFont::Bundled
+            };
+        let font = match applied_font {
+            AppliedInterfaceFont::Bundled => None,
+            AppliedInterfaceFont::Omarchy(_) => self.omarchy_font.as_ref(),
+        };
+        theme::install_with_font(ctx, font);
+        self.applied_interface_font = Some(applied_font);
         ctx.add_bytes_loader(std::sync::Arc::new(self.backend.art().clone()));
-        ctx.set_theme(match self.settings.theme {
-            ThemeChoice::Dark => egui::ThemePreference::Dark,
-            ThemeChoice::Light => egui::ThemePreference::Light,
-            ThemeChoice::System => egui::ThemePreference::System,
-        });
-        self.applied_dark = None;
+        ctx.set_theme(theme_preference(self.settings.theme));
+        self.applied_palette = None;
+        self.omarchy_watcher = None;
         self.winamp.forget_textures();
         self.window_hidden = false;
         self.hide_intent = false;
@@ -709,6 +767,7 @@ impl App {
         self.window_hidden = true;
         self.hide_intent = false;
         self.wants_show = false;
+        self.omarchy_watcher = None;
         if let Some(tray) = &mut self.tray {
             tray.hidden();
         }
@@ -1764,7 +1823,7 @@ impl App {
             && self.winamp.worn != self.settings.skin
         {
             match self.settings.skin.clone() {
-                None => self.winamp.wear(None, crate::skin::Skin::builtin()),
+                None => self.refresh_builtin_skin(),
                 Some(name) => self.winamp.load(name, &self.dirs.skins_dir(), ctx),
             }
         }
@@ -1942,18 +2001,89 @@ impl App {
     }
 
     fn apply_theme(&mut self, ctx: &egui::Context) {
+        self.sync_omarchy_theme(ctx);
+        self.apply_interface_font(ctx);
         let dark = ctx.theme() == egui::Theme::Dark;
-        if self.applied_dark != Some(dark) {
-            self.palette = if dark {
-                Palette::dark()
-            } else {
-                Palette::light()
-            };
+        let palette = if self.settings.theme == ThemeChoice::Omarchy {
+            self.omarchy_palette.unwrap_or_else(|| {
+                if dark {
+                    Palette::dark()
+                } else {
+                    Palette::light()
+                }
+            })
+        } else if dark {
+            Palette::dark()
+        } else {
+            Palette::light()
+        };
+        if self.applied_palette != Some(palette) {
+            self.palette = palette;
             theme::apply(ctx, &self.palette);
-            self.applied_dark = Some(dark);
+            self.refresh_builtin_skin();
+            self.applied_palette = Some(palette);
             self.accents.clear();
             self.accent_pending.clear();
         }
+    }
+
+    fn refresh_builtin_skin(&mut self) {
+        if self.settings.skin.is_none() {
+            self.winamp
+                .wear(None, crate::skin::Skin::builtin_for(&self.palette));
+        }
+    }
+
+    fn sync_omarchy_theme(&mut self, ctx: &egui::Context) {
+        if self.settings.theme != ThemeChoice::Omarchy {
+            self.omarchy_watcher = None;
+            return;
+        }
+        if self.omarchy_watcher.is_none() {
+            self.omarchy_watcher = crate::omarchy::ThemeWatcher::spawn(ctx.clone());
+        }
+        let update = self
+            .omarchy_watcher
+            .as_ref()
+            .and_then(crate::omarchy::ThemeWatcher::latest_palette);
+        match update {
+            Some(Ok(palette)) => {
+                self.omarchy_theme_available = true;
+                self.omarchy_palette = Some(palette);
+            }
+            Some(Err(error)) => log::warn!("unable to update the Omarchy theme: {error}"),
+            None => {}
+        }
+        let font_update = self
+            .omarchy_watcher
+            .as_ref()
+            .and_then(crate::omarchy::ThemeWatcher::latest_font);
+        match font_update {
+            Some(Ok(font)) => {
+                log::info!("using Omarchy interface font {}", font.family);
+                self.omarchy_font = Some(font);
+                self.omarchy_font_revision = self.omarchy_font_revision.wrapping_add(1).max(1);
+            }
+            Some(Err(error)) => log::warn!("unable to update the Omarchy font: {error}"),
+            None => {}
+        }
+    }
+
+    fn apply_interface_font(&mut self, ctx: &egui::Context) {
+        let wanted = if self.settings.theme == ThemeChoice::Omarchy && self.omarchy_font.is_some() {
+            AppliedInterfaceFont::Omarchy(self.omarchy_font_revision)
+        } else {
+            AppliedInterfaceFont::Bundled
+        };
+        if self.applied_interface_font == Some(wanted) {
+            return;
+        }
+        let font = match wanted {
+            AppliedInterfaceFont::Bundled => None,
+            AppliedInterfaceFont::Omarchy(_) => self.omarchy_font.as_ref(),
+        };
+        theme::apply_interface_font(ctx, font);
+        self.applied_interface_font = Some(wanted);
     }
 
     fn handle_tray(&mut self) {
@@ -5291,11 +5421,9 @@ impl App {
             }
             Action::SettingsChanged => {
                 self.settings_dirty = true;
-                ctx.set_theme(match self.settings.theme {
-                    ThemeChoice::Dark => egui::ThemePreference::Dark,
-                    ThemeChoice::Light => egui::ThemePreference::Light,
-                    ThemeChoice::System => egui::ThemePreference::System,
-                });
+                ctx.set_theme(theme_preference(self.settings.theme));
+                self.applied_palette = None;
+                ctx.request_repaint();
             }
             Action::RestartEngine => {
                 self.save_settings();
@@ -8511,6 +8639,26 @@ mod tests {
         });
         assert_eq!(app.winamp.worn.as_deref(), Some("A.wsz"));
         assert_eq!(app.settings.skin.as_deref(), Some("B.wsz"));
+    }
+
+    #[test]
+    fn palette_changes_recolour_only_the_built_in_skin() {
+        let mut app = headless_app();
+        app.settings.skin = None;
+        app.palette = Palette::light();
+        app.refresh_builtin_skin();
+        assert_eq!(
+            app.winamp.skin.sheet(crate::skin::Sheet::Main).pixel(1, 1),
+            Some([0xff, 0xff, 0xff, 0xff])
+        );
+
+        let custom = std::sync::Arc::new(some_skin("Custom"));
+        app.winamp
+            .wear(Some("Custom.wsz".into()), std::sync::Arc::clone(&custom));
+        app.settings.skin = Some("Custom.wsz".into());
+        app.palette = Palette::dark();
+        app.refresh_builtin_skin();
+        assert!(std::sync::Arc::ptr_eq(&app.winamp.skin, &custom));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,11 @@ pub mod media_controls;
 pub mod media_controls;
 pub mod milkdrop;
 pub mod model;
+#[cfg(target_os = "linux")]
+pub mod omarchy;
+#[cfg(not(target_os = "linux"))]
+#[path = "omarchy_stub.rs"]
+pub mod omarchy;
 pub mod opener;
 pub mod paths;
 pub mod player;

--- a/src/omarchy.rs
+++ b/src/omarchy.rs
@@ -1,0 +1,528 @@
+//! Omarchy desktop theme integration.
+//!
+//! Omarchy resolves the active theme into one small palette file. Reading it
+//! keeps Fastpotify independent of individual theme repositories and watching
+//! it means `omarchy theme set` can retint an open window without a hook.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver};
+use std::time::Duration;
+
+use egui::Color32;
+
+use crate::theme::{FontFace, InterfaceFont, Palette};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The active, fully resolved Omarchy palette.
+fn theme_path() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|dirs| {
+        dirs.home_dir()
+            .join(".local/state/omarchy/current/theme/colors.toml")
+    })
+}
+
+/// Omarchy writes its selected interface font here. Reading the declared
+/// family directly avoids a package-owned Fontconfig default masking the
+/// later user rule, while watching it still catches `omarchy font set`
+/// without requiring an application-specific hook.
+fn fontconfig_path() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|dirs| dirs.home_dir().join(".config/fontconfig/fonts.conf"))
+}
+
+/// Reads the active Omarchy palette once.
+pub(crate) fn load_palette() -> Result<Palette, String> {
+    let path =
+        theme_path().ok_or_else(|| "Omarchy themes are only available on Linux".to_string())?;
+    let source = std::fs::read_to_string(&path)
+        .map_err(|error| format!("unable to read {}: {error}", path.display()))?;
+    parse_palette(&source).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+/// Resolves the active Omarchy font through Fontconfig, including the closest
+/// installed face for each weight Fastpotify uses.
+pub(crate) fn load_font() -> Result<InterfaceFont, String> {
+    let path =
+        fontconfig_path().ok_or_else(|| "Omarchy fonts are only available on Linux".to_string())?;
+    let source = std::fs::read_to_string(&path)
+        .map_err(|error| format!("unable to read {}: {error}", path.display()))?;
+    load_font_source(&source).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn load_font_source(source: &str) -> Result<InterfaceFont, String> {
+    let configured_family = parse_font_family(source)?;
+    let regular = match_font(&configured_family, 80)?;
+    let medium = match_font(&configured_family, 100)?;
+    let semibold = match_font(&configured_family, 180)?;
+    let bold = match_font(&configured_family, 200)?;
+    let family = regular.family.clone();
+    let mut files = HashMap::new();
+    Ok(InterfaceFont {
+        family,
+        regular: read_face(regular, &mut files)?,
+        medium: read_face(medium, &mut files)?,
+        semibold: read_face(semibold, &mut files)?,
+        bold: read_face(bold, &mut files)?,
+    })
+}
+
+struct MatchedFont {
+    family: String,
+    path: PathBuf,
+    index: u32,
+}
+
+fn match_font(family: &str, weight: u16) -> Result<MatchedFont, String> {
+    let pattern = format!("{family}:weight={weight}");
+    let output = Command::new("fc-match")
+        .args(["-f", "%{family[0]}\n%{file}\n%{index}\n", &pattern])
+        .output()
+        .map_err(|error| format!("unable to run fc-match: {error}"))?;
+    if !output.status.success() {
+        return Err(format!("fc-match exited with {}", output.status));
+    }
+    parse_font_match(&output.stdout)
+}
+
+fn parse_font_family(source: &str) -> Result<String, String> {
+    let (_, after_monospace) = source
+        .split_once("<string>monospace</string>")
+        .ok_or_else(|| "missing the monospace font rule".to_string())?;
+    let edit_start = after_monospace
+        .find("<edit")
+        .ok_or_else(|| "missing the monospace family edit".to_string())?;
+    let edit = &after_monospace[edit_start..];
+    let edit_end = edit
+        .find("</edit>")
+        .ok_or_else(|| "incomplete monospace family edit".to_string())?;
+    let edit = &edit[..edit_end];
+    let (_, family) = edit
+        .split_once("<string>")
+        .ok_or_else(|| "missing the selected font family".to_string())?;
+    let (family, _) = family
+        .split_once("</string>")
+        .ok_or_else(|| "incomplete selected font family".to_string())?;
+    let family = family.trim();
+    if family.is_empty() {
+        return Err("selected font family is empty".to_string());
+    }
+    Ok(family.to_string())
+}
+
+fn parse_font_match(output: &[u8]) -> Result<MatchedFont, String> {
+    let output = std::str::from_utf8(output)
+        .map_err(|error| format!("fc-match returned invalid UTF-8: {error}"))?;
+    let mut lines = output.lines();
+    let family = lines.next().unwrap_or_default().trim();
+    let path = lines.next().unwrap_or_default().trim();
+    let index = lines.next().unwrap_or_default().trim();
+    if family.is_empty() || path.is_empty() || index.is_empty() {
+        return Err("fc-match returned an incomplete font description".to_string());
+    }
+    let index = index
+        .parse()
+        .map_err(|error| format!("fc-match returned an invalid face index: {error}"))?;
+    Ok(MatchedFont {
+        family: family.to_string(),
+        path: PathBuf::from(path),
+        index,
+    })
+}
+
+fn read_face(
+    matched: MatchedFont,
+    files: &mut HashMap<PathBuf, Arc<[u8]>>,
+) -> Result<FontFace, String> {
+    let bytes = if let Some(bytes) = files.get(&matched.path) {
+        Arc::clone(bytes)
+    } else {
+        let bytes: Arc<[u8]> = std::fs::read(&matched.path)
+            .map_err(|error| format!("unable to read {}: {error}", matched.path.display()))?
+            .into();
+        files.insert(matched.path.clone(), Arc::clone(&bytes));
+        bytes
+    };
+    Ok(FontFace {
+        bytes,
+        index: matched.index,
+    })
+}
+
+/// Background reader for changes to Omarchy's theme and Fontconfig state.
+pub(crate) struct ThemeWatcher {
+    palette_updates: Receiver<Result<Palette, String>>,
+    font_updates: Receiver<Result<InterfaceFont, String>>,
+    stop: Arc<AtomicBool>,
+}
+
+impl ThemeWatcher {
+    pub(crate) fn spawn(ctx: egui::Context) -> Option<Self> {
+        let path = theme_path()?;
+        Some(Self::spawn_at(path, fontconfig_path(), ctx, POLL_INTERVAL))
+    }
+
+    fn spawn_at(
+        path: PathBuf,
+        font_path: Option<PathBuf>,
+        ctx: egui::Context,
+        interval: Duration,
+    ) -> Self {
+        let (palette_send, palette_updates) = mpsc::channel();
+        let (font_send, font_updates) = mpsc::channel();
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut last_source = None;
+            let mut last_font_source = None;
+            while !thread_stop.load(Ordering::Relaxed) {
+                let read = std::fs::read_to_string(&path);
+                let source_key = match &read {
+                    Ok(source) => source.clone(),
+                    Err(error) => format!("read-error:{:?}:{error}", error.kind()),
+                };
+                if last_source.as_ref() != Some(&source_key) {
+                    last_source = Some(source_key);
+                    let update = read
+                        .map_err(|error| format!("unable to read {}: {error}", path.display()))
+                        .and_then(|source| {
+                            parse_palette(&source)
+                                .map_err(|error| format!("{}: {error}", path.display()))
+                        });
+                    if palette_send.send(update).is_err() {
+                        return;
+                    }
+                    ctx.request_repaint();
+                }
+                if let Some(font_path) = &font_path {
+                    let read = std::fs::read_to_string(font_path);
+                    let source_key = match &read {
+                        Ok(source) => source.clone(),
+                        Err(error) => format!("read-error:{:?}:{error}", error.kind()),
+                    };
+                    if last_font_source.as_ref() != Some(&source_key) {
+                        last_font_source = Some(source_key);
+                        let update = read
+                            .map_err(|error| {
+                                format!("unable to read {}: {error}", font_path.display())
+                            })
+                            .and_then(|source| {
+                                load_font_source(&source)
+                                    .map_err(|error| format!("{}: {error}", font_path.display()))
+                            });
+                        if font_send.send(update).is_err() {
+                            return;
+                        }
+                        ctx.request_repaint();
+                    }
+                }
+                std::thread::sleep(interval);
+            }
+        });
+        Self {
+            palette_updates,
+            font_updates,
+            stop,
+        }
+    }
+
+    /// Returns only the newest update when several theme changes arrived
+    /// between frames.
+    pub(crate) fn latest_palette(&self) -> Option<Result<Palette, String>> {
+        let mut latest = None;
+        while let Ok(update) = self.palette_updates.try_recv() {
+            latest = Some(update);
+        }
+        latest
+    }
+
+    /// Returns only the newest font update when several changes arrived
+    /// between frames.
+    pub(crate) fn latest_font(&self) -> Option<Result<InterfaceFont, String>> {
+        let mut latest = None;
+        while let Ok(update) = self.font_updates.try_recv() {
+            latest = Some(update);
+        }
+        latest
+    }
+}
+
+impl Drop for ThemeWatcher {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+fn parse_palette(source: &str) -> Result<Palette, String> {
+    let values: HashMap<_, _> = source
+        .lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once('=')?;
+            let key = key.trim();
+            let value = quoted(value.trim())?;
+            Some((key, value))
+        })
+        .collect();
+
+    let background = required_color(&values, "background")?;
+    let dark = match values.get("mode").copied() {
+        Some("dark") => true,
+        Some("light") => false,
+        Some(other) => return Err(format!("unsupported mode {other:?}")),
+        None => relative_luminance(background) < 0.5,
+    };
+    let foreground = required_color(&values, "foreground")?;
+    let accent = required_color(&values, "accent")?;
+    let selection =
+        optional_color(&values, "selection")?.unwrap_or_else(|| mix(background, foreground, 0.16));
+    let muted =
+        optional_color(&values, "muted")?.unwrap_or_else(|| mix(background, foreground, 0.24));
+    let panel = optional_color(&values, "dark_background")?.unwrap_or(background);
+    let surface = optional_color(&values, "lighter_background")?
+        .unwrap_or_else(|| mix(background, foreground, 0.08));
+    let text = optional_color(&values, "bright_foreground")?.unwrap_or(foreground);
+    let secondary = optional_color(&values, "light_foreground")?.unwrap_or(foreground);
+    let dim = optional_color(&values, "dark_foreground")?.unwrap_or(muted);
+
+    Ok(Palette {
+        dark,
+        window: background,
+        panel,
+        surface,
+        surface_hover: selection,
+        surface_active: muted,
+        outline: selection,
+        text,
+        secondary,
+        dim,
+        accent,
+        accent_hover: mix(
+            accent,
+            if dark { Color32::WHITE } else { Color32::BLACK },
+            0.16,
+        ),
+        on_accent: contrasting_text(accent),
+        danger: optional_color(&values, "red")?.unwrap_or(accent),
+        warning: optional_color(&values, "yellow")?.unwrap_or(accent),
+        overlay: surface,
+        shadow: Color32::from_black_alpha(if dark { 140 } else { 50 }),
+    })
+}
+
+fn quoted(value: &str) -> Option<&str> {
+    let value = value.strip_prefix('"')?;
+    Some(&value[..value.find('"')?])
+}
+
+fn required<'a>(values: &HashMap<&str, &'a str>, key: &str) -> Result<&'a str, String> {
+    values
+        .get(key)
+        .copied()
+        .ok_or_else(|| format!("missing {key:?}"))
+}
+
+fn required_color(values: &HashMap<&str, &str>, key: &str) -> Result<Color32, String> {
+    parse_color(required(values, key)?).map_err(|()| format!("invalid color for {key:?}"))
+}
+
+fn optional_color(values: &HashMap<&str, &str>, key: &str) -> Result<Option<Color32>, String> {
+    values
+        .get(key)
+        .map(|value| parse_color(value).map_err(|()| format!("invalid color for {key:?}")))
+        .transpose()
+}
+
+fn parse_color(value: &str) -> Result<Color32, ()> {
+    let hex = value.strip_prefix('#').ok_or(())?;
+    if hex.len() != 6 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(());
+    }
+    let channel = |offset| u8::from_str_radix(&hex[offset..offset + 2], 16).map_err(|_| ());
+    Ok(Color32::from_rgb(channel(0)?, channel(2)?, channel(4)?))
+}
+
+fn mix(from: Color32, to: Color32, amount: f32) -> Color32 {
+    let channel = |from: u8, to: u8| {
+        (f32::from(from) * (1.0 - amount) + f32::from(to) * amount).round() as u8
+    };
+    Color32::from_rgb(
+        channel(from.r(), to.r()),
+        channel(from.g(), to.g()),
+        channel(from.b(), to.b()),
+    )
+}
+
+fn contrasting_text(background: Color32) -> Color32 {
+    let luminance = relative_luminance(background);
+    let black_contrast = (luminance + 0.05) / 0.05;
+    let white_contrast = 1.05 / (luminance + 0.05);
+    if black_contrast >= white_contrast {
+        Color32::BLACK
+    } else {
+        Color32::WHITE
+    }
+}
+
+fn relative_luminance(color: Color32) -> f32 {
+    let linear = |channel: u8| {
+        let channel = f32::from(channel) / 255.0;
+        if channel <= 0.04045 {
+            channel / 12.92
+        } else {
+            ((channel + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    0.2126 * linear(color.r()) + 0.7152 * linear(color.g()) + 0.0722 * linear(color.b())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKYO_NIGHT: &str = r##"
+mode = "dark"
+accent = "#7aa2f7"
+selection = "#292e42"
+muted = "#414868"
+background = "#1a1b26"
+dark_background = "#13141c"
+lighter_background = "#24283b"
+foreground = "#a9b1d6"
+dark_foreground = "#565f89"
+light_foreground = "#b4bee6"
+bright_foreground = "#c0caf5"
+red = "#f7768e"
+yellow = "#e0af68"
+"##;
+
+    #[test]
+    fn maps_omarchy_tokens_to_fastpotify_surfaces() {
+        let palette = parse_palette(TOKYO_NIGHT).unwrap();
+        assert!(palette.dark);
+        assert_eq!(palette.window, Color32::from_rgb(0x1a, 0x1b, 0x26));
+        assert_eq!(palette.panel, Color32::from_rgb(0x13, 0x14, 0x1c));
+        assert_eq!(palette.surface, Color32::from_rgb(0x24, 0x28, 0x3b));
+        assert_eq!(palette.surface_hover, Color32::from_rgb(0x29, 0x2e, 0x42));
+        assert_eq!(palette.text, Color32::from_rgb(0xc0, 0xca, 0xf5));
+        assert_eq!(palette.accent, Color32::from_rgb(0x7a, 0xa2, 0xf7));
+        assert_eq!(palette.on_accent, Color32::BLACK);
+        assert_eq!(palette.danger, Color32::from_rgb(0xf7, 0x76, 0x8e));
+    }
+
+    #[test]
+    fn accepts_a_minimal_light_palette_and_derives_optional_surfaces() {
+        let palette = parse_palette(
+            r##"mode = "light"
+accent = "#205ea6"
+background = "#fffcf0"
+foreground = "#100f0f"
+"##,
+        )
+        .unwrap();
+        assert!(!palette.dark);
+        assert_eq!(palette.panel, palette.window);
+        assert_ne!(palette.surface, palette.window);
+        assert_eq!(palette.danger, palette.accent);
+        assert_eq!(palette.on_accent, Color32::WHITE);
+    }
+
+    #[test]
+    fn infers_legacy_palette_mode_from_its_background() {
+        let mars = parse_palette(
+            r##"accent = "#7b534e"
+selection = "#4a2c2c"
+background = "#000000"
+foreground = "#d9afa7"
+"##,
+        )
+        .unwrap();
+        assert!(mars.dark);
+
+        let light = parse_palette(
+            r##"accent = "#205ea6"
+background = "#fffcf0"
+foreground = "#100f0f"
+"##,
+        )
+        .unwrap();
+        assert!(!light.dark);
+    }
+
+    #[test]
+    fn rejects_unknown_modes_and_malformed_colors() {
+        assert!(parse_palette(&TOKYO_NIGHT.replace("dark", "sepia")).is_err());
+        for color in ["blue", "#12345g", "#aé123"] {
+            assert!(parse_palette(&TOKYO_NIGHT.replace("#7aa2f7", color)).is_err());
+        }
+    }
+
+    #[test]
+    fn parses_fontconfig_face_descriptions() {
+        let matched = parse_font_match(
+            b"JetBrainsMono Nerd Font\n/usr/share/fonts/TTF/JetBrainsMono-Regular.ttf\n2\n",
+        )
+        .unwrap();
+        assert_eq!(matched.family, "JetBrainsMono Nerd Font");
+        assert_eq!(
+            matched.path,
+            PathBuf::from("/usr/share/fonts/TTF/JetBrainsMono-Regular.ttf")
+        );
+        assert_eq!(matched.index, 2);
+        assert!(parse_font_match(b"missing fields\n").is_err());
+    }
+
+    #[test]
+    fn reads_the_family_declared_by_omarchy_instead_of_a_masked_alias() {
+        let source = r#"<?xml version="1.0"?>
+<fontconfig>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend_first" binding="strong">
+      <string>Liberation Mono</string>
+    </edit>
+  </match>
+</fontconfig>"#;
+        assert_eq!(parse_font_family(source).unwrap(), "Liberation Mono");
+        assert!(parse_font_family("<fontconfig/>").is_err());
+    }
+
+    #[test]
+    fn watcher_publishes_palette_changes() {
+        let path = std::env::temp_dir().join(format!(
+            "fastpotify-omarchy-theme-{}-{}.toml",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::write(&path, TOKYO_NIGHT).unwrap();
+        let watcher = ThemeWatcher::spawn_at(
+            path.clone(),
+            None,
+            egui::Context::default(),
+            Duration::from_millis(10),
+        );
+
+        let wait_for = |dark| {
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            while std::time::Instant::now() < deadline {
+                if let Some(Ok(palette)) = watcher.latest_palette()
+                    && palette.dark == dark
+                {
+                    return true;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            false
+        };
+        assert!(wait_for(true));
+        std::fs::write(&path, TOKYO_NIGHT.replacen("dark", "light", 1)).unwrap();
+        assert!(wait_for(false));
+
+        drop(watcher);
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/omarchy_stub.rs
+++ b/src/omarchy_stub.rs
@@ -1,0 +1,27 @@
+//! No-op Omarchy theme integration for non-Linux platforms.
+
+use crate::theme::{InterfaceFont, Palette};
+
+pub(crate) fn load_palette() -> Result<Palette, String> {
+    Err("Omarchy themes are only available on Linux".to_string())
+}
+
+pub(crate) fn load_font() -> Result<InterfaceFont, String> {
+    Err("Omarchy fonts are only available on Linux".to_string())
+}
+
+pub(crate) struct ThemeWatcher;
+
+impl ThemeWatcher {
+    pub(crate) fn spawn(_ctx: egui::Context) -> Option<Self> {
+        None
+    }
+
+    pub(crate) fn latest_palette(&self) -> Option<Result<Palette, String>> {
+        None
+    }
+
+    pub(crate) fn latest_font(&self) -> Option<Result<InterfaceFont, String>> {
+        None
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,6 +11,7 @@ pub enum ThemeChoice {
     Dark,
     Light,
     System,
+    Omarchy,
 }
 
 /// Mini-player visualizer mode.
@@ -35,13 +36,14 @@ impl VisMode {
 }
 
 impl ThemeChoice {
-    pub const ALL: [ThemeChoice; 3] = [Self::Dark, Self::Light, Self::System];
+    pub const ALL: [ThemeChoice; 4] = [Self::Dark, Self::Light, Self::System, Self::Omarchy];
 
     pub fn label(self) -> &'static str {
         match self {
             Self::Dark => "Dark",
             Self::Light => "Light",
             Self::System => "Follow system",
+            Self::Omarchy => "Omarchy",
         }
     }
 }
@@ -270,7 +272,7 @@ impl Settings {
 
 #[cfg(test)]
 mod tests {
-    use super::Settings;
+    use super::{Settings, ThemeChoice};
 
     #[test]
     fn older_settings_keep_the_sidebar_visible() {
@@ -329,6 +331,18 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let restored: Settings = serde_json::from_str(&json).unwrap();
         assert!(!restored.sidebar_visible);
+    }
+
+    #[test]
+    fn an_omarchy_theme_choice_round_trips() {
+        let settings = Settings {
+            theme: ThemeChoice::Omarchy,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains(r#""theme":"omarchy""#));
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.theme, ThemeChoice::Omarchy);
     }
 
     #[test]

--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -17,8 +17,23 @@ use std::sync::{Arc, LazyLock};
 
 use thiserror::Error;
 
+use crate::theme::Palette;
+
 pub use config::{Mask, PlaylistStyle, Regions, Rgb, VisColors};
 pub use sprites::{Sheet, Sprite};
+
+const BUILTIN_WINDOW: Rgb = [0x0f, 0x11, 0x14];
+const BUILTIN_PANEL: Rgb = [0x15, 0x18, 0x1c];
+const BUILTIN_SURFACE: Rgb = [0x1d, 0x21, 0x27];
+const BUILTIN_SURFACE_HOVER: Rgb = [0x26, 0x2b, 0x33];
+const BUILTIN_SURFACE_ACTIVE: Rgb = [0x2f, 0x35, 0x3f];
+const BUILTIN_OUTLINE: Rgb = [0x2a, 0x30, 0x38];
+const BUILTIN_TEXT: Rgb = [0xf2, 0xf4, 0xf6];
+const BUILTIN_SECONDARY: Rgb = [0xa9, 0xb1, 0xbc];
+const BUILTIN_DIM: Rgb = [0x6e, 0x77, 0x84];
+const BUILTIN_ACCENT: Rgb = [0x1e, 0xd7, 0x60];
+const BUILTIN_ON_ACCENT: Rgb = [0x0a, 0x14, 0x0e];
+const BUILTIN_ACCENT_FADED: Rgb = [0x14, 0x4a, 0x2a];
 
 #[derive(Debug, Error)]
 pub enum SkinError {
@@ -200,6 +215,94 @@ impl Skin {
         BUILTIN.clone()
     }
 
+    /// The built-in skin recoloured to the active application palette.
+    /// Classic skins supplied by the listener remain exactly as authored.
+    pub fn builtin_for(palette: &Palette) -> Arc<Skin> {
+        if *palette == Palette::dark() {
+            return Self::builtin();
+        }
+
+        let target_window = rgb(palette.window);
+        let target_panel = rgb(palette.panel);
+        let target_surface = rgb(palette.surface);
+        let target_surface_hover = rgb(palette.surface_hover);
+        let target_surface_active = rgb(palette.surface_active);
+        let target_outline = rgb(palette.outline);
+        let target_text = rgb(palette.text);
+        let target_secondary = rgb(palette.secondary);
+        let target_dim = rgb(palette.dim);
+        let target_accent = rgb(palette.accent);
+        let target_on_accent = rgb(palette.on_accent);
+        let target_accent_faded = mix_rgb(target_window, target_accent, 0.3);
+        let mut replacements: HashMap<Rgb, Rgb> = [
+            (BUILTIN_WINDOW, target_window),
+            (BUILTIN_PANEL, target_panel),
+            (BUILTIN_SURFACE, target_surface),
+            (BUILTIN_SURFACE_HOVER, target_surface_hover),
+            (BUILTIN_SURFACE_ACTIVE, target_surface_active),
+            (BUILTIN_OUTLINE, target_outline),
+            (BUILTIN_TEXT, target_text),
+            (BUILTIN_SECONDARY, target_secondary),
+            (BUILTIN_DIM, target_dim),
+            (BUILTIN_ACCENT, target_accent),
+            (BUILTIN_ON_ACCENT, target_on_accent),
+            (BUILTIN_ACCENT_FADED, target_accent_faded),
+        ]
+        .into_iter()
+        .collect();
+        // The equalizer curve carries a nineteen-step accent gradient in its
+        // bitmap, so include every generated shade in the substitution map.
+        for step in 0..=18 {
+            let amount = step as f32 / 18.0;
+            replacements.insert(
+                mix_rgb(BUILTIN_ACCENT, BUILTIN_ACCENT_FADED, amount),
+                mix_rgb(target_accent, target_accent_faded, amount),
+            );
+        }
+
+        let sheets = BUILTIN
+            .sheets
+            .iter()
+            .map(|(sheet, bitmap)| {
+                let mut bitmap = bitmap.clone();
+                for pixel in bitmap.rgba.as_chunks_mut::<4>().0 {
+                    let color = [pixel[0], pixel[1], pixel[2]];
+                    if let Some(replacement) = replacements.get(&color) {
+                        pixel[..3].copy_from_slice(replacement);
+                    }
+                }
+                (*sheet, bitmap)
+            })
+            .collect();
+        let mut playlist = BUILTIN.playlist.clone();
+        playlist.normal = target_secondary;
+        playlist.current = target_accent;
+        playlist.normal_background = target_window;
+        playlist.selected_background = target_surface_active;
+        let mut vis_colors = BUILTIN.vis_colors;
+        vis_colors[0] = target_window;
+        vis_colors[1] = target_outline;
+        for (step, color) in vis_colors[2..18].iter_mut().enumerate() {
+            *color = mix_rgb(target_accent, target_accent_faded, step as f32 / 15.0);
+        }
+        vis_colors[18..23].copy_from_slice(&[
+            target_text,
+            target_secondary,
+            target_secondary,
+            target_dim,
+            target_dim,
+        ]);
+        vis_colors[23] = target_text;
+
+        Arc::new(Self {
+            name: BUILTIN.name.clone(),
+            sheets,
+            playlist,
+            vis_colors,
+            regions: BUILTIN.regions.clone(),
+        })
+    }
+
     /// Whether the skin brought this sheet itself.
     pub fn has(&self, sheet: Sheet) -> bool {
         self.sheets.contains_key(&sheet)
@@ -240,6 +343,17 @@ impl Skin {
         let clipped = sprite.clipped_to(bitmap.width, bitmap.height)?;
         Some((bitmap, clipped))
     }
+}
+
+fn rgb(color: egui::Color32) -> Rgb {
+    [color.r(), color.g(), color.b()]
+}
+
+fn mix_rgb(from: Rgb, to: Rgb, amount: f32) -> Rgb {
+    std::array::from_fn(|channel| {
+        (f32::from(from[channel]) + (f32::from(to[channel]) - f32::from(from[channel])) * amount)
+            .round() as u8
+    })
 }
 
 /// Whether a file inside a skin is one this reader looks at, so cursors,
@@ -325,6 +439,70 @@ mod tests {
         let a = text.crop(font::glyph('A')).unwrap();
         let blank = text.crop(font::glyph(' ')).unwrap();
         assert_ne!(a, blank);
+    }
+
+    #[test]
+    fn the_built_in_skin_follows_the_application_palette() {
+        let mut source_colors: std::collections::HashSet<Rgb> = [
+            BUILTIN_WINDOW,
+            BUILTIN_PANEL,
+            BUILTIN_SURFACE,
+            BUILTIN_SURFACE_HOVER,
+            BUILTIN_SURFACE_ACTIVE,
+            BUILTIN_OUTLINE,
+            BUILTIN_TEXT,
+            BUILTIN_SECONDARY,
+            BUILTIN_DIM,
+            BUILTIN_ACCENT,
+            BUILTIN_ON_ACCENT,
+            BUILTIN_ACCENT_FADED,
+        ]
+        .into_iter()
+        .collect();
+        for step in 0..=18 {
+            source_colors.insert(mix_rgb(
+                BUILTIN_ACCENT,
+                BUILTIN_ACCENT_FADED,
+                step as f32 / 18.0,
+            ));
+        }
+        for sheet in Sheet::ALL {
+            for pixel in Skin::builtin().sheet(sheet).rgba.as_chunks::<4>().0 {
+                assert!(
+                    source_colors.contains(&[pixel[0], pixel[1], pixel[2]]),
+                    "{} has an unmapped colour {pixel:?}",
+                    sheet.file_stem()
+                );
+            }
+        }
+
+        let palette = Palette::light();
+        let skin = Skin::builtin_for(&palette);
+        let color = |color: egui::Color32| [color.r(), color.g(), color.b()];
+
+        assert_eq!(
+            skin.sheet(Sheet::Main).pixel(1, 1),
+            Some([palette.panel.r(), palette.panel.g(), palette.panel.b(), 255])
+        );
+        assert_eq!(skin.playlist.normal, color(palette.secondary));
+        assert_eq!(skin.playlist.current, color(palette.accent));
+        assert_eq!(skin.playlist.normal_background, color(palette.window));
+        assert_eq!(
+            skin.playlist.selected_background,
+            color(palette.surface_active)
+        );
+        assert_eq!(skin.vis_colors[0], color(palette.window));
+        assert_eq!(skin.vis_colors[2], color(palette.accent));
+        assert_eq!(skin.vis_colors[23], color(palette.text));
+        for sheet in Sheet::ALL {
+            assert_eq!(
+                (skin.sheet(sheet).width, skin.sheet(sheet).height),
+                (
+                    Skin::builtin().sheet(sheet).width,
+                    Skin::builtin().sheet(sheet).height
+                )
+            );
+        }
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,10 +1,24 @@
 //! Shared palette, typography, icons, and base widgets.
 //!
-//! Inter provides real font weights, and Lucide provides a consistent icon set.
-//! All colors use [`Palette`] so light, dark, and album-art-tinted themes stay
-//! consistent.
+//! Bundled Inter provides the default font and fallback, while Omarchy can
+//! supply the active interface font on Linux. Lucide provides a consistent
+//! icon set. All colors use [`Palette`] so light, dark, and album-art-tinted
+//! themes stay consistent.
 
 use egui::{Color32, CornerRadius, Response, Sense, Stroke, Vec2};
+
+pub(crate) struct FontFace {
+    pub(crate) bytes: std::sync::Arc<[u8]>,
+    pub(crate) index: u32,
+}
+
+pub(crate) struct InterfaceFont {
+    pub(crate) family: String,
+    pub(crate) regular: FontFace,
+    pub(crate) medium: FontFace,
+    pub(crate) semibold: FontFace,
+    pub(crate) bold: FontFace,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Palette {
@@ -141,9 +155,17 @@ pub fn bold(size: f32) -> egui::FontId {
 
 /// Install fonts, icons, and the base style once.
 pub fn install(ctx: &egui::Context) {
-    install_fonts(ctx);
+    install_with_font(ctx, None);
+}
+
+pub(crate) fn install_with_font(ctx: &egui::Context, font: Option<&InterfaceFont>) {
+    install_fonts(ctx, font);
     register_icons(ctx);
     egui_extras::install_image_loaders(ctx);
+}
+
+pub(crate) fn apply_interface_font(ctx: &egui::Context, font: Option<&InterfaceFont>) {
+    install_fonts(ctx, font);
 }
 
 /// Applies the palette to egui's own widgets so dialogs, menus, and text
@@ -248,7 +270,7 @@ pub fn apply(ctx: &egui::Context, palette: &Palette) {
     ctx.set_global_style(style);
 }
 
-fn install_fonts(ctx: &egui::Context) {
+fn install_fonts(ctx: &egui::Context, interface_font: Option<&InterfaceFont>) {
     use egui::epaint::text::VariationCoords;
     use egui::{FontData, FontDefinitions, FontFamily};
     use std::sync::Arc;
@@ -271,6 +293,38 @@ fn install_fonts(ctx: &egui::Context) {
         .font_data
         .insert(INTER_BOLD.to_owned(), weighted(700.0));
 
+    let omarchy_face = |face: &FontFace, weight: f32| {
+        let mut data = FontData::from_owned(face.bytes.to_vec());
+        data.index = face.index;
+        data.tweak.coords = VariationCoords::new([(b"wght", weight)]);
+        Arc::new(data)
+    };
+    let (regular, medium, semibold, bold) = if let Some(font) = interface_font {
+        fonts.font_data.insert(
+            "omarchy-regular".to_owned(),
+            omarchy_face(&font.regular, 400.0),
+        );
+        fonts.font_data.insert(
+            "omarchy-medium".to_owned(),
+            omarchy_face(&font.medium, 500.0),
+        );
+        fonts.font_data.insert(
+            "omarchy-semibold".to_owned(),
+            omarchy_face(&font.semibold, 600.0),
+        );
+        fonts
+            .font_data
+            .insert("omarchy-bold".to_owned(), omarchy_face(&font.bold, 700.0));
+        (
+            "omarchy-regular",
+            "omarchy-medium",
+            "omarchy-semibold",
+            "omarchy-bold",
+        )
+    } else {
+        ("inter", INTER_MEDIUM, INTER_SEMIBOLD, INTER_BOLD)
+    };
+
     let noto_emoji = include_bytes!("../assets/fonts/NotoEmoji.ttf");
     fonts.font_data.insert(
         "noto_emoji".to_owned(),
@@ -281,27 +335,50 @@ fn install_fonts(ctx: &egui::Context) {
         .families
         .entry(FontFamily::Proportional)
         .or_default()
-        .insert(0, "inter".to_owned());
-    // Right behind the text face, ahead of the emoji subset and the icon
-    // font egui bundles, so every emoji comes from the one full face and
-    // wears the same style; egui's pair still serves what Noto lacks.
+        .insert(0, regular.to_owned());
+    if interface_font.is_some() {
+        fonts
+            .families
+            .entry(FontFamily::Proportional)
+            .or_default()
+            .insert(1, "inter".to_owned());
+        fonts
+            .families
+            .entry(FontFamily::Monospace)
+            .or_default()
+            .insert(0, regular.to_owned());
+    }
+    // Behind the interface and bundled fallback faces, ahead of the icon font
+    // egui bundles, so every emoji comes from the one full face and wears the
+    // same style; egui's pair still serves what Noto lacks.
     fonts
         .families
         .entry(FontFamily::Proportional)
         .or_default()
-        .insert(1, "noto_emoji".to_owned());
+        .insert(
+            if interface_font.is_some() { 2 } else { 1 },
+            "noto_emoji".to_owned(),
+        );
     fonts
         .families
         .entry(FontFamily::Monospace)
         .or_default()
         .insert(1, "noto_emoji".to_owned());
+    let fallback_offset = if interface_font.is_some() { 2 } else { 1 };
     let fallbacks: Vec<String> = fonts.families[&FontFamily::Proportional]
         .iter()
-        .skip(1)
+        .skip(fallback_offset)
         .cloned()
         .collect();
-    for name in [INTER_MEDIUM, INTER_SEMIBOLD, INTER_BOLD] {
-        let mut family = vec![name.to_owned()];
+    for (name, face, inter_fallback) in [
+        (INTER_MEDIUM, medium, INTER_MEDIUM),
+        (INTER_SEMIBOLD, semibold, INTER_SEMIBOLD),
+        (INTER_BOLD, bold, INTER_BOLD),
+    ] {
+        let mut family = vec![face.to_owned()];
+        if interface_font.is_some() {
+            family.push(inter_fallback.to_owned());
+        }
         family.extend(fallbacks.iter().cloned());
         fonts.families.insert(FontFamily::Name(name.into()), family);
     }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -446,27 +446,42 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         });
     });
 
+    let omarchy_theme_visible = cfg!(target_os = "linux")
+        && (app.omarchy_theme_available || app.settings.theme == ThemeChoice::Omarchy);
     section(ui, &palette, "Appearance", |ui| {
-        widgets::setting_row(ui, &palette, "Theme", "", |ui| {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                for choice in ThemeChoice::ALL {
-                    if theme::soft_button(
-                        ui,
-                        &palette,
-                        None,
-                        choice.label(),
-                        app.settings.theme == choice,
-                    )
-                    .clicked()
-                        && app.settings.theme != choice
-                    {
-                        app.settings.theme = choice;
-                        changed = true;
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Theme",
+            if omarchy_theme_visible {
+                "Omarchy follows the active desktop palette."
+            } else {
+                ""
+            },
+            |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 6.0;
+                    for choice in ThemeChoice::ALL {
+                        if choice == ThemeChoice::Omarchy && !omarchy_theme_visible {
+                            continue;
+                        }
+                        if theme::soft_button(
+                            ui,
+                            &palette,
+                            None,
+                            choice.label(),
+                            app.settings.theme == choice,
+                        )
+                        .clicked()
+                            && app.settings.theme != choice
+                        {
+                            app.settings.theme = choice;
+                            changed = true;
+                        }
                     }
-                }
-            });
-        });
+                });
+            },
+        );
         widgets::setting_row(
             ui,
             &palette,


### PR DESCRIPTION
## Visible changes

- Adds an opt-in **Omarchy** appearance choice on Linux. The main window follows the desktop palette and selected interface font, including changes made while Fastpotify is open.
- The built-in Winamp skin follows the app palette, including Light mode. Its playlist, equalizer, and visualizer use the same colors. User-installed `.wsz` skins remain unchanged.
- No controls or panels are moved. Dark, Light, and Follow system retain their existing main-window appearance.

## Why

Fastpotify can match an Omarchy desktop without maintaining a separate app theme or installing a theme-change hook.

This overlaps with the desktop-theming use case in #171. That PR proposes general custom schemes; this one reads Omarchy's existing palette and font selection directly.

## What changed

- Read the active palette and selected Fontconfig family, with a background reader for live updates.
- Support current and legacy palettes, plus safe fallbacks for missing or invalid input.
- Keep bundled fonts as fallbacks and isolate Omarchy integration to Linux.
- Add regression tests and document the new setting and file access. No new dependencies, network access, or changes to Omarchy configuration.

## Verification

Tested on Linux. Both test configurations pass 305 library tests and 3 executable tests. Windows and macOS were not tested locally.

```sh
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets
cargo test --locked --all-targets --all-features
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
(cd docs && bundle exec jekyll build)
```

All images below use the repository's demo fixtures, not a real account. The captures contain no textual or EXIF metadata and are hosted on a separate review-assets branch, outside this source diff.

<details>
<summary>Main window: before and after, dark and light</summary>

| Upstream | Omarchy |
| --- | --- |
| Dark, bundled font | Tokyo Night, JetBrainsMono Nerd Font |
| ![Before: Dark](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/before-dark-main.png) | ![After: Tokyo Night](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/after-tokyo-main.png) |
| Light, bundled font | Flexoki Light, Liberation Mono |
| ![Before: Light](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/before-light-main.png) | ![After: Flexoki Light](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/after-flexoki-main.png) |

</details>

<details>
<summary>Mini-player: original skin, Tokyo Night, and Flexoki Light</summary>

| Original | Tokyo Night | Flexoki Light |
| --- | --- | --- |
| ![Original mini-player](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/before-mini.png) | ![Tokyo Night mini-player](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/after-tokyo-mini.png) | ![Flexoki Light mini-player](https://raw.githubusercontent.com/derluke/fastpotify/bd0a84688fd235e0660bda808f623e4b7d8d1c68/after-flexoki-mini.png) |

</details>
