### PR TITLE
Add experimental Spotify DJ playback and set controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,7 +2847,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "aes",
  "bytes",
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "aes",
  "base64",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "log",
  "oauth2",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "cpal",
  "form_urlencoded",
@@ -2981,8 +2981,10 @@ dependencies = [
  "librespot-audio",
  "librespot-core",
  "librespot-metadata",
+ "librespot-protocol",
  "log",
  "portable-atomic",
+ "protobuf",
  "rand 0.9.5",
  "rand_distr",
  "rodio",
@@ -2996,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#5604d0c47673b09b3b18b1f625538ca0f60d63bc"
+source = "git+https://github.com/derluke/librespot?rev=3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a#3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,12 +173,14 @@ opt-level = 0
 projectm-sys = { git = "https://github.com/crmne/projectm-rs", branch = "respect-cmake-generator" }
 # librespot 0.8.0 plus the small patches Fastpotify needs: queue controls,
 # normalisation-factor reporting for the visualisers, and a distinct event
-# when Spotify refuses an audio key. Every librespot crate comes from the
-# fork so one copy exists. Drop patches as upstream takes them.
-librespot-audio = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-connect = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-core = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-metadata = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-oauth = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-playback = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-protocol = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
+# when Spotify refuses an audio key, plus experimental DJ session/narration
+# support. The immutable DJ review pin must move to the maintainer's merged
+# commit when the engine PR lands. Every librespot crate uses the same source.
+# Drop patches as upstream takes them.
+librespot-audio = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }
+librespot-connect = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }
+librespot-core = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }
+librespot-metadata = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }
+librespot-oauth = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }
+librespot-playback = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }
+librespot-protocol = { git = "https://github.com/derluke/librespot", rev = "3c79ae742ac1b194a00b28d4b9bfe0c24d94f07a" }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ everyday use, and connection details.
   in it, whether it is running or not. `open.spotify.com` addresses go
   through the browser, which hands them to the same handler.
 - **Queue** as a side panel or a page; add anything to it from a row menu.
