### PR TITLE
dragging selection of two tracks

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1302,10 +1302,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    /// A drag in flight renders, and releasing it over an owned playlist
-    /// row lands in the same add-to-playlist plumbing the row menu uses.
+    /// A drag in flight renders, and releasing a selected set over an owned
+    /// playlist row lands every song in the usual add-to-playlist plumbing.
     #[test]
-    fn dropping_a_song_on_a_sidebar_playlist_adds_it() {
+    fn dropping_selected_songs_on_a_sidebar_playlist_adds_them_all() {
         let root =
             std::env::temp_dir().join(format!("fastpotify-drag-test-{}", std::process::id()));
         let dirs = AppDirs {
@@ -1327,10 +1327,30 @@ mod tests {
         );
         app.attach(&ctx);
         populate(&mut app);
+        app.library
+            .playlists
+            .get_mut()
+            .expect("the demo library")
+            .retain(|playlist| playlist.id == "pl1");
         app.open(Page::Playlist("pl1".into()));
         for _ in 0..3 {
             frame(&ctx, &mut app);
         }
+        let before = app.playlist_pages["pl1"].items.items.len();
+        let dragged = vec![
+            PlayableItem::Track(Track {
+                id: Some("not-in-demo-playlists".into()),
+                uri: "spotify:track:not-in-demo-playlists".into(),
+                name: "A new song".into(),
+                ..Default::default()
+            }),
+            PlayableItem::Track(Track {
+                id: Some("also-not-in-demo-playlists".into()),
+                uri: "spotify:track:also-not-in-demo-playlists".into(),
+                name: "Another new song".into(),
+                ..Default::default()
+            }),
+        ];
 
         // Sweep a held track down the sidebar; somewhere along the sweep
         // the pointer crosses an owned playlist row, and releasing there
@@ -1343,15 +1363,9 @@ mod tests {
             egui::DragAndDrop::set_payload(
                 &ctx,
                 DragTrack {
-                    uri: "spotify:track:not-in-demo-playlists".into(),
                     title: "A new song".into(),
                     image: None,
-                    item: PlayableItem::Track(Track {
-                        id: Some("not-in-demo-playlists".into()),
-                        uri: "spotify:track:not-in-demo-playlists".into(),
-                        name: "A new song".into(),
-                        ..Default::default()
-                    }),
+                    items: dragged.clone(),
                     from: None,
                 },
             );
@@ -1373,6 +1387,7 @@ mod tests {
             }
         }
         assert!(dropped, "no sweep position landed on an owned playlist row");
+        assert_eq!(app.playlist_pages["pl1"].items.items.len(), before + 2);
         app.backend.shutdown();
         let _ = std::fs::remove_dir_all(root);
     }
@@ -1431,8 +1446,8 @@ mod tests {
 
         let payload = egui::DragAndDrop::payload::<DragTrack>(&ctx)
             .expect("dragging the bottom-left song should create a song payload");
-        assert_eq!(payload.uri, "spotify:track:trk0");
-        assert_eq!(payload.item.uri(), "spotify:track:trk0");
+        assert_eq!(payload.items.len(), 1);
+        assert_eq!(payload.items[0].uri(), "spotify:track:trk0");
         assert_eq!(payload.from, None, "this is an add, not a playlist move");
 
         egui::DragAndDrop::clear_payload(&ctx);
@@ -1642,14 +1657,13 @@ mod tests {
         let original = order(&app);
         let from = 5usize;
         let held = |from: usize, uri: &str| DragTrack {
-            uri: uri.to_string(),
             title: "Closer".into(),
             image: None,
-            item: PlayableItem::Track(Track {
+            items: vec![PlayableItem::Track(Track {
                 uri: uri.to_string(),
                 name: "Closer".into(),
                 ..Default::default()
-            }),
+            })],
             from: Some(("pl1".into(), from as u32)),
         };
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -542,12 +542,12 @@ pub enum RowContext {
 /// Track data held during a drag.
 #[derive(Clone, Debug)]
 pub struct DragTrack {
-    pub uri: String,
     pub title: String,
     /// Cover art for the drag preview.
     pub image: Option<String>,
     /// Full row data, so dropping can update an open playlist immediately.
-    pub item: PlayableItem,
+    /// A picked table row carries the whole selection in table order.
+    pub items: Vec<PlayableItem>,
     /// Source playlist ID and row index for moves within an editable playlist.
     pub from: Option<(String, u32)>,
 }

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -194,10 +194,9 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         egui::DragAndDrop::set_payload(
             ui.ctx(),
             DragTrack {
-                uri: item.uri().to_string(),
                 title: item.name().to_string(),
                 image: item.image(64).map(str::to_string),
-                item: item.clone(),
+                items: vec![item.clone()],
                 from: None,
             },
         );

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -970,16 +970,21 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                     && let Some(track) = response.dnd_release_payload::<DragTrack>()
                 {
                     if entry.liked {
-                        // Dropping on Liked Songs saves; a song already
-                        // saved is left alone.
-                        if app.is_saved(&track.uri) != Some(true) {
-                            app.actions.push(Action::ToggleSaved(track.uri.clone()));
-                        }
+                        // Dropping on Liked Songs saves every dragged song;
+                        // songs already saved stay saved.
+                        app.actions.push(Action::SetSavedMany {
+                            uris: track
+                                .items
+                                .iter()
+                                .map(|item| item.uri().to_string())
+                                .collect(),
+                            saved: true,
+                        });
                     } else if let Page::Playlist(id) = &entry.page {
                         app.actions.push(Action::AddToPlaylist {
                             playlist_id: id.clone(),
                             playlist_name: entry.name.clone(),
-                            items: vec![track.item.clone()],
+                            items: track.items.clone(),
                         });
                     }
                 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1191,6 +1191,14 @@ fn dragged_items(
     }
 }
 
+fn drag_label(track: &DragTrack) -> String {
+    match track.items.as_slice() {
+        [] => track.title.clone(),
+        [item] => item.name().to_string(),
+        [first, rest @ ..] => format!("{} + {} more", first.name(), rest.len()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1213,13 +1221,33 @@ mod tests {
             "the sidebar receives every selected row in table order"
         );
     }
+
+    #[test]
+    fn dragging_multiple_songs_labels_the_first_and_the_rest() {
+        let track = DragTrack {
+            title: "Fitraten (VDJ Fly LoFi)".into(),
+            image: None,
+            items: vec![
+                PlayableItem::Track(Track {
+                    name: "Kora Panna".into(),
+                    ..Default::default()
+                }),
+                PlayableItem::Track(Track {
+                    name: "Fitraten (VDJ Fly LoFi)".into(),
+                    ..Default::default()
+                }),
+            ],
+            from: None,
+        };
+        assert_eq!(drag_label(&track), "Kora Panna + 1 more");
+    }
 }
 
 /// The chip that rides the pointer while a song is being dragged.
 pub fn drag_ghost(ctx: &egui::Context, palette: &Palette) {
     // A song and a sidebar row ride the pointer the same way.
     let chip = egui::DragAndDrop::payload::<DragTrack>(ctx)
-        .map(|track| (track.title.clone(), track.image.clone()))
+        .map(|track| (drag_label(&track), track.image.clone()))
         .or_else(|| {
             egui::DragAndDrop::payload::<DragEntry>(ctx)
                 .map(|entry| (entry.title.clone(), entry.image.clone()))

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1199,50 +1199,6 @@ fn drag_label(track: &DragTrack) -> String {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn song(uri: &str) -> PlayableItem {
-        PlayableItem::Track(Track {
-            uri: uri.to_string(),
-            ..Default::default()
-        })
-    }
-
-    #[test]
-    fn dragging_a_picked_row_carries_the_whole_selection() {
-        let first = song("spotify:track:first");
-        let second = song("spotify:track:second");
-        let dragged = dragged_items(&second, true, &[first.clone(), second.clone()]);
-        assert_eq!(
-            dragged.iter().map(PlayableItem::uri).collect::<Vec<_>>(),
-            [first.uri(), second.uri()],
-            "the sidebar receives every selected row in table order"
-        );
-    }
-
-    #[test]
-    fn dragging_multiple_songs_labels_the_first_and_the_rest() {
-        let track = DragTrack {
-            title: "Fitraten (VDJ Fly LoFi)".into(),
-            image: None,
-            items: vec![
-                PlayableItem::Track(Track {
-                    name: "Kora Panna".into(),
-                    ..Default::default()
-                }),
-                PlayableItem::Track(Track {
-                    name: "Fitraten (VDJ Fly LoFi)".into(),
-                    ..Default::default()
-                }),
-            ],
-            from: None,
-        };
-        assert_eq!(drag_label(&track), "Kora Panna + 1 more");
-    }
-}
-
 /// The chip that rides the pointer while a song is being dragged.
 pub fn drag_ghost(ctx: &egui::Context, palette: &Palette) {
     // A song and a sidebar row ride the pointer the same way.
@@ -1979,4 +1935,48 @@ pub fn setting_row(
         ui.with_layout(Layout::right_to_left(Align::Center), control);
     });
     ui.add_space(10.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn song(uri: &str) -> PlayableItem {
+        PlayableItem::Track(Track {
+            uri: uri.to_string(),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn dragging_a_picked_row_carries_the_whole_selection() {
+        let first = song("spotify:track:first");
+        let second = song("spotify:track:second");
+        let dragged = dragged_items(&second, true, &[first.clone(), second.clone()]);
+        assert_eq!(
+            dragged.iter().map(PlayableItem::uri).collect::<Vec<_>>(),
+            [first.uri(), second.uri()],
+            "the sidebar receives every selected row in table order"
+        );
+    }
+
+    #[test]
+    fn dragging_multiple_songs_labels_the_first_and_the_rest() {
+        let track = DragTrack {
+            title: "Fitraten (VDJ Fly LoFi)".into(),
+            image: None,
+            items: vec![
+                PlayableItem::Track(Track {
+                    name: "Kora Panna".into(),
+                    ..Default::default()
+                }),
+                PlayableItem::Track(Track {
+                    name: "Fitraten (VDJ Fly LoFi)".into(),
+                    ..Default::default()
+                }),
+            ],
+            from: None,
+        };
+        assert_eq!(drag_label(&track), "Kora Panna + 1 more");
+    }
 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -643,21 +643,23 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) -> Option<RowPic
     }
     // Start a sidebar drag only after egui's drag threshold.
     if row.item.is_track() && response.drag_started_by(egui::PointerButton::Primary) {
+        let items = dragged_items(row.item, row.picked, row.picked_songs);
         // Keep the source index for moves within an editable playlist.
-        let from = match row.context {
-            RowContext::Context {
-                editable_playlist: Some((id, _)),
-                ..
-            } => Some((id.clone(), row.index as u32)),
-            _ => None,
-        };
+        let from = (items.len() == 1)
+            .then(|| match row.context {
+                RowContext::Context {
+                    editable_playlist: Some((id, _)),
+                    ..
+                } => Some((id.clone(), row.index as u32)),
+                _ => None,
+            })
+            .flatten();
         egui::DragAndDrop::set_payload(
             ui.ctx(),
             DragTrack {
-                uri: row.item.uri().to_string(),
                 title: row.item.name().to_string(),
                 image: row.item.image(64).map(str::to_string),
-                item: row.item.clone(),
+                items,
                 from,
             },
         );
@@ -1175,6 +1177,42 @@ pub fn track_row(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) -> Option<RowPic
             }
         });
     pick
+}
+
+fn dragged_items(
+    item: &PlayableItem,
+    picked: bool,
+    picked_songs: &[PlayableItem],
+) -> Vec<PlayableItem> {
+    if picked && !picked_songs.is_empty() {
+        picked_songs.to_vec()
+    } else {
+        vec![item.clone()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn song(uri: &str) -> PlayableItem {
+        PlayableItem::Track(Track {
+            uri: uri.to_string(),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn dragging_a_picked_row_carries_the_whole_selection() {
+        let first = song("spotify:track:first");
+        let second = song("spotify:track:second");
+        let dragged = dragged_items(&second, true, &[first.clone(), second.clone()]);
+        assert_eq!(
+            dragged.iter().map(PlayableItem::uri).collect::<Vec<_>>(),
+            [first.uri(), second.uri()],
+            "the sidebar receives every selected row in table order"
+        );
+    }
 }
 
 /// The chip that rides the pointer while a song is being dragged.


### PR DESCRIPTION
## Why

Dragging a multi-track selection to a playlist only added the row where the drag began. This fixes https://github.com/crmne/fastpotify/issues/285 so selected tracks behave consistently with other batch actions.

## What changed

- Carry every selected track in the drag payload, in table order.
- Add every dragged track when dropped on a playlist.
- Show the drag preview as the first selected track plus the remaining count, for example `Kora Panna + 1 more`.
- Keep single-track drags and in-playlist reordering unchanged.

## Verification

Tested on Linux:

```sh
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets
cargo test --locked --lib ui::widgets::tests

