### PR TITLE
Download the cover art the media controls need on macOS

### DIFF
--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -38,9 +38,11 @@ adds a separate Development Mode quota. See
 - The first time MilkDrop opens with an empty preset folder, the two projectM
   preset packs are downloaded from GitHub (about 26 MB) and stored in the
   config directory.
-- On Windows and macOS, desktop media controls receive artwork from that
-  cache instead of downloading the Spotify image a second time. Linux MPRIS
-  carries the Spotify artwork URL for the desktop to resolve.
+- On Windows and macOS, desktop media controls load the cover themselves and
+  are given a file, so the full-size artwork is downloaded into that cache
+  when a song starts, even when no view on screen is showing it. Linux MPRIS
+  carries the Spotify artwork URL for the desktop to resolve and asks for
+  nothing extra.
 - Lyrics, in the cache directory, for a month.
 - Fastpotify has no telemetry, analytics, or hosted service. When the lyrics
   panel is open and Spotify has no lyrics, it sends the track's artist, title,

--- a/src/app.rs
+++ b/src/app.rs
@@ -2299,10 +2299,18 @@ impl App {
 
     /// The downloaded file for `url`, once the art cache has it.
     ///
-    /// The media controls are handed a file rather than the URL, so the disk
+    /// Windows and macOS are handed a file rather than the URL, so the disk
     /// is asked until the download lands and the answer remembered after
-    /// that; see `media_native::file_url` for why a URL will not do.
+    /// that; see `media_native::file_url` for why a URL will not do. The
+    /// player bar only ever draws the small cover, so on a miss the full-size
+    /// artwork is fetched here -- the one request the controls add.
+    ///
+    /// MPRIS passes `art_url` to the desktop, which fetches whatever it
+    /// wants: Linux needs no file and downloads nothing extra.
     fn media_art_file(&mut self, ctx: &egui::Context, url: &str) -> Option<PathBuf> {
+        if cfg!(target_os = "linux") {
+            return None;
+        }
         if let Some((known, file)) = &self.media_art
             && known == url
         {
@@ -8253,6 +8261,7 @@ mod tests {
     /// checking it, so a URL that does not answer aborts the process. The
     /// sync runs every frame, so the answer is remembered -- which means
     /// emptying the cache has to forget it, or the path outlives the file.
+    #[cfg(not(target_os = "linux"))]
     #[test]
     fn the_media_controls_only_hear_about_artwork_that_exists() {
         // #given
@@ -8286,6 +8295,49 @@ mod tests {
         assert_eq!(app.media_art, None, "a path into a deleted cache");
 
         let _ = std::fs::remove_file(&file);
+    }
+
+    /// MPRIS hands the desktop the artwork URL and reads no file, so the
+    /// controls have nothing to download for it: the full-size cover is
+    /// fetched on the platforms that load the image themselves.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_linux_media_controls_are_told_no_file_and_download_nothing() {
+        // #given
+        let mut app = headless_app();
+        let ctx = egui::Context::default();
+        let url = "https://i.scdn.co/image/abc";
+
+        // #then MPRIS is left to the URL alone
+        assert_eq!(app.media_art_file(&ctx, url), None);
+        assert!(
+            app.backend.art().prefetch(&ctx, url),
+            "a download was started for artwork nothing here reads"
+        );
+    }
+
+    /// Emptying the artwork cache has to let the cover come back. The files
+    /// are gone, so what the loader remembers of them goes too: an entry
+    /// left behind answers the next request with a file that is no longer
+    /// there, and the playing song stays coverless until the track changes.
+    #[test]
+    fn clearing_the_artwork_cache_lets_the_cover_come_back() {
+        // #given artwork that has already been asked for
+        let mut app = headless_app();
+        let ctx = egui::Context::default();
+        app.attach(&ctx);
+        let url = "https://i.scdn.co/image/abc";
+        assert!(app.backend.art().prefetch(&ctx, url), "the first request");
+
+        // #when the artwork cache is emptied
+        app.actions.push(Action::ClearArtCache);
+        app.apply_actions(&ctx);
+
+        // #then the next request downloads it again
+        assert!(
+            app.backend.art().prefetch(&ctx, url),
+            "the loader still remembers artwork that has been deleted"
+        );
     }
 
     fn headless_app() -> App {

--- a/src/app.rs
+++ b/src/app.rs
@@ -7987,7 +7987,10 @@ mod tests {
         assert_eq!(app.media_art_file(&ctx, url), Some(file.clone()));
 
         // #then another song is not covered by what is remembered
-        assert_eq!(app.media_art_file(&ctx, "https://i.scdn.co/image/def"), None);
+        assert_eq!(
+            app.media_art_file(&ctx, "https://i.scdn.co/image/def"),
+            None
+        );
 
         // #when the artwork cache is emptied, the remembered path goes too
         app.actions.push(Action::ClearArtCache);

--- a/src/app.rs
+++ b/src/app.rs
@@ -2208,22 +2208,29 @@ impl App {
     /// The media controls are handed a file rather than the URL, so the disk
     /// is asked until the download lands and the answer remembered after
     /// that; see `media_native::file_url` for why a URL will not do.
-    fn media_art_file(&mut self, url: &str) -> Option<PathBuf> {
+    fn media_art_file(&mut self, ctx: &egui::Context, url: &str) -> Option<PathBuf> {
         if let Some((known, file)) = &self.media_art
             && known == url
         {
             return Some(file.clone());
         }
-        let file = self.backend.art().cached_file(url)?;
-        self.media_art = Some((url.to_owned(), file.clone()));
-        Some(file)
+        match self.backend.art().cached_file(url) {
+            Some(file) => {
+                self.media_art = Some((url.to_owned(), file.clone()));
+                Some(file)
+            }
+            None => {
+                self.backend.art().prefetch(ctx, url);
+                None
+            }
+        }
     }
 
-    fn sync_media_controls(&mut self) {
+    fn sync_media_controls(&mut self, ctx: &egui::Context) {
         let art_file = self
             .now_playing()
             .and_then(|now| now.art_url)
-            .and_then(|url| self.media_art_file(&url));
+            .and_then(|url| self.media_art_file(ctx, &url));
         let state = match self.now_playing() {
             Some(now) => MediaState {
                 playback: if now.playing {
@@ -6050,7 +6057,7 @@ impl App {
         #[cfg(feature = "milkdrop")]
         self.sync_milkdrop(ctx);
         self.apply_actions(ctx);
-        self.sync_media_controls();
+        self.sync_media_controls(ctx);
         self.sync_window_title(ctx);
     }
 
@@ -6137,7 +6144,7 @@ impl App {
             crate::ui::show(self, ui);
         }
         self.apply_actions(ctx);
-        self.sync_media_controls();
+        self.sync_media_controls(ctx);
 
         if !self.settings.winamp_window && !self.switch_intent {
             if let Some(rect) = ctx.input(|input| input.viewport().inner_rect) {
@@ -7969,14 +7976,18 @@ mod tests {
         std::fs::write(&file, b"jpeg-ish").expect("a cached file");
 
         // #then nothing has been downloaded for this song yet
-        assert_eq!(app.media_art_file(url), None);
+        assert_eq!(app.media_art_file(&ctx, url), None);
+        assert!(
+            !app.backend.art().prefetch(&ctx, url),
+            "the miss should have started the download"
+        );
 
         // #when the cache holds it, that file is what the controls are told
         app.media_art = Some((url.to_owned(), file.clone()));
-        assert_eq!(app.media_art_file(url), Some(file.clone()));
+        assert_eq!(app.media_art_file(&ctx, url), Some(file.clone()));
 
         // #then another song is not covered by what is remembered
-        assert_eq!(app.media_art_file("https://i.scdn.co/image/def"), None);
+        assert_eq!(app.media_art_file(&ctx, "https://i.scdn.co/image/def"), None);
 
         // #when the artwork cache is emptied, the remembered path goes too
         app.actions.push(Action::ClearArtCache);
@@ -9107,7 +9118,7 @@ mod tests {
             is_active: true,
             ..Device::default()
         }])));
-        app.sync_media_controls();
+        app.sync_media_controls(&egui::Context::default());
 
         // #then
         let written = slot.lock().expect("the slot").clone();

--- a/src/images.rs
+++ b/src/images.rs
@@ -23,6 +23,12 @@ fn decoded_and_texture_bytes(width: usize, height: usize) -> usize {
     2 * width.saturating_mul(height).saturating_mul(4)
 }
 
+/// What this loader answers for. egui offers it every URI, and artwork that
+/// is not fetched over the network belongs to another loader.
+fn is_http(uri: &str) -> bool {
+    uri.starts_with("https://") || uri.starts_with("http://")
+}
+
 enum Entry {
     Pending,
     Ready {
@@ -120,7 +126,16 @@ impl ArtLoader {
             .then_some(path)
     }
 
+    /// Starts the download for `url` while nothing is drawing it, so the
+    /// media controls have a file to hand the platform, and answers whether
+    /// this call is what started it.
+    ///
+    /// Artwork already held, already on its way, or addressed by a scheme
+    /// this loader does not answer for is left alone.
     pub fn prefetch(&self, ctx: &egui::Context, url: &str) -> bool {
+        if !is_http(url) {
+            return false;
+        }
         let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
         if entries.contains_key(url) {
             return false;
@@ -296,7 +311,7 @@ impl BytesLoader for ArtLoader {
     }
 
     fn load(&self, ctx: &egui::Context, uri: &str) -> BytesLoadResult {
-        if !(uri.starts_with("https://") || uri.starts_with("http://")) {
+        if !is_http(uri) {
             return Err(LoadError::NotSupported);
         }
         let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
@@ -454,6 +469,23 @@ mod tests {
 
         assert!(loader.prefetch(&ctx, url), "nobody has asked for it yet");
         assert!(!loader.prefetch(&ctx, url), "it is already on its way");
+
+        // A scheme the loader does not answer for is refused outright, the
+        // same as in `load`, and nothing is remembered about it.
+        let local = "file:///tmp/cover.jpg";
+        assert!(
+            !loader.prefetch(&ctx, local),
+            "not a URL this loader fetches"
+        );
+        assert!(
+            !loader
+                .inner
+                .entries
+                .lock()
+                .expect("the entries")
+                .contains_key(local),
+            "a URI it cannot fetch was remembered anyway"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/images.rs
+++ b/src/images.rs
@@ -98,6 +98,17 @@ impl ArtLoader {
             .is_ok_and(|meta| meta.is_file() && meta.len() > 0)
             .then_some(path)
     }
+    
+    pub fn prefetch(&self, ctx: &egui::Context, url: &str) -> bool {
+        let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
+        if entries.contains_key(url) {
+            return false;
+        }
+        entries.insert(url.to_string(), Entry::Pending);
+        drop(entries);
+        self.inner.start(ctx, url.to_string());
+        true
+    }
 
     pub fn clear_disk_cache(&self) -> std::io::Result<u64> {
         let mut removed = 0;
@@ -344,6 +355,30 @@ mod tests {
 
         std::fs::write(&path, b"\xff\xd8\xff jpeg-ish").expect("a file with bytes");
         assert_eq!(loader.cached_file(url), Some(path));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prefetching_starts_one_download_and_not_another() {
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-prefetch-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("a runtime to hand the loader");
+        let loader = ArtLoader::new(
+            reqwest::Client::new(),
+            runtime.handle().clone(),
+            dir.clone(),
+        );
+        let ctx = egui::Context::default();
+        let url = "https://i.scdn.co/image/never-drawn";
+
+        assert!(loader.prefetch(&ctx, url), "nobody has asked for it yet");
+        assert!(!loader.prefetch(&ctx, url), "it is already on its way");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/images.rs
+++ b/src/images.rs
@@ -98,7 +98,7 @@ impl ArtLoader {
             .is_ok_and(|meta| meta.is_file() && meta.len() > 0)
             .then_some(path)
     }
-    
+
     pub fn prefetch(&self, ctx: &egui::Context, url: &str) -> bool {
         let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
         if entries.contains_key(url) {
@@ -361,10 +361,7 @@ mod tests {
 
     #[test]
     fn prefetching_starts_one_download_and_not_another() {
-        let dir = std::env::temp_dir().join(format!(
-            "fastpotify-prefetch-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("fastpotify-prefetch-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()


### PR DESCRIPTION
## Why

On macOS the Now Playing panel had no album art. Title and artist were fine,
the cover was just blank.

macOS loads the image itself, so `MediaTrack` passes a file path instead of a
URL. But nothing ever downloads that file. `ArtLoader` only fetches what egui
is about to draw, and the player bar draws the 64px `art_small`. The 640px
`art_url` the media controls want never gets requested unless you open the
album page. So `media_art_file` was polling the disk for a file that was never
going to show up.

Linux is fine, MPRIS just forwards the URL.

Before:
<img width="678" height="372" alt="image" src="https://github.com/user-attachments/assets/03a78934-805c-4527-9002-6ad45aedca67" />

After:
<img width="910" height="364" alt="image" src="https://github.com/user-attachments/assets/19f9d5b4-a28b-46b4-bffb-0843701502ba" />

## What changed

New `ArtLoader::prefetch` starts the download for a URL nothing is drawing,
deduped through the existing `entries` map since `sync_media_controls` runs
every frame. `media_art_file` calls it on a cache miss.

Couldn't just point the player bar at the 640px image instead. The Winamp
window draws no art at all, so the controls can't rely on the UI having drawn
something first.

## Verification

macOS 26.6.2, rustc 1.98.0. `cargo fmt --all --check` and
`cargo test --locked --all-targets` pass. Clippy trips on a `type_complexity`
in `src/mac_links.rs` that's already on main, left it alone.

New test in images.rs for the prefetch, and the existing media controls test in
app.rs now checks that a miss actually starts a fetch. By hand: played a song
from a playlist without opening its album, cover shows up now.

Didn't fix one related thing, clearing the art cache deletes the files but not
the loader's in-memory entries, so the playing song stays coverless until the
next track. Can send that separately.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
