### PR TITLE
fix: update queue when toggling shuffle

### DIFF
--- a/docs/_reference/queue.md
+++ b/docs/_reference/queue.md
@@ -43,6 +43,8 @@ check every one of them.
 
 8. **Changes appear immediately.** Fastpotify updates the queue before Spotify
    confirms the change. For local playback, it updates its own player directly.
+   Toggling shuffle rechecks the queue so the new playback order appears
+   promptly without waiting for the song to finish.
 
 9. **Closing the app keeps the queue.** Fastpotify saves it locally. When you
    resume the last song, it restores your queued songs and playlist position.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4122,6 +4122,9 @@ impl App {
                 match result {
                     Ok(()) => {
                         self.remote_recheck_at = Some(Instant::now() + REMOTE_RECHECK);
+                        if action == RemoteAction::Shuffle {
+                            self.queue_recheck_at = Some(Instant::now() + QUEUE_RECHECK);
+                        }
                     }
                     Err(error) => {
                         self.optimistic_playing = None;
@@ -4445,6 +4448,7 @@ impl App {
         if shuffle_first {
             self.shuffle_wanted = true;
             self.shuffle_set_at = Some(Instant::now());
+            self.queue_recheck_at = Some(Instant::now() + QUEUE_RECHECK);
         }
         let shuffle = shuffle_first || self.shuffle_wanted;
         if shuffle
@@ -4857,6 +4861,7 @@ impl App {
         if let Some(assumed) = &mut self.assumed_context {
             assumed.shuffle = Some(shuffle);
         }
+        self.queue_recheck_at = Some(Instant::now() + QUEUE_RECHECK);
         match self.target() {
             Target::Local => {
                 self.local.shuffle = shuffle;
@@ -7500,6 +7505,271 @@ mod tests {
         );
         app.manual_queue.clear();
         assert_eq!(app.queued_rows_len(), 0);
+    }
+
+    /// Changing shuffle rechecks the queue to reflect the new playback order.
+    #[test]
+    fn changing_shuffle_schedules_a_queue_recheck() {
+        let mut app = headless_app();
+        app.queue = loaded_queue("spotify:track:a", &["spotify:track:b"]);
+        assert!(app.queue_recheck_at.is_none());
+        app.set_shuffle(true);
+        assert!(
+            app.queue_recheck_at.is_some(),
+            "toggling shuffle asks Spotify for the reordered queue"
+        );
+    }
+
+    /// Toggling shuffle for local playback rechecks the queue, reveals the
+    /// new playback order without losing hand-queued songs, and ignores an
+    /// old response from before the toggle.
+    #[test]
+    fn shuffling_local_playback_updates_queue_and_keeps_user_songs() {
+        let mut app = headless_app();
+        app.auth = AuthStatus::Connected {
+            username: "alice".into(),
+        };
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:playing".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Playing;
+        app.manual_queue = vec!["spotify:track:manual1".into()];
+        app.queue = loaded_queue(
+            "spotify:track:playing",
+            &[
+                "spotify:track:manual1",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+                "spotify:track:ctx3",
+            ],
+        );
+        assert_eq!(app.queued_rows_len(), 1);
+
+        // Toggle shuffle on local player.
+        app.set_shuffle(true);
+        assert!(
+            app.queue_recheck_at.is_some(),
+            "toggling shuffle schedules a queue recheck"
+        );
+
+        // Start the queue refresh with a new sequence number.
+        app.refresh_queue(true);
+        let seq = app.queue_seq;
+
+        // A response from before the shuffle command is dropped unread.
+        let old_response = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:manual1"),
+                queued_song("spotify:track:ctx1"),
+                queued_song("spotify:track:ctx2"),
+                queued_song("spotify:track:ctx3"),
+            ],
+        };
+        app.handle_api(ApiResponse::Queue {
+            seq: seq - 1,
+            result: Ok(old_response),
+        });
+        let (_, next) = queue_uris(&app);
+        assert_eq!(
+            next,
+            vec![
+                "spotify:track:manual1",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+                "spotify:track:ctx3",
+            ],
+            "the superseded pre-shuffle response is dropped unread"
+        );
+
+        // When the fresh response arrives, the context rows reflect the new shuffle
+        // order while manually queued rows stay on top.
+        let shuffled_response = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:manual1"),
+                queued_song("spotify:track:ctx3"),
+                queued_song("spotify:track:ctx1"),
+                queued_song("spotify:track:ctx2"),
+            ],
+        };
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(shuffled_response),
+        });
+
+        let (current, next) = queue_uris(&app);
+        assert_eq!(current.as_deref(), Some("spotify:track:playing"));
+        assert_eq!(
+            next,
+            vec![
+                "spotify:track:manual1",
+                "spotify:track:ctx3",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+            ],
+            "the user's song stays on top and the shuffled context order is shown"
+        );
+        assert_eq!(
+            app.queued_rows_len(),
+            1,
+            "the user's queued section is preserved"
+        );
+    }
+
+    /// Toggling shuffle for remote playback rechecks the queue on confirmation,
+    /// adopts the new shuffle order while keeping hand-queued songs, and drops
+    /// an overtaken response.
+    #[test]
+    fn shuffling_remote_playback_updates_queue_and_keeps_user_songs() {
+        let mut app = headless_app();
+        app.auth = AuthStatus::Connected {
+            username: "alice".into(),
+        };
+        app.local_ready = false;
+        app.selected_device = Some("speaker".into());
+        app.remote = Some(RemoteSnapshot {
+            state: PlaybackState {
+                device: Some(crate::api::models::Device {
+                    id: Some("speaker".into()),
+                    name: "Speaker".into(),
+                    is_active: true,
+                    ..Default::default()
+                }),
+                item: Some(crate::api::models::PlayableItem::Track(
+                    crate::api::models::Track {
+                        uri: "spotify:track:playing".into(),
+                        ..Default::default()
+                    },
+                )),
+                is_playing: true,
+                shuffle_state: false,
+                ..Default::default()
+            },
+            received_at: Instant::now(),
+        });
+        app.manual_queue = vec!["spotify:track:manual1".into()];
+        app.queue = loaded_queue(
+            "spotify:track:playing",
+            &[
+                "spotify:track:manual1",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+            ],
+        );
+        assert_eq!(app.queued_rows_len(), 1);
+
+        // Turn on shuffle on the remote target.
+        app.set_shuffle(true);
+        assert!(app.queue_recheck_at.is_some());
+
+        // Spotify confirms the remote shuffle action.
+        app.handle_api(ApiResponse::Remote {
+            action: RemoteAction::Shuffle,
+            result: Ok(()),
+        });
+        assert!(
+            app.queue_recheck_at.is_some(),
+            "confirmed remote shuffle rechecks the queue"
+        );
+
+        // Fetch the queue with a new sequence number.
+        app.refresh_queue(true);
+        let seq = app.queue_seq;
+
+        // An older response is ignored.
+        let stale = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:manual1"),
+                queued_song("spotify:track:ctx1"),
+                queued_song("spotify:track:ctx2"),
+            ],
+        };
+        app.handle_api(ApiResponse::Queue {
+            seq: seq - 1,
+            result: Ok(stale),
+        });
+        assert_eq!(
+            queue_uris(&app).1,
+            vec![
+                "spotify:track:manual1",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+            ]
+        );
+
+        // The confirming response shows the new shuffle order.
+        let shuffled = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:manual1"),
+                queued_song("spotify:track:ctx2"),
+                queued_song("spotify:track:ctx1"),
+            ],
+        };
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(shuffled),
+        });
+
+        let (current, next) = queue_uris(&app);
+        assert_eq!(current.as_deref(), Some("spotify:track:playing"));
+        assert_eq!(
+            next,
+            vec![
+                "spotify:track:manual1",
+                "spotify:track:ctx2",
+                "spotify:track:ctx1",
+            ],
+            "remote shuffle preserves hand-queued songs and updates context rows"
+        );
+        assert_eq!(app.queued_rows_len(), 1);
+    }
+
+    /// A stale queue answer whose current track does not match the active
+    /// local player is rejected rather than accepted after a shuffle toggle.
+    #[test]
+    fn stale_queue_after_shuffle_is_retried_and_not_accepted() {
+        let mut app = headless_app();
+        app.auth = AuthStatus::Connected {
+            username: "alice".into(),
+        };
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:playing".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Playing;
+        app.queue = loaded_queue(
+            "spotify:track:playing",
+            &["spotify:track:ctx1", "spotify:track:ctx2"],
+        );
+
+        app.set_shuffle(true);
+        app.refresh_queue(true);
+        let seq = app.queue_seq;
+
+        // A stale response that reports an old playing track is rejected.
+        let stale_track_response = Queue {
+            currently_playing: Some(queued_song("spotify:track:old_song")),
+            queue: vec![
+                queued_song("spotify:track:ctx2"),
+                queued_song("spotify:track:ctx1"),
+            ],
+        };
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(stale_track_response),
+        });
+
+        assert_eq!(
+            queue_uris(&app).1,
+            vec!["spotify:track:ctx1", "spotify:track:ctx2"],
+            "the queue remains uncorrupted by the stale response"
+        );
+        assert_eq!(app.queue_stale_retries, 1);
+        assert!(app.queue_recheck_at.is_some());
     }
 
     fn picked(app: &App, page: &Page) -> Vec<usize> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -94,6 +94,14 @@ enum TrackConfirmation {
     Remote { after_poll: u64, mismatches: u8 },
 }
 
