### PR TITLE
feat(nix): add darwin appbundle wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ vcpkg (`vcpkg install glew:x64-windows-static`, with
 With [Nix](https://nixos.org), `nix develop` provides all of it, along with
 the exact toolchain `rust-toolchain.toml` pins.
 
+On macOS, the flake also exposes `packages.<system>.fastpotify-app`, an
+ad-hoc signed `Fastpotify.app` bundle for the Dock, Launch Services, and
+`spotify:` links. With nix-darwin, add it to `environment.systemPackages`
+and link `"/Applications"` through `environment.pathsToLink`; with Home
+Manager, `home.packages` is enough, as its darwin support links the bundle
+into `~/Applications`.
+
 Fastpotify uses system fonts for scripts not covered by its interface font,
 including Chinese, Japanese, Korean, Arabic, Hebrew, Thai, and Indic scripts.
 macOS and Windows include common fonts. On Linux, install `noto-fonts` and

--- a/docs/_guide/download.md
+++ b/docs/_guide/download.md
@@ -55,37 +55,6 @@ later, allow it in Privacy & Security:
 
 Later launches work with a normal double-click.
 
-### Nix
-
-The repository [flake](https://github.com/crmne/fastpotify) can install the
-app instead of the download above. On macOS,
-`packages.<system>.fastpotify-app` is a `Fastpotify.app` bundle, ad-hoc
-signed and assembled like the release bundle. Nix builds it locally, so it
-is never quarantined and the first-open steps above do not apply.
-
-With nix-darwin, add the flake to your inputs and the bundle appears in
-`/Applications/Nix Apps`:
-
-```nix
-inputs.fastpotify.url = "github:crmne/fastpotify";
-```
-
-```nix
-environment.systemPackages = [
-  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".fastpotify-app
-];
-environment.pathsToLink = [ "/Applications" ];
-```
-
-With Home Manager, `home.packages` is enough; its darwin support links app
-bundles into `~/Applications`:
-
-```nix
-home.packages = [
-  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".fastpotify-app
-];
-```
-
 ## Windows
 
 The installer adds Fastpotify to the Start menu and needs no administrator
@@ -143,3 +112,43 @@ handling `spotify:` links.
 The binary needs ALSA, PulseAudio or PipeWire, and Wayland or X11.
 
 Or build from source: see [Getting Started](/getting-started/).
+
+## Nix
+
+Add the repository [flake](https://github.com/crmne/fastpotify) to your
+inputs:
+
+```nix
+inputs.fastpotify.url = "github:crmne/fastpotify";
+```
+
+On NixOS, install the default package:
+
+```nix
+environment.systemPackages = [
+  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".default
+];
+```
+
+### nix-darwin
+
+On macOS, use the `fastpotify-app` package instead. It is a `Fastpotify.app`
+bundle built and signed locally, so it is never quarantined and the
+first-open steps above do not apply:
+
+```nix
+environment.systemPackages = [
+  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".fastpotify-app
+];
+environment.pathsToLink = [ "/Applications" ];
+```
+
+The bundle appears in `/Applications/Nix Apps`. With Home Manager,
+`home.packages` is enough; its darwin support links app bundles into
+`~/Applications`:
+
+```nix
+home.packages = [
+  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".fastpotify-app
+];
+```

--- a/docs/_guide/download.md
+++ b/docs/_guide/download.md
@@ -63,8 +63,8 @@ app instead of the download above. On macOS,
 signed and assembled like the release bundle. Nix builds it locally, so it
 is never quarantined and the first-open steps above do not apply.
 
-With nix-darwin, add the flake to your inputs and put the bundle in
-`/Applications`:
+With nix-darwin, add the flake to your inputs and the bundle appears in
+`/Applications/Nix Apps`:
 
 ```nix
 inputs.fastpotify.url = "github:crmne/fastpotify";

--- a/docs/_guide/download.md
+++ b/docs/_guide/download.md
@@ -55,6 +55,37 @@ later, allow it in Privacy & Security:
 
 Later launches work with a normal double-click.
 
+### Nix
+
+The repository [flake](https://github.com/crmne/fastpotify) can install the
+app instead of the download above. On macOS,
+`packages.<system>.fastpotify-app` is a `Fastpotify.app` bundle, ad-hoc
+signed and assembled like the release bundle. Nix builds it locally, so it
+is never quarantined and the first-open steps above do not apply.
+
+With nix-darwin, add the flake to your inputs and put the bundle in
+`/Applications`:
+
+```nix
+inputs.fastpotify.url = "github:crmne/fastpotify";
+```
+
+```nix
+environment.systemPackages = [
+  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".fastpotify-app
+];
+environment.pathsToLink = [ "/Applications" ];
+```
+
+With Home Manager, `home.packages` is enough; its darwin support links app
+bundles into `~/Applications`:
+
+```nix
+home.packages = [
+  inputs.fastpotify.packages."${pkgs.stdenv.hostPlatform.system}".fastpotify-app
+];
+```
+
 ## Windows
 
 The installer adds Fastpotify to the Start menu and needs no administrator

--- a/flake.nix
+++ b/flake.nix
@@ -83,10 +83,10 @@
         };
       });
 
-      packages = forAllSystems (pkgs: rec {
-        default = fastpotify;
-        fastpotify =
-          let
+      packages = forAllSystems (
+        pkgs:
+        let
+          fastpotify = let
             toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
             rustPlatform = pkgs.makeRustPlatform {
               cargo = toolchain;
@@ -174,7 +174,43 @@
               mainProgram = "fastpotify";
             };
           };
-      });
+      
+          fastpotify-app =
+            let
+              version = pkgs.lib.getVersion fastpotify;
+              build = pkgs.lib.head (pkgs.lib.splitString "-" version);
+              icon = pkgs.runCommand "fastpotify-icon" {
+                nativeBuildInputs = [ pkgs.icnsify ];
+              } ''
+                icnsify ${./packaging/macos/icon-1024.png} -o $out
+              '';
+            in
+            pkgs.runCommand "fastpotify-app"
+              {
+                meta = {
+                  description = "Fastpotify as a macOS app bundle";
+                  homepage = "https://fastpotify.rocks";
+                  license = pkgs.lib.licenses.mit;
+                  platforms = pkgs.lib.platforms.darwin;
+                };
+              }
+              ''
+                app="$out/Applications/Fastpotify.app/Contents"
+                mkdir -p "$app/MacOS" "$app/Resources"
+                ln -s ${fastpotify}/bin/fastpotify "$app/MacOS/fastpotify"
+                cp ${icon} "$app/Resources/fastpotify.icns"
+                sed -e "s/__VERSION__/${version}/g" -e "s/__BUILD__/${build}/g" \
+                  ${./packaging/macos/Info.plist} > "$app/Info.plist"
+              '';
+        in
+        {
+          default = fastpotify;
+          inherit fastpotify;
+        }
+        // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+          inherit fastpotify-app;
+        }
+      );
 
       formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
     };

--- a/flake.nix
+++ b/flake.nix
@@ -86,104 +86,108 @@
       packages = forAllSystems (
         pkgs:
         let
-          fastpotify = let
-            toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-            rustPlatform = pkgs.makeRustPlatform {
-              cargo = toolchain;
-              rustc = toolchain;
-            };
-            cmakeWithLibdir = pkgs.writeShellScript "cmake-fastpotify" ''
-              if [[ "$1" == "--build" ]]; then
-                exec ${pkgs.cmake}/bin/cmake "$@"
-              else
-                exec ${pkgs.cmake}/bin/cmake "$@" -DCMAKE_INSTALL_LIBDIR=lib
-              fi
-            '';
-            runtimeLibs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
-              with pkgs;
-              [
-                libxkbcommon
-                wayland
-                libGL
-                libx11
-                libxcursor
-                libxi
-                libxrandr
-              ]
-            );
-          in
-          rustPlatform.buildRustPackage {
-            pname = "fastpotify";
-            version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
-            src = self;
-
-            # The lock file contains git dependencies. fetchCargoVendor includes
-            # them in the fixed-output dependency tree, unlike cargoLock alone.
-            cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+          fastpotify =
+            let
+              toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+              rustPlatform = pkgs.makeRustPlatform {
+                cargo = toolchain;
+                rustc = toolchain;
+              };
+              cmakeWithLibdir = pkgs.writeShellScript "cmake-fastpotify" ''
+                if [[ "$1" == "--build" ]]; then
+                  exec ${pkgs.cmake}/bin/cmake "$@"
+                else
+                  exec ${pkgs.cmake}/bin/cmake "$@" -DCMAKE_INSTALL_LIBDIR=lib
+                fi
+              '';
+              runtimeLibs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
+                with pkgs;
+                [
+                  libxkbcommon
+                  wayland
+                  libGL
+                  libx11
+                  libxcursor
+                  libxi
+                  libxrandr
+                ]
+              );
+            in
+            rustPlatform.buildRustPackage {
               pname = "fastpotify";
               version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
               src = self;
-              hash = "sha256-wC3tq8xj9tLYmZkvnsoHgYaTAtnwmktL1lAifeK0ui8=";
-            };
 
-            nativeBuildInputs =
-              with pkgs;
-              [
-                pkg-config
-                # libprojectM (MilkDrop) is built from source by CMake, and
-                # its bindings by bindgen, which needs libclang.
-                cmake
-                rustPlatform.bindgenHook
-              ]
-              ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ makeWrapper ];
-            buildInputs =
-              pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
+              # The lock file contains git dependencies. fetchCargoVendor includes
+              # them in the fixed-output dependency tree, unlike cargoLock alone.
+              cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+                pname = "fastpotify";
+                version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
+                src = self;
+                hash = "sha256-wC3tq8xj9tLYmZkvnsoHgYaTAtnwmktL1lAifeK0ui8=";
+              };
+
+              nativeBuildInputs =
                 with pkgs;
                 [
-                  alsa-lib
-                  libpulseaudio
-                  # libprojectM links OpenGL directly and its GL loader needs
-                  # X11 headers while it is built.
-                  libGL
-                  libx11
+                  pkg-config
+                  # libprojectM (MilkDrop) is built from source by CMake, and
+                  # its bindings by bindgen, which needs libclang.
+                  cmake
+                  rustPlatform.bindgenHook
                 ]
-              )
-              ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk ];
+                ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ makeWrapper ];
+              buildInputs =
+                pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux (
+                  with pkgs;
+                  [
+                    alsa-lib
+                    libpulseaudio
+                    # libprojectM links OpenGL directly and its GL loader needs
+                    # X11 headers while it is built.
+                    libGL
+                    libx11
+                  ]
+                )
+                ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk ];
 
-            # projectm-sys expects CMake to install into lib/, while CMake
-            # defaults to lib64/ on NixOS.
-            env.CMAKE = "${cmakeWithLibdir}";
+              # projectm-sys expects CMake to install into lib/, while CMake
+              # defaults to lib64/ on NixOS.
+              env.CMAKE = "${cmakeWithLibdir}";
 
-            # The GUI dlopens its Wayland, X11 and GL libraries at run time.
-            postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
-              wrapProgram $out/bin/fastpotify \
-                --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath runtimeLibs}
-            '';
+              # The GUI dlopens its Wayland, X11 and GL libraries at run time.
+              postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                wrapProgram $out/bin/fastpotify \
+                  --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath runtimeLibs}
+              '';
 
-            postInstall = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
-              install -Dm644 packaging/applications/fastpotify.desktop \
-                $out/share/applications/fastpotify.desktop
-              install -Dm644 packaging/icons/fastpotify.svg \
-                $out/share/icons/hicolor/scalable/apps/fastpotify.svg
-            '';
+              postInstall = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                install -Dm644 packaging/applications/fastpotify.desktop \
+                  $out/share/applications/fastpotify.desktop
+                install -Dm644 packaging/icons/fastpotify.svg \
+                  $out/share/icons/hicolor/scalable/apps/fastpotify.svg
+              '';
 
-            meta = {
-              description = "Fast native Spotify client with local playback and Spotify Connect";
-              homepage = "https://fastpotify.rocks";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "fastpotify";
+              meta = {
+                description = "Fast native Spotify client with local playback and Spotify Connect";
+                homepage = "https://fastpotify.rocks";
+                license = pkgs.lib.licenses.mit;
+                mainProgram = "fastpotify";
+              };
             };
-          };
-      
+
           fastpotify-app =
             let
               version = pkgs.lib.getVersion fastpotify;
               build = pkgs.lib.head (pkgs.lib.splitString "-" version);
-              icon = pkgs.runCommand "fastpotify-icon" {
-                nativeBuildInputs = [ pkgs.icnsify ];
-              } ''
-                icnsify ${./packaging/macos/icon-1024.png} -o $out
-              '';
+              icon =
+                pkgs.runCommand "fastpotify-icon"
+                  {
+                    nativeBuildInputs = [ pkgs.icnsify ];
+                  }
+                  ''
+                    icnsify ${./packaging/macos/icon-1024.png} -o $out
+                  '';
             in
             pkgs.runCommand "fastpotify-app"
               {

--- a/flake.nix
+++ b/flake.nix
@@ -201,10 +201,15 @@
               ''
                 app="$out/Applications/Fastpotify.app/Contents"
                 mkdir -p "$app/MacOS" "$app/Resources"
-                ln -s ${fastpotify}/bin/fastpotify "$app/MacOS/fastpotify"
+                cp ${fastpotify}/bin/fastpotify "$app/MacOS/fastpotify"
+                chmod 755 "$app/MacOS/fastpotify"
                 cp ${icon} "$app/Resources/fastpotify.icns"
                 sed -e "s/__VERSION__/${version}/g" -e "s/__BUILD__/${build}/g" \
                   ${./packaging/macos/Info.plist} > "$app/Info.plist"
+                /usr/bin/codesign --force --sign - \
+                  "$out/Applications/Fastpotify.app"
+                /usr/bin/codesign --verify --strict \
+                  "$out/Applications/Fastpotify.app"
               '';
         in
         {


### PR DESCRIPTION
## Why

On nix-darwin the fastpotify binary cannot sit in the Dock or register with Launch Services, so every nix-darwin user has to assemble their own Fastpotify.app wrapper in their config.

## What changed

flake.nix exposes a fastpotify-app package on the two darwin systems, assembled the same way packaging/macos/bundle.sh assembles a release bundle. If you want the release pipeline to use this I can refactor that as well.

See first commit for easier git diff review.

## Verification

- nix fmt
- nix flake check
- nix build .#fastpotify-app
- Tested the fork in my own [nix-config](https://github.com/ankarhem/nix-config/blob/main/modules/general.nix#L49-L86) repo

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [ ] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
