### PR TITLE
docs: fix subject-verb agreement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@ the story from before the user's action is stale, so hold the shown
 state and ask again rather than let the lagging answer undo what the
 user just did. Nothing the user did may ever flicker away and come back.
 
-Every visualiser, the spectrum analyser, the oscilloscope, and MilkDrop,
-shows the signal post-equalizer and pre-volume: the EQ shapes what is
+Every visualiser, the spectrum analyser, the oscilloscope, and MilkDrop
+show the signal post-equalizer and pre-volume: the EQ shapes what is
 heard so the picture follows it, and the volume knob never moves the
 picture. Zero volume still dances.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `AGENTS.md` (line 55).

## Problem

Subject-verb disagreement: the compound subject (four items joined by "and") is plural, so the verb should be "show", not "shows". The comma after "MilkDrop" is also a stray separator before the verb.

The problematic text:

```markdown
Every visualiser, the spectrum analyser, the oscilloscope, and MilkDrop,
shows the signal post-equalizer and pre-volume
```

## Fix

Replaced with:

```markdown
Every visualiser, the spectrum analyser, the oscilloscope, and MilkDrop
show the signal post-equalizer and pre-volume
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text