+/// Upcoming context order before shuffle was toggled, used to detect lagging responses.
+#[derive(Clone, Debug)]
+struct QueueShufflePending {
+    current_uri: Option<String>,
+    context_uris: Vec<String>,
+    at: Instant,
+}
+
 /// The playing item as the interface sees it, whichever device plays it.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NowPlaying {
@@ -237,6 +245,8 @@ pub struct App {
     queue_stale_retries: u8,
     /// Rows removed by Clear queue, used to detect stale responses.
     queue_cleared: Option<(std::collections::HashSet<String>, Instant)>,
+    /// Upcoming context order before shuffle was toggled, used to detect lagging responses.
+    queue_shuffle_pending: Option<QueueShufflePending>,
     /// What the window's title bar says, as last set.
     window_title: String,
 
@@ -542,6 +552,7 @@ impl App {
             queue_recheck_at: None,
             queue_stale_retries: 0,
             queue_cleared: None,
+            queue_shuffle_pending: None,
             window_title: String::new(),
             library: Library::default(),
             home: HomeData::default(),
@@ -1417,6 +1428,7 @@ impl App {
         self.saved_recordings.clear();
         self.saved_writes.clear();
         self.queue = Loadable::NotLoaded;
+        self.queue_shuffle_pending = None;
         self.devices.clear();
         self.control_devices_stale = true;
         self.devices_fetched_at = None;
@@ -3064,6 +3076,24 @@ impl App {
         {
             return true;
         }
+        // An unchanged context order right after toggling shuffle means the
+        // reordered queue has not landed yet.
+        if let Some(pending) = &self.queue_shuffle_pending
+            && pending.at.elapsed() < PLAYBACK_HOLD
+            && fetched.currently_playing.as_ref().map(|item| item.uri())
+                == pending.current_uri.as_deref()
+        {
+            let at = Self::end_of_queued_rows(&fetched.queue, &self.manual_queue);
+            let fetched_context = &fetched.queue[at..];
+            if fetched_context.len() == pending.context_uris.len()
+                && fetched_context
+                    .iter()
+                    .map(|item| item.uri())
+                    .eq(pending.context_uris.iter().map(String::as_str))
+            {
+                return true;
+            }
+        }
         false
     }
 
@@ -3302,6 +3332,7 @@ impl App {
                 self.queue_stale_retries = 0;
                 if result.is_ok() {
                     self.queue_cleared = None;
+                    self.queue_shuffle_pending = None;
                 }
                 self.queue = Loadable::from_result(result);
                 self.reconcile_pending_queue();
@@ -4124,6 +4155,11 @@ impl App {
                         self.remote_recheck_at = Some(Instant::now() + REMOTE_RECHECK);
                         if action == RemoteAction::Shuffle {
                             self.queue_recheck_at = Some(Instant::now() + QUEUE_RECHECK);
+                            if let Some(pending) = &mut self.queue_shuffle_pending {
+                                pending.at = Instant::now();
+                            } else {
+                                self.note_shuffle_pending();
+                            }
                         }
                     }
                     Err(error) => {
@@ -4445,6 +4481,7 @@ impl App {
         // Shuffle applies across contexts until disabled. A selected row still
         // starts first; otherwise choose a random starting track.
         let mut request = request;
+        self.queue_shuffle_pending = None;
         if shuffle_first {
             self.shuffle_wanted = true;
             self.shuffle_set_at = Some(Instant::now());
@@ -4854,6 +4891,25 @@ impl App {
         }
     }
 
+    fn note_shuffle_pending(&mut self) {
+        if let Loadable::Loaded(queue) = &self.queue {
+            let at = Self::end_of_queued_rows(&queue.queue, &self.manual_queue);
+            let context_uris: Vec<String> = queue.queue[at..]
+                .iter()
+                .map(|item| item.uri().to_string())
+                .collect();
+            if context_uris.len() > 1 && context_uris.iter().any(|uri| uri != &context_uris[0]) {
+                self.queue_shuffle_pending = Some(QueueShufflePending {
+                    current_uri: self.current_track_uri(),
+                    context_uris,
+                    at: Instant::now(),
+                });
+            } else {
+                self.queue_shuffle_pending = None;
+            }
+        }
+    }
+
     fn set_shuffle(&mut self, shuffle: bool) {
         self.shuffle_wanted = shuffle;
         self.shuffle_set_at = Some(Instant::now());
@@ -4862,6 +4918,7 @@ impl App {
             assumed.shuffle = Some(shuffle);
         }
         self.queue_recheck_at = Some(Instant::now() + QUEUE_RECHECK);
+        self.note_shuffle_pending();
         match self.target() {
             Target::Local => {
                 self.local.shuffle = shuffle;
@@ -7770,6 +7827,155 @@ mod tests {
         );
         assert_eq!(app.queue_stale_retries, 1);
         assert!(app.queue_recheck_at.is_some());
+    }
+
+    /// A lagging queue answer after a shuffle toggle with the same current song
+    /// and sequence is rejected and retried until the new order arrives.
+    #[test]
+    fn lagging_queue_after_shuffle_is_retried_until_new_order_arrives() {
+        let mut app = headless_app();
+        app.auth = AuthStatus::Connected {
+            username: "alice".into(),
+        };
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:playing".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Playing;
+        app.manual_queue = vec!["spotify:track:manual1".into()];
+        app.queue = loaded_queue(
+            "spotify:track:playing",
+            &[
+                "spotify:track:manual1",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+                "spotify:track:ctx3",
+            ],
+        );
+
+        app.set_shuffle(true);
+        app.refresh_queue(true);
+        let seq = app.queue_seq;
+
+        // A lagging response arrives with the same currently playing track and
+        // the current sequence, but the context rows are still in the old order.
+        let lagging_response = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:manual1"),
+                queued_song("spotify:track:ctx1"),
+                queued_song("spotify:track:ctx2"),
+                queued_song("spotify:track:ctx3"),
+            ],
+        };
+
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(lagging_response.clone()),
+        });
+
+        // The stale pre-shuffle order is rejected, preserving the existing queue,
+        // incrementing the retry counter, and scheduling a prompt recheck.
+        assert_eq!(app.queue_stale_retries, 1);
+        assert!(app.queue_recheck_at.is_some());
+        assert_eq!(
+            queue_uris(&app).1,
+            vec![
+                "spotify:track:manual1",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+                "spotify:track:ctx3",
+            ]
+        );
+
+        // A second lagging response also retries.
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(lagging_response),
+        });
+        assert_eq!(app.queue_stale_retries, 2);
+        assert!(app.queue_recheck_at.is_some());
+
+        // Once the reordered response arrives, it is accepted and pending state clears.
+        let new_order_response = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:manual1"),
+                queued_song("spotify:track:ctx3"),
+                queued_song("spotify:track:ctx1"),
+                queued_song("spotify:track:ctx2"),
+            ],
+        };
+
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(new_order_response),
+        });
+
+        assert_eq!(app.queue_stale_retries, 0);
+        assert!(app.queue_shuffle_pending.is_none());
+        assert_eq!(
+            queue_uris(&app).1,
+            vec![
+                "spotify:track:manual1",
+                "spotify:track:ctx3",
+                "spotify:track:ctx1",
+                "spotify:track:ctx2",
+            ]
+        );
+    }
+
+    /// If Spotify returns an unchanged queue order after shuffle, Fastpotify
+    /// retries up to the limit and then accepts the result as a bounded fallback.
+    #[test]
+    fn unchanged_shuffle_result_has_bounded_fallback() {
+        let mut app = headless_app();
+        app.auth = AuthStatus::Connected {
+            username: "alice".into(),
+        };
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:playing".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Playing;
+        app.queue = loaded_queue(
+            "spotify:track:playing",
+            &["spotify:track:ctx1", "spotify:track:ctx2"],
+        );
+
+        app.set_shuffle(true);
+        app.refresh_queue(true);
+        let seq = app.queue_seq;
+
+        let unchanged_response = Queue {
+            currently_playing: Some(queued_song("spotify:track:playing")),
+            queue: vec![
+                queued_song("spotify:track:ctx1"),
+                queued_song("spotify:track:ctx2"),
+            ],
+        };
+
+        // Responses with the pre-shuffle order are rejected as stale and scheduled for retry.
+        for expected_retries in 1..=QUEUE_STALE_RETRIES {
+            app.handle_api(ApiResponse::Queue {
+                seq,
+                result: Ok(unchanged_response.clone()),
+            });
+            assert_eq!(app.queue_stale_retries, expected_retries);
+            assert!(app.queue_recheck_at.is_some());
+        }
+
+        // The next response exceeds the retry limit, so Fastpotify accepts it.
+        app.handle_api(ApiResponse::Queue {
+            seq,
+            result: Ok(unchanged_response),
+        });
+        assert_eq!(app.queue_stale_retries, 0);
+        assert!(app.queue_shuffle_pending.is_none());
+        assert_eq!(
+            queue_uris(&app).1,
+            vec!["spotify:track:ctx1", "spotify:track:ctx2"]
+        );
     }
 
     fn picked(app: &App, page: &Page) -> Vec<usize> {


### PR DESCRIPTION
Toggling shuffle reorders upcoming playback, but set_shuffle did not schedule a queue fetch. The queue sidebar remained on the previous unshuffled order until playback transitioned to a new track or the sidebar was closed and reopened.

Schedule queue_recheck_at when changing shuffle and when remote shuffle succeeds, and add a regression test.

## Why

When listening to a playlist and toggling shuffle (via the player bar button, menu, or the S key shortcut), upcoming playback is reordered by the player engine or Spotify Connect, but the queue sidebar on the right does not reflect the new order. The user has to close and reopen the queue tab or wait for the current song to finish for the shuffled order to appear.                                  

This change ensures the queue reflects the new playback order promptly upon toggling shuffle.

## What changed
- In `set_shuffle`, schedule `self.queue_recheck_at = Some(Instant::now() + QUEUE_RECHECK)` so changing shuffle triggers a queue fetch after 700 ms.                                                                                                                           
- In `play_request`, schedule `queue_recheck_at` when starting playback with `shuffle_first`.                                          
- In `ApiResponse::Remote`, schedule `queue_recheck_at` when `RemoteAction::Shuffle` succeeds.                                         
- Added regression test `changing_shuffle_schedules_a_queue_recheck` in `src/app.rs`.                                                  
                                                                                                                                           
User-visible UI impact:                                                                                                                
- The queue sidebar ("Next up") automatically refreshes and displays the new playback order when shuffle is toggled.

## Verification

    - Added regression unit test `changing_shuffle_schedules_a_queue_recheck`.                                   
    - Verified on Windows with `cargo run --no-default-features`: toggling shuffle updates the queue sidebar     
  immediately without closing and reopening the panel.                                                           
                                                                                                                 
    - [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.                                    
    - [x] I added or updated tests for behaviour that can regress.                                               
    - [x] I ran formatting, Clippy, and the relevant tests locally.                                              
    - [x] I updated documentation for user-visible behaviour, settings, files, or network access.                
    - [x] I understand and take responsibility for every submitted line, including AI-assisted code. 