+- **Experimental Spotify DJ.** Plays Spotify's generated sets and narration.
+  The **DJ** button changes sets; ordinary Next still skips one song. Local DJ
+  playback keeps shuffle off. Text and voice requests stay in Spotify's app.
+  See [connection details](docs/_reference/how-it-connects.md#experimental-dj-receiver).
 - **Resumes the last session.** On startup, the last song is paused where it
   stopped. Play resumes it, and the other playback controls work before it
   starts.

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -91,3 +91,29 @@ The engine discovers access points through `apresolve.spotify.com` and
 connects over TCP in the resolver's preference order: port 4070 first,
 falling back to 443 and 80. Only outbound connections are needed; no
 inbound ports have to be open.
+
+## Experimental DJ receiver
+
+The development DJ build resolves Spotify's generated DJ session and fetches
+its continuation pages as the queue runs low, independently of the autoplay
+setting. Start DJ in the official Spotify app and transfer playback to it,
+or open the DJ context through Fastpotify's existing media interface. Local DJ
+playback automatically turns shuffle off and keeps it off for DJ's intended
+sequence, including after a transfer. Outside DJ, shuffle can be enabled again;
+repeat is unchanged. This is experimental, not a feature of the published release.
+
+When a track carries narration, librespot sends Spotify's supplied script to
+Spotify's authenticated `client-tts` service. Its signed HTTPS audio URL is
+downloaded without forwarding Spotify authorization headers. Clips stay in
+memory, with an 8 MiB download limit, a two-minute decoded-duration limit, and
+an eight-second request timeout. A failed clip is skipped without dropping
+the music. No microphone audio or user-written prompt is collected or sent.
+
+Narration passes through the same equalizer, visualization tap, and volume
+control as music. The song clock stays still during speech. Seeking skips an
+introduction, and transferring or loading partway through a song omits its
+narration. In the main player bar, **DJ** skips to Spotify's next set boundary
+and uses its jump introduction, leaving manually queued songs intact. This is
+a local playback control, not a new playlist or prompt-generation endpoint.
+Its menu can open DJ in Spotify for text/voice requests; those requests are
+not sent by Fastpotify.

--- a/docs/_reference/queue.md
+++ b/docs/_reference/queue.md
@@ -50,3 +50,8 @@ check every one of them.
 10. **Old answers from Spotify are ignored.** Queue responses can be a few
     seconds late. Fastpotify ignores stale responses and asks again. Your
     changes stay visible while it waits for confirmation.
+
+In the experimental DJ build, **Next** still removes one row. **DJ** skips
+the remaining context songs in the current set and starts the next set with
+its DJ introduction. Your manually queued songs remain next after that
+chosen song; changing the DJ set does not clear them.

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -126,7 +126,8 @@ settings.
 `--demo-page` opens a page, such as `home`, `playlist:pl1`, or `artist:art0`,
 and `--demo-show` adds surfaces on top of it: a comma separated list of
 `queue`, `devices`, `shortcuts`, `premium`, `create`, `duplicate`, `light`,
-`focus`, `winamp`, `playlist`, `eq`, `eq-shade`, and `compact`.
+`focus`, `winamp`, `playlist`, `eq`, `eq-shade`, `compact`, `dj`, `dj-speaking`,
+and `dj-playlist` (an empty, sorted DJ placeholder for testing its Play button).
 
 `--demo-shot <PATH>` writes the window to a PNG and exits, which is how the
 screenshots in these pages are made:

--- a/docs/_reference/what-spotify-allows.md
+++ b/docs/_reference/what-spotify-allows.md
@@ -71,6 +71,11 @@ Fastpotify uses a small librespot fork. Its patches add queue controls,
 normalisation data for the visualisers, and an event for rejected audio keys.
 They are listed in `Cargo.toml`. Larger changes go upstream first.
 
+The experimental DJ build also uses proposed engine support for Spotify's
+generated DJ sessions, narration, continuation pages, and set changes. This
+is not a capability of unmodified librespot 0.8. See
+[How It Connects](/how-it-connects/#experimental-dj-receiver).
+
 ## Not available
 
 The Web API and librespot do not provide these features:
@@ -80,6 +85,8 @@ The Web API and librespot do not provide these features:
   support its protocol. Fastpotify's pins are local and are stored in
   `settings.json`. See [issue #31](https://github.com/crmne/fastpotify/issues/31).
 - **Editing playlist folders.** librespot can only read them.
+- **Text or voice requests to DJ.** Fastpotify can play Spotify's supplied
+  sets, but cannot send a custom prompt or record microphone input for DJ.
 - **Smart Shuffle, Jam, Blend, and similar Spotify features.** Spotify
   generates these for its own clients. Fastpotify only has plain shuffle.
 - **Lossless audio.** librespot does not receive lossless streams. Fastpotify

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,6 +77,12 @@ struct AssumedContext {
     at: Instant,
 }
 
+struct DjJump {
+    next: crate::player::DjSet,
+    preview: crate::player::LocalTrack,
+    at: Instant,
+}
+
 /// A track the interface shows before playback has reported its new state.
 ///
 /// Local engine events are ordered, so its next track report settles the
@@ -352,6 +358,7 @@ pub struct App {
     /// empty URI means a plain track list, whose lack of a context must also
     /// hide stale state.
     assumed_context: Option<AssumedContext>,
+    dj_jump_pending: Option<DjJump>,
     last_now_playing_uri: Option<String>,
     pub playlist_busy: bool,
     pub quit_requested: bool,
@@ -612,6 +619,7 @@ impl App {
             last_unavailable_reconnect: None,
             premium_notice_shown: false,
             assumed_context: None,
+            dj_jump_pending: None,
             last_now_playing_uri: None,
             playlist_busy: false,
             quit_requested: false,
@@ -882,6 +890,12 @@ impl App {
                 return (!assumed.uri.is_empty()).then(|| assumed.uri.clone());
             }
         }
+        if matches!(self.target(), Target::Local)
+            && self.local.is_active()
+            && let Some(context) = &self.local.dj_context
+        {
+            return Some(context.clone());
+        }
         remote
     }
 
@@ -893,6 +907,96 @@ impl App {
             return Some(intent.uri.clone());
         }
         self.now_playing().map(|now| now.uri)
+    }
+
+    pub fn dj_mode(&self) -> bool {
+        self.playing_context_uri().is_some_and(|uri| {
+            uri == crate::player::DJ_URI
+                || (matches!(self.target(), Target::Local)
+                    && self.local.dj_context.as_deref() == Some(uri.as_str()))
+        })
+    }
+
+    pub fn dj_change_pending(&self) -> bool {
+        self.dj_jump_pending
+            .as_ref()
+            .is_some_and(|jump| jump.at.elapsed() < Duration::from_secs(12))
+    }
+
+    pub fn local_dj_mode(&self) -> bool {
+        matches!(self.target(), Target::Local) && self.dj_mode()
+    }
+
+    pub fn can_change_dj_set(&self) -> bool {
+        self.dj_mode()
+            && matches!(self.target(), Target::Local)
+            && self.local.connected
+            && self.local.is_active()
+            && !self.local.shuffle
+            && self.local.repeat == RepeatMode::Off
+            && self.local.dj_next_set.is_some()
+            && !self.dj_change_pending()
+            && !self.any_play_pending()
+    }
+
+    fn change_dj_set(&mut self) {
+        if !self.can_change_dj_set() {
+            return;
+        }
+        let next = self.local.dj_next_set.clone().expect("checked above");
+        let mut item = self.optimistic_queue_item(&next.uri, "DJ: next set");
+        let queued = self.queued_rows_len();
+        if let Loadable::Loaded(queue) = &mut self.queue {
+            let matches = queue
+                .queue
+                .iter()
+                .skip(queued)
+                .take(next.consumed.len())
+                .map(|item| item.uri())
+                .eq(next.consumed.iter().map(String::as_str));
+            if matches && !next.consumed.is_empty() {
+                let mut consumed = queue.queue.drain(queued..queued + next.consumed.len());
+                let chosen = consumed.next_back();
+                drop(consumed);
+                if let Some(chosen) = &chosen {
+                    item = chosen.clone();
+                }
+                queue.currently_playing = chosen;
+            }
+        }
+        let preview = match item {
+            PlayableItem::Track(track) => crate::player::LocalTrack {
+                uri: track.uri,
+                title: track.name,
+                artists: track
+                    .artists
+                    .iter()
+                    .map(|artist| artist.name.clone())
+                    .collect(),
+                album: track
+                    .album
+                    .as_ref()
+                    .map(|album| album.name.clone())
+                    .unwrap_or_default(),
+                art_url: track
+                    .album
+                    .as_ref()
+                    .and_then(|album| pick_image(&album.images, 300))
+                    .map(str::to_owned),
+                duration_ms: track.duration_ms,
+                ..Default::default()
+            },
+            _ => return,
+        };
+        self.dj_jump_pending = Some(DjJump {
+            next: next.clone(),
+            preview,
+            at: Instant::now(),
+        });
+        self.expect_track(next.uri.clone());
+        self.set_play_pending(vec![next.uri]);
+        self.optimistic_playing = Some((true, Instant::now()));
+        self.backend.player(PlayerCommand::DjNextSet(next.uid));
     }
 
     /// Shows a user-requested track until the responsible playback surface
@@ -993,7 +1097,13 @@ impl App {
     /// What a device is actually playing, here or elsewhere.
     fn now_playing_live(&self) -> Option<NowPlaying> {
         if self.local.is_active() {
-            let track = self.local.track.as_ref()?;
+            let dj_preview = self
+                .dj_jump_pending
+                .as_ref()
+                .filter(|_| self.dj_change_pending());
+            let track = dj_preview
+                .map(|jump| &jump.preview)
+                .or(self.local.track.as_ref())?;
             let cached = track
                 .uri
                 .rsplit(':')
@@ -1035,9 +1145,13 @@ impl App {
                     .clone()
                     .or_else(|| track.art_url.clone()),
                 duration_ms: track.duration_ms,
-                position_ms: self.local.position_now(),
+                position_ms: if dj_preview.is_some() {
+                    0
+                } else {
+                    self.local.position_now()
+                },
                 playing,
-                loading: self.local.playback == Playback::Loading,
+                loading: dj_preview.is_some() || self.local.playback == Playback::Loading,
                 shuffle: self.shuffle_wanted,
                 repeat: self.local.repeat,
                 volume_percent: volume_to_percent(self.local.volume),
@@ -1443,6 +1557,11 @@ impl App {
         if let Some(error) = &state.error
             && self.local.error.as_deref() != Some(error.as_str())
         {
+            if self.dj_jump_pending.take().is_some() {
+                self.intent_track = None;
+                self.clear_play_pending();
+                self.refresh_queue(true);
+            }
             self.toast_error(error.clone());
             // One unavailable track is Spotify's catalogue; several in a
             // row is the session's audio-key service gone bad, which
@@ -1481,11 +1600,35 @@ impl App {
             }));
         }
         self.local = state;
+        if self.local_dj_mode() {
+            // DJ's ordered playback overrides a recent shuffle preference too.
+            // Do not let a delayed options event light the control back up.
+            if self.shuffle_wanted {
+                self.session_dirty = true;
+            }
+            self.shuffle_wanted = false;
+            if let Some(assumed) = &mut self.assumed_context {
+                assumed.shuffle = Some(false);
+            }
+        }
         if let Some(volume) = held_volume {
             self.local.volume = volume;
         }
         if track_changed {
             self.on_now_playing_changed();
+        }
+        if self.dj_jump_pending.as_ref().is_some_and(|jump| {
+            self.local
+                .track
+                .as_ref()
+                .is_some_and(|track| track.uri == jump.next.uri)
+                && self
+                    .local
+                    .dj_next_set
+                    .as_ref()
+                    .is_none_or(|next| next.uid != jump.next.uid)
+        }) {
+            self.dj_jump_pending = None;
         }
         if reconnected {
             if let Some(request) = self.queued_play.take() {
@@ -1695,7 +1838,10 @@ impl App {
             }
         }
         // Remove a manually queued track once it starts.
-        if self.manual_queue.first().map(String::as_str) == Some(now.uri.as_str()) {
+        let dj_jump = self.dj_jump_pending.as_ref().is_some_and(|jump| {
+            jump.next.uri == now.uri && jump.at.elapsed() < Duration::from_secs(12)
+        });
+        if !dj_jump && self.manual_queue.first().map(String::as_str) == Some(now.uri.as_str()) {
             self.manual_queue.remove(0);
             self.session_dirty = true;
         }
@@ -3008,6 +3154,16 @@ impl App {
 
     /// Whether a fetched queue predates the latest local change.
     fn queue_fetch_is_stale(&self, fetched: &Queue) -> bool {
+        if self.dj_change_pending()
+            && self.dj_jump_pending.as_ref().is_some_and(|jump| {
+                fetched
+                    .currently_playing
+                    .as_ref()
+                    .is_none_or(|track| track.uri() != jump.next.uri)
+            })
+        {
+            return true;
+        }
         if self.queue_stale_retries >= QUEUE_STALE_RETRIES {
             return false;
         }
@@ -3209,6 +3365,7 @@ impl App {
                                 .as_ref()
                                 .map(|remote| remote.state.shuffle_state),
                         ) && previous != current
+                            && !self.local_dj_mode()
                             && self
                                 .shuffle_set_at
                                 .is_none_or(|at| at.elapsed() > Duration::from_secs(5))
@@ -4421,11 +4578,20 @@ impl App {
         // Shuffle applies across contexts until disabled. A selected row still
         // starts first; otherwise choose a random starting track.
         let mut request = request;
-        if shuffle_first {
+        let dj = matches!(self.target(), Target::Local)
+            && request.context_uri.as_deref().is_some_and(|uri| {
+                uri == crate::player::DJ_URI || self.local.dj_context.as_deref() == Some(uri)
+            });
+        if dj {
+            self.shuffle_wanted = false;
+            self.local.shuffle = false;
+            self.shuffle_set_at = Some(Instant::now());
+            self.session_dirty = true;
+        } else if shuffle_first {
             self.shuffle_wanted = true;
             self.shuffle_set_at = Some(Instant::now());
         }
-        let shuffle = shuffle_first || self.shuffle_wanted;
+        let shuffle = !dj && (shuffle_first || self.shuffle_wanted);
         if shuffle
             && request.offset_uri.is_none()
             && request.offset_position.is_none()
@@ -4830,6 +4996,7 @@ impl App {
     }
 
     fn set_shuffle(&mut self, shuffle: bool) {
+        let shuffle = shuffle && !self.local_dj_mode();
         self.shuffle_wanted = shuffle;
         self.shuffle_set_at = Some(Instant::now());
         self.session_dirty = true;
@@ -5292,6 +5459,7 @@ impl App {
                 self.play_request(PlayRequest::context(uri), true);
             }
             Action::TogglePlay => self.toggle_play(),
+            Action::DjNextSet => self.change_dj_set(),
             Action::Next if self.resume_only() => {
                 self.step_resume(true);
             }
@@ -6542,6 +6710,366 @@ fn cap_uris(uris: Vec<String>, index: u32) -> (Vec<String>, u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dj_app() -> App {
+        let mut app = headless_app();
+        app.local.connected = true;
+        app.local.playback = Playback::Playing;
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:a".into(),
+            title: "Before".into(),
+            ..Default::default()
+        });
+        app.local.dj_context = Some(crate::player::DJ_URI.into());
+        app.local.dj_next_set = Some(crate::player::DjSet {
+            uri: "spotify:track:c".into(),
+            uid: "set-two-first".into(),
+            consumed: vec!["spotify:track:b".into(), "spotify:track:c".into()],
+        });
+        app.queue = loaded_queue(
+            "spotify:track:a",
+            &[
+                "spotify:track:q",
+                "spotify:track:b",
+                "spotify:track:c",
+                "spotify:track:d",
+            ],
+        );
+        app.manual_queue = vec!["spotify:track:q".into()];
+        app
+    }
+
+    #[test]
+    fn dj_set_changes_are_immediate_and_preserve_queued_songs() {
+        let ctx = egui::Context::default();
+        let mut app = dj_app();
+        let old = app.local.clone();
+        app.apply(Action::DjNextSet, &ctx);
+        assert_eq!(
+            queue_uris(&app),
+            (
+                Some("spotify:track:c".into()),
+                vec!["spotify:track:q".into(), "spotify:track:d".into()]
+            )
+        );
+        assert_eq!(app.manual_queue, vec!["spotify:track:q"]);
+        assert_eq!(app.now_playing().unwrap().uri, "spotify:track:c");
+        assert!(app.dj_change_pending());
+        assert!(!app.can_change_dj_set());
+        app.handle_local(old);
+        assert_eq!(
+            app.now_playing().unwrap().uri,
+            "spotify:track:c",
+            "an old snapshot cannot undo the clicked set"
+        );
+        app.queue_stale_retries = QUEUE_STALE_RETRIES;
+        let stale = loaded_queue("spotify:track:a", &["spotify:track:b"]);
+        assert!(app.queue_fetch_is_stale(stale.get().unwrap()));
+        let mut confirmed = app.local.clone();
+        confirmed.track.as_mut().unwrap().uri = "spotify:track:c".into();
+        confirmed.dj_next_set = None;
+        app.handle_local(confirmed);
+        assert!(!app.dj_change_pending());
+    }
+
+    #[test]
+    fn dj_does_not_consume_a_manually_queued_copy_of_its_chosen_song() {
+        let mut app = dj_app();
+        app.manual_queue = vec!["spotify:track:c".into()];
+        app.queue = loaded_queue(
+            "spotify:track:a",
+            &[
+                "spotify:track:c",
+                "spotify:track:b",
+                "spotify:track:c",
+                "spotify:track:d",
+            ],
+        );
+        app.change_dj_set();
+        let mut confirmed = app.local.clone();
+        confirmed.track.as_mut().unwrap().uri = "spotify:track:c".into();
+        confirmed.dj_next_set = None;
+        app.handle_local(confirmed);
+        assert_eq!(app.manual_queue, vec!["spotify:track:c"]);
+        assert_eq!(
+            queue_uris(&app).1,
+            vec!["spotify:track:c", "spotify:track:d"]
+        );
+    }
+
+    #[test]
+    fn dj_controls_need_a_local_ordered_session_and_a_real_set_boundary() {
+        let mut app = dj_app();
+        assert!(app.can_change_dj_set());
+        app.local.shuffle = true;
+        assert!(!app.can_change_dj_set());
+        app.local.shuffle = false;
+        app.local.dj_next_set = None;
+        assert!(!app.can_change_dj_set());
+        app.local.dj_context = None;
+        assert!(!app.dj_mode());
+        app = dj_app();
+        app.apply(
+            Action::PlayContext {
+                uri: "spotify:album:ordinary".into(),
+                offset_uri: None,
+                offset_index: None,
+            },
+            &egui::Context::default(),
+        );
+        assert!(!app.dj_mode(), "leaving DJ hides its controls immediately");
+    }
+
+    #[test]
+    fn starting_dj_turns_shuffle_off_immediately() {
+        let mut app = headless_app();
+        app.local.connected = true;
+        app.set_shuffle(true);
+        app.play_request(
+            PlayRequest {
+                context_uri: Some(crate::player::DJ_URI.into()),
+                ..Default::default()
+            },
+            true,
+        );
+        assert!(app.local_dj_mode());
+        assert!(!app.shuffle_wanted);
+        assert!(!app.local.shuffle);
+        let request = PlayRequest {
+            context_uri: Some(crate::player::DJ_URI.into()),
+            ..Default::default()
+        };
+        assert_ne!(local_load(&request, app.shuffle_wanted).shuffle, Some(true));
+    }
+
+    #[cfg(feature = "demo")]
+    #[test]
+    fn the_dj_playlist_play_button_loads_the_session_even_with_an_empty_sorted_view() {
+        for (context_uri, sorted, paused) in [
+            (crate::player::DJ_URI, false, false),
+            (crate::player::DJ_URI, true, false),
+            (crate::player::DJ_URI, true, true),
+            ("spotify:playlist:ordinary", true, false),
+        ] {
+            let mut app = headless_app();
+            crate::demo::populate(&mut app);
+            app.remote = None;
+            app.local.connected = true;
+            if paused {
+                app.local.playback = Playback::Paused;
+                app.local.dj_context = Some(context_uri.into());
+                app.local.track = Some(crate::player::LocalTrack {
+                    uri: "spotify:track:example".into(),
+                    ..Default::default()
+                });
+            }
+            let ctx = egui::Context::default();
+            app.attach(&ctx);
+            app.actions.clear();
+            let mut center = egui::Pos2::ZERO;
+            for pressed in [None, Some(true), Some(false)] {
+                let events = pressed
+                    .map(|pressed| {
+                        vec![
+                            egui::Event::PointerMoved(center),
+                            egui::Event::PointerButton {
+                                pos: center,
+                                button: egui::PointerButton::Primary,
+                                pressed,
+                                modifiers: egui::Modifiers::NONE,
+                            },
+                        ]
+                    })
+                    .unwrap_or_default();
+                let mut output = ctx.run_ui(
+                    egui::RawInput {
+                        events,
+                        ..Default::default()
+                    },
+                    |ui| {
+                        let view = crate::ui::collection::prepare_table_view(
+                            ui,
+                            &app,
+                            &Page::Playlist("dj-placeholder".into()),
+                            &[],
+                            "no match",
+                            sorted.then_some(TableSort {
+                                column: SortColumn::Title,
+                                ascending: true,
+                            }),
+                            0,
+                        );
+                        center = ui.next_widget_position() + egui::vec2(28.0, 28.0);
+                        crate::ui::collection::actions_row(
+                            &mut app,
+                            ui,
+                            crate::ui::collection::Actions {
+                                play_uri: Some(context_uri.into()),
+                                view: view.view_uris.as_ref().map(|uris| uris.to_vec()),
+                                saved: None,
+                                saved_icons: (
+                                    crate::theme::Icon::Heart,
+                                    crate::theme::Icon::HeartFilled,
+                                ),
+                                saved_tooltips: ("", ""),
+                                owned_playlist: None,
+                                name: "DJ",
+                            },
+                            None,
+                        );
+                    },
+                );
+                output.textures_delta.clear();
+            }
+            if context_uri != crate::player::DJ_URI {
+                assert!(
+                    matches!(app.actions.as_slice(), [Action::PlayFromRow { .. }]),
+                    "ordinary sorted playlists still play their visible rows"
+                );
+                app.backend.shutdown();
+                continue;
+            }
+            assert!(
+                matches!(app.actions.as_slice(), [Action::PlayContext { uri, .. }] if uri == crate::player::DJ_URI),
+                "sorted={sorted}"
+            );
+            app.apply_actions(&ctx);
+            assert!(app.play_pending(crate::player::DJ_URI));
+            assert!(
+                app.local_list.is_none(),
+                "DJ must not become an empty song list"
+            );
+            assert!(!app.shuffle_wanted);
+            app.backend.shutdown();
+        }
+    }
+
+    #[test]
+    fn dj_play_pending_clears_on_confirmation_and_can_be_retried_after_expiry() {
+        let mut app = dj_app();
+        app.local.playback = Playback::Paused;
+        let before = app.local.clone();
+        let ctx = egui::Context::default();
+        let play = || Action::PlayContext {
+            uri: crate::player::DJ_URI.into(),
+            offset_uri: None,
+            offset_index: None,
+        };
+        app.apply(play(), &ctx);
+        app.handle_local(before.clone());
+        assert!(
+            app.play_pending(crate::player::DJ_URI),
+            "old paused state is not confirmation"
+        );
+        app.pending_play_at = Some(Instant::now() - Duration::from_secs(9));
+        assert!(!app.any_play_pending());
+        app.apply(play(), &ctx);
+        assert!(app.play_pending(crate::player::DJ_URI));
+        let mut confirmed = before;
+        confirmed.playback = Playback::Playing;
+        confirmed.narrating = true;
+        app.handle_local(confirmed);
+        assert!(
+            !app.any_play_pending(),
+            "the same song can confirm a new DJ start"
+        );
+        assert!(app.can_change_dj_set());
+    }
+
+    #[test]
+    fn dj_play_waits_for_reconnection_then_dispatches_the_session_unshuffled() {
+        let mut app = headless_app();
+        app.shuffle_wanted = true;
+        app.play_request(PlayRequest::context(crate::player::DJ_URI), false);
+        assert_eq!(
+            app.queued_play.as_ref().unwrap().context_uri.as_deref(),
+            Some(crate::player::DJ_URI)
+        );
+        app.pending_play_at = Some(Instant::now() - Duration::from_secs(60));
+        assert!(
+            app.play_pending(crate::player::DJ_URI),
+            "connecting is not a play timeout"
+        );
+        app.handle_local(LocalState {
+            connected: true,
+            ..Default::default()
+        });
+        assert!(app.queued_play.is_none());
+        assert!(app.play_pending(crate::player::DJ_URI));
+        assert!(!app.shuffle_wanted);
+        assert!(app.local_list.is_none());
+    }
+
+    #[test]
+    fn dj_shuffle_policy_overrides_recent_intent_and_stale_spotify_answers() {
+        let ctx = egui::Context::default();
+        let mut app = dj_app();
+        let confirmed = app.local.clone();
+        app.shuffle_wanted = true;
+        app.local.shuffle = true;
+        app.shuffle_set_at = Some(Instant::now());
+        app.handle_local(confirmed);
+        assert!(!app.now_playing().unwrap().shuffle);
+        assert!(app.can_change_dj_set());
+
+        app.apply(Action::ToggleShuffle, &ctx);
+        assert!(!app.shuffle_wanted);
+        assert!(!app.local.shuffle);
+        assert!(app.can_change_dj_set());
+        app.local.repeat = RepeatMode::Context;
+        app.apply(Action::ToggleShuffle, &ctx);
+        assert_eq!(app.local.repeat, RepeatMode::Context);
+
+        app.shuffle_set_at = Some(Instant::now() - Duration::from_secs(6));
+        app.remote = Some(RemoteSnapshot {
+            state: PlaybackState::default(),
+            received_at: Instant::now(),
+        });
+        app.handle_api(ApiResponse::PlaybackState {
+            seq: app.remote_poll_seq,
+            result: Ok(Some(PlaybackState {
+                shuffle_state: true,
+                ..Default::default()
+            })),
+        });
+        assert!(
+            !app.shuffle_wanted,
+            "a delayed Web API answer cannot undo DJ order"
+        );
+
+        app.play_request(
+            PlayRequest {
+                context_uri: Some("spotify:album:ordinary".into()),
+                ..Default::default()
+            },
+            false,
+        );
+        app.apply(Action::ToggleShuffle, &ctx);
+        assert!(app.shuffle_wanted, "shuffle works after leaving DJ");
+        assert!(app.local.shuffle);
+    }
+
+    #[test]
+    fn dj_on_another_device_keeps_its_shuffle_controls() {
+        let mut app = dj_app();
+        app.local.playback = Playback::Stopped;
+        app.selected_device = Some("phone".into());
+        app.remote = Some(RemoteSnapshot {
+            state: PlaybackState {
+                context: Some(crate::api::models::Context {
+                    uri: crate::player::DJ_URI.into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            received_at: Instant::now(),
+        });
+        assert!(app.dj_mode());
+        assert!(!app.local_dj_mode());
+        app.set_shuffle(true);
+        assert!(app.shuffle_wanted);
+        assert!(app.remote.as_ref().unwrap().state.shuffle_state);
+    }
 
     /// A song started outside a playlist must turn off the playlist's
     /// sidebar light at once, even while Spotify still reports the old

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -606,6 +606,68 @@ pub fn apply_flags(app: &mut App, page: Option<&str>, show: Option<&str>) {
     }
     for surface in show.unwrap_or("").split(',').map(str::trim) {
         match surface {
+            "dj-playlist" => {
+                let uri = crate::player::DJ_URI;
+                let id = uri.rsplit(':').next().expect("DJ playlist id");
+                let mut placeholder = PlaylistPage {
+                    playlist: Loadable::Loaded(Playlist {
+                        id: id.into(),
+                        uri: uri.into(),
+                        name: "DJ".into(),
+                        description: Some("Your own DJ. Press play to start your session.".into()),
+                        owner: Owner {
+                            id: Some("spotify".into()),
+                            display_name: Some("Spotify".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                };
+                placeholder.items.absorb(0, self::page(Vec::new()));
+                app.playlist_pages.insert(id.into(), placeholder);
+                let page = Page::Playlist(id.into());
+                app.table_sorts.insert(
+                    page.clone(),
+                    TableSort {
+                        column: SortColumn::Title,
+                        ascending: true,
+                    },
+                );
+                app.remote = None;
+                app.open(page);
+            }
+            "dj" | "dj-speaking" => {
+                let item = track(0);
+                app.local.connected = true;
+                app.local.playback = crate::player::Playback::Playing;
+                app.local.track = Some(crate::player::LocalTrack {
+                    uri: item.uri,
+                    title: item.name,
+                    artists: item
+                        .artists
+                        .iter()
+                        .map(|artist| artist.name.clone())
+                        .collect(),
+                    duration_ms: item.duration_ms,
+                    art_url: item
+                        .album
+                        .as_ref()
+                        .and_then(|album| album.images.first())
+                        .map(|image| image.url.clone()),
+                    ..Default::default()
+                });
+                app.local.position_ms = if surface == "dj-speaking" { 0 } else { 45_000 };
+                app.local.narrating = surface == "dj-speaking";
+                app.local.dj_context = Some(crate::player::DJ_URI.into());
+                app.local.dj_next_set = Some(crate::player::DjSet {
+                    uri: "spotify:track:trk5".into(),
+                    uid: "demo-set-two".into(),
+                    consumed: (1..=5)
+                        .map(|index| format!("spotify:track:trk{index}"))
+                        .collect(),
+                });
+            }
             "queue" => app.show_queue_panel = true,
             "recents" => {
                 app.show_queue_panel = true;

--- a/src/model.rs
+++ b/src/model.rs
@@ -631,6 +631,7 @@ pub enum Action {
     ShufflePlay(String),
     TogglePlay,
     Next,
+    DjNextSet,
     Previous,
     Seek(u32),
     SeekBy(i64),

--- a/src/player.rs
+++ b/src/player.rs
@@ -36,6 +36,9 @@ use sha1::{Digest, Sha1};
 use crate::sink::{ErrorHook, RodioSink};
 use crate::vis::{AudioTap, Tapped};
 
+pub use librespot_playback::player::DjSet;
+pub const DJ_URI: &str = "spotify:playlist:37i9dQZF1EYkqdzj48dyYq";
+
 #[derive(Clone, Debug)]
 pub struct EngineConfig {
     pub device_name: String,
@@ -160,6 +163,10 @@ pub struct LocalState {
     pub position_ms: u32,
     /// When `position_ms` was observed; `None` while not advancing.
     pub position_at: Option<Instant>,
+    /// Speech is audible, but the song clock is stationary.
+    pub narrating: bool,
+    pub dj_context: Option<String>,
+    pub dj_next_set: Option<DjSet>,
     pub volume: u16,
     pub shuffle: bool,
     pub repeat: RepeatMode,
@@ -199,6 +206,9 @@ impl LocalState {
 
     /// The position now, interpolated from the last report while playing.
     pub fn position_now(&self) -> u32 {
+        if self.narrating {
+            return self.position_ms;
+        }
         match (self.playback, self.position_at) {
             (Playback::Playing, Some(at)) => {
                 let elapsed = at.elapsed().as_millis() as u32;
@@ -235,6 +245,7 @@ pub struct LoadSpec {
 pub enum PlayerCommand {
     Toggle,
     Next,
+    DjNextSet(String),
     Previous,
     /// Remove manually queued tracks and keep context tracks.
     ClearQueue,
@@ -489,6 +500,7 @@ impl Engine {
         match command {
             PlayerCommand::Toggle => spirc.play_pause()?,
             PlayerCommand::Next => spirc.next()?,
+            PlayerCommand::DjNextSet(uid) => spirc.dj_next_set(uid)?,
             PlayerCommand::Previous => spirc.prev()?,
             PlayerCommand::ClearQueue => spirc.clear_queue()?,
             PlayerCommand::AddToQueue(uri) => spirc.add_to_queue(uri)?,
@@ -660,13 +672,37 @@ fn set<T: PartialEq>(target: &mut T, value: T) -> bool {
 
 fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
     match event {
+        PlayerEvent::DjStateChanged {
+            context_uri,
+            next_set,
+        } => {
+            let mut changed = set(&mut state.dj_context, context_uri);
+            changed |= set(&mut state.dj_next_set, next_set);
+            changed
+        }
+        PlayerEvent::DjJumpRejected => set(
+            &mut state.error,
+            Some("The DJ set changed before the request arrived. Try the DJ button again".into()),
+        ),
+        PlayerEvent::Narration {
+            active,
+            position_ms,
+            ..
+        } => {
+            state.narrating = active;
+            state.position_ms = position_ms;
+            state.position_at = (!active && state.playback == Playback::Playing).then(Instant::now);
+            true
+        }
         PlayerEvent::Stopped { .. } => {
+            state.narrating = false;
             let mut changed = set(&mut state.playback, Playback::Stopped);
             changed |= set(&mut state.position_ms, 0);
             changed |= set(&mut state.position_at, None);
             changed
         }
         PlayerEvent::Loading { position_ms, .. } => {
+            state.narrating = false;
             let mut changed = if state.playback == Playback::Stopped {
                 set(&mut state.playback, Playback::Loading)
             } else {
@@ -680,7 +716,7 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
         PlayerEvent::Playing { position_ms, .. } => {
             let mut changed = set(&mut state.playback, Playback::Playing);
             changed |= set(&mut state.position_ms, position_ms);
-            state.position_at = Some(Instant::now());
+            state.position_at = (!state.narrating).then(Instant::now);
             changed || true
         }
         PlayerEvent::Paused { position_ms, .. } => {
@@ -692,12 +728,13 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
         PlayerEvent::PositionCorrection { position_ms, .. }
         | PlayerEvent::PositionChanged { position_ms, .. } => {
             state.position_ms = position_ms;
-            if state.playback == Playback::Playing {
+            if state.playback == Playback::Playing && !state.narrating {
                 state.position_at = Some(Instant::now());
             }
             true
         }
         PlayerEvent::Seeked { position_ms, .. } => {
+            state.narrating = false;
             state.position_ms = position_ms;
             if state.playback == Playback::Playing {
                 state.position_at = Some(Instant::now());
@@ -706,6 +743,7 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
             true
         }
         PlayerEvent::TrackChanged { audio_item } => {
+            state.narrating = false;
             let mut changed = set(&mut state.track, Some(local_track(&audio_item)));
             changed |= set(&mut state.error, None);
             changed
@@ -730,7 +768,13 @@ fn apply_event(state: &mut LocalState, event: PlayerEvent) -> bool {
         // In librespot this event means the Connect device became inactive,
         // usually because another device took over. The engine session is
         // still alive, and `Load` activates it again before starting a track.
-        PlayerEvent::SessionDisconnected { .. } => set(&mut state.active_client, String::new()),
+        PlayerEvent::SessionDisconnected { .. } => {
+            let mut changed = set(&mut state.dj_context, None);
+            changed |= set(&mut state.dj_next_set, None);
+            changed |= set(&mut state.narrating, false);
+            changed |= set(&mut state.active_client, String::new());
+            changed
+        }
         PlayerEvent::SessionClientChanged { client_name, .. } => {
             set(&mut state.active_client, client_name)
         }
@@ -963,6 +1007,35 @@ mod tests {
     use super::*;
     use librespot_core::SpotifyUri;
 
+    #[test]
+    fn dj_state_is_explicit_and_cleared_on_disconnect() {
+        let mut state = LocalState::default();
+        assert!(apply_event(
+            &mut state,
+            PlayerEvent::DjStateChanged {
+                context_uri: Some(DJ_URI.into()),
+                next_set: None
+            }
+        ));
+        assert_eq!(state.dj_context.as_deref(), Some(DJ_URI));
+        assert!(!apply_event(
+            &mut state,
+            PlayerEvent::DjStateChanged {
+                context_uri: Some(DJ_URI.into()),
+                next_set: None
+            }
+        ));
+        apply_event(
+            &mut state,
+            PlayerEvent::SessionDisconnected {
+                connection_id: String::new(),
+                user_name: String::new(),
+            },
+        );
+        assert!(state.dj_context.is_none());
+        assert!(state.dj_next_set.is_none());
+    }
+
     fn uri() -> SpotifyUri {
         SpotifyUri::from_uri("spotify:track:14XWXWv5FoCbFzLksawpEe").unwrap()
     }
@@ -978,6 +1051,62 @@ mod tests {
         assert_eq!(state.position_now(), 5_000);
         state.playback = Playback::Playing;
         assert!(state.position_now() >= 7_000);
+    }
+
+    #[test]
+    fn narration_freezes_the_song_clock_across_progress_pause_and_resume() {
+        let mut state = LocalState {
+            playback: Playback::Playing,
+            ..LocalState::default()
+        };
+        apply_event(
+            &mut state,
+            PlayerEvent::Narration {
+                track_id: uri(),
+                play_request_id: 1,
+                position_ms: 0,
+                active: true,
+            },
+        );
+        apply_event(
+            &mut state,
+            PlayerEvent::PositionCorrection {
+                track_id: uri(),
+                play_request_id: 1,
+                position_ms: 0,
+            },
+        );
+        assert!(state.position_at.is_none());
+        apply_event(
+            &mut state,
+            PlayerEvent::Paused {
+                track_id: uri(),
+                play_request_id: 1,
+                position_ms: 0,
+            },
+        );
+        apply_event(
+            &mut state,
+            PlayerEvent::Playing {
+                track_id: uri(),
+                play_request_id: 1,
+                position_ms: 0,
+            },
+        );
+        assert!(state.position_at.is_none());
+        state.position_at = Some(Instant::now() - Duration::from_secs(5));
+        assert_eq!(state.position_now(), 0);
+        apply_event(
+            &mut state,
+            PlayerEvent::Narration {
+                track_id: uri(),
+                play_request_id: 1,
+                position_ms: 0,
+                active: false,
+            },
+        );
+        assert!(state.position_at.is_some());
+        assert!(!state.narrating);
     }
 
     #[test]

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -151,7 +151,12 @@ pub fn actions_row(
             {
                 if now_playing_here {
                     app.actions.push(Action::TogglePlay);
-                } else if let Some(uris) = actions.view.clone() {
+                } else if let Some(uris) = actions.view.clone().filter(|_| {
+                    // DJ is a generated session, not the (usually empty)
+                    // placeholder's rows, even when the table is sorted.
+                    uri != crate::player::DJ_URI
+                        && app.local.dj_context.as_deref() != Some(uri.as_str())
+                }) {
                     app.actions.push(Action::PlayFromRow {
                         context: RowContext::View {
                             uris,

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -171,7 +171,20 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         }
     }
     text_ui.horizontal_top(|ui| {
-        if now.artists.is_empty() {
+        if app.dj_change_pending() {
+            theme::text(ui, "Changing DJ set…", theme::regular(12.0), palette.accent);
+        } else if app.dj_mode() && now.local && app.local.narrating {
+            theme::text(
+                ui,
+                if now.playing {
+                    "DJ speaking"
+                } else {
+                    "DJ paused"
+                },
+                theme::regular(12.0),
+                palette.accent,
+            );
+        } else if now.artists.is_empty() {
             if theme::link(ui, &now.subtitle, theme::regular(12.0), palette.secondary).clicked()
                 && let Some(id) = &now.show_id
             {
@@ -272,7 +285,8 @@ fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region:
     // Button widths: icon buttons occupy icon size + 12; the disc is 36.
     let widths = [29.0, 30.0, 36.0, 30.0, 29.0];
     let gap = 10.0;
-    let total: f32 = widths.iter().sum::<f32>() + gap * 4.0;
+    let dj = app.dj_mode();
+    let total: f32 = widths.iter().sum::<f32>() + gap * 4.0 + if dj { 46.0 } else { 0.0 };
     let mut x = region.center().x - total / 2.0;
     let mut slot = |width: f32| {
         let rect = Rect::from_center_size(pos2(x + width / 2.0, cy), vec2(width, 36.0));
@@ -289,6 +303,12 @@ fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region:
 
     let shuffle_color = if shuffle { palette.accent } else { dim };
     let mut cell = centered(ui, slot(widths[0]));
+    let shuffle_tooltip = if app.local_dj_mode() {
+        cell.disable();
+        "DJ keeps shuffle off so its sets play in order."
+    } else {
+        "Shuffle"
+    };
     if theme::icon_button(
         &mut cell,
         Icon::Shuffle,
@@ -299,8 +319,9 @@ fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region:
         } else {
             palette.text
         },
-        "Shuffle",
+        shuffle_tooltip,
     )
+    .on_disabled_hover_text(shuffle_tooltip)
     .clicked()
     {
         app.actions.push(Action::ToggleShuffle);
@@ -390,6 +411,11 @@ fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region:
         app.actions.push(Action::CycleRepeat);
     }
 
+    if dj {
+        let mut cell = centered(ui, slot(36.0));
+        dj_button(app, &mut cell);
+    }
+
     // Progress row, just below the buttons (disc bottom + 6px gap + half of
     // the time text's line height).
     let row_cy = cy + 31.0;
@@ -452,6 +478,117 @@ fn transport(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>, region:
         theme::regular(11.5),
         time_color,
     );
+}
+
+fn dj_button(app: &mut App, ui: &mut egui::Ui) -> egui::Response {
+    let palette = app.palette;
+    let pending = app.dj_change_pending();
+    let local = matches!(app.target(), crate::app::Target::Local);
+    let tooltip = if !local {
+        "DJ is playing on another device. Change sets or make requests in Spotify."
+    } else if app.local.shuffle {
+        "DJ is turning shuffle off…"
+    } else if app.local.repeat != RepeatMode::Off {
+        "Turn repeat off to move through DJ sets."
+    } else if pending {
+        "Changing DJ set…"
+    } else if app.local.dj_next_set.is_none() {
+        "DJ mode · The next set is not ready yet."
+    } else {
+        "Next DJ set · Change the mood, with a new DJ introduction. Your queued songs stay."
+    };
+    let response = ui
+        .add_enabled(
+            app.can_change_dj_set(),
+            egui::Button::new(
+                egui::RichText::new(if pending { "…" } else { "DJ" })
+                    .font(theme::semibold(12.0))
+                    .color(palette.accent),
+            )
+            .fill(super::blend(palette.panel, palette.accent, 0.16))
+            .stroke(egui::Stroke::new(1.0, palette.accent.gamma_multiply(0.5)))
+            .corner_radius(14.0)
+            .min_size(vec2(34.0, 28.0)),
+        )
+        .on_hover_text(tooltip)
+        .on_disabled_hover_text(tooltip);
+    if response.clicked() {
+        app.actions.push(Action::DjNextSet);
+    }
+    response.context_menu(|ui| {
+        ui.label("Text and voice requests currently need Spotify.");
+        if ui.button("Open DJ in Spotify…").clicked() {
+            app.actions.push(Action::OpenUrl(
+                "https://open.spotify.com/playlist/37i9dQZF1EYkqdzj48dyYq".into(),
+            ));
+            ui.close();
+        }
+    });
+    response
+}
+
+#[cfg(all(test, feature = "demo"))]
+mod dj_tests {
+    use super::*;
+
+    #[test]
+    fn dj_button_emits_a_distinct_action_and_disables_without_a_boundary() {
+        let root =
+            std::env::temp_dir().join(format!("fastpotify-dj-ui-test-{}", std::process::id()));
+        let mut app = App::new(
+            &crate::backend::Waker::default(),
+            crate::paths::AppDirs {
+                config: root.join("config"),
+                state: root.join("state"),
+                cache: root.join("cache"),
+            },
+            crate::settings::Settings::default(),
+            crate::app::AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        );
+        crate::demo::populate(&mut app);
+        crate::demo::apply_flags(&mut app, None, Some("dj-speaking"));
+        let ctx = egui::Context::default();
+        app.attach(&ctx);
+        app.actions.clear();
+        let mut center = egui::Pos2::ZERO;
+        for pressed in [None, Some(true), Some(false)] {
+            let events = pressed
+                .map(|pressed| {
+                    vec![
+                        egui::Event::PointerMoved(center),
+                        egui::Event::PointerButton {
+                            pos: center,
+                            button: egui::PointerButton::Primary,
+                            pressed,
+                            modifiers: egui::Modifiers::NONE,
+                        },
+                    ]
+                })
+                .unwrap_or_default();
+            let mut output = ctx.run_ui(
+                egui::RawInput {
+                    events,
+                    ..Default::default()
+                },
+                |ui| {
+                    center = dj_button(&mut app, ui).rect.center();
+                },
+            );
+            output.textures_delta.clear();
+        }
+        assert!(matches!(app.actions.as_slice(), [Action::DjNextSet]));
+        app.actions.clear();
+        app.local.dj_next_set = None;
+        let mut output = ctx.run_ui(Default::default(), |ui| {
+            assert!(!dj_button(&mut app, ui).enabled());
+        });
+        output.textures_delta.clear();
+        assert!(app.actions.is_empty());
+        app.backend.shutdown();
+    }
 }
 
 fn extras(app: &mut App, ui: &mut egui::Ui, now: Option<&NowPlaying>) {


### PR DESCRIPTION
## Interface changes

Adds a DJ-only button in the main player bar to change sets, plus speaking/changing-set status and an option to open DJ in Spotify. Ordinary Next still skips one song. Local DJ playback turns shuffle off and disables its shuffle control; other playback keeps its existing controls.

Starts Spotify's generated DJ session even when its playlist view is empty, sorted, or filtered. Set changes update the displayed song and queue immediately, preserve manually queued songs, and ignore stale state while playback catches up. Custom text/voice requests remain in Spotify's app.

Depends on [crmne/librespot#1](https://github.com/crmne/librespot/pull/1). All seven engine crates are pinned to its public commit, so the branch builds without local patches or setup scripts.

## Validation

On Linux: formatting, both Clippy configurations with warnings denied, all-target tests with default features (321 tests) and all features (323 tests), documentation tests, strict Rustdoc, and the Jekyll site build pass. Regression tests cover the actual DJ playlist Play button, timeout/retry/reconnection, shuffle normalization, distinct set-change actions, and optimistic queue handling. macOS and Windows have not been tested locally.

## Before merge

- Land the engine change, then move the review dependency pin to the maintainer's merged commit and refresh the Nix vendor hash. The existing hash is not valid for this dependency change; Nix has not been checked locally.
- Review before/after screenshots at representative window sizes in light and dark, and approve the DJ control's visual scope. Demo fixtures: `--demo-show dj`, `dj-speaking`, and `dj-playlist`.
