### PR TITLE
Prevent a crash when removing a song from Liked Songs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3877,7 +3877,6 @@ impl App {
                                         } else {
                                             self.library
                                                 .liked
-                                                .items
                                                 .retain(|item| item.track.uri != *uri);
                                             if let Some(total) = self.library.liked.total.as_mut() {
                                                 *total = total.saturating_sub(1);
@@ -9517,6 +9516,47 @@ mod tests {
                 100.0, 150.0
             ))),
             "attach restored the main window position: {commands:?}"
+        );
+    }
+
+    /// Unliking a song shortens Liked Songs. The table caches its row order
+    /// against the list's revision, so a silent removal leaves the cache
+    /// pointing past the end of the rows and the next frame panics.
+    #[test]
+    fn unliking_a_song_moves_the_liked_revision() {
+        use crate::api::models::SavedTrack;
+
+        let saved = |uri: &str| SavedTrack {
+            added_at: None,
+            track: Track {
+                uri: uri.into(),
+                ..Default::default()
+            },
+        };
+        let mut app = headless_app();
+        app.library.liked.items = vec![saved("spotify:track:stays"), saved("spotify:track:goes")];
+        app.library.liked.total = Some(2);
+        app.library.liked.loaded_once = true;
+        let before = app.library.liked.revision;
+
+        app.handle_api(ApiResponse::SavedChanged {
+            uris: vec!["spotify:track:goes".into()],
+            saved: false,
+            result: Ok(()),
+        });
+
+        let uris: Vec<&str> = app
+            .library
+            .liked
+            .items
+            .iter()
+            .map(|item| item.track.uri.as_str())
+            .collect();
+        assert_eq!(uris, vec!["spotify:track:stays"], "the song is gone");
+        assert_eq!(app.library.liked.total, Some(1));
+        assert_ne!(
+            app.library.liked.revision, before,
+            "the shorter list must invalidate the table's cached row order"
         );
     }
 }


### PR DESCRIPTION
## Why

Removing a song from Liked Songs crashes the app. It is a panic in Fastpotify's own state handling, not a Spotify or upstream limit, and it takes playback down with it.

Fixes #305 

## What changed

Removing a liked song ran [`self.library.liked.items.retain(...)`](https://github.com/crmne/fastpotify/blob/3c96b5416c907221068da7d869fd73f996edfde2/src/app.rs#L3878-L3881), which calls `Vec::retain` instead of [`PagedList::retain`](https://github.com/crmne/fastpotify/blob/3c96b5416c907221068da7d869fd73f996edfde2/src/model.rs#L228-L234) and leaves `PagedList::revision` untouched. The track table caches its row order against [that revision](https://github.com/crmne/fastpotify/blob/3c96b5416c907221068da7d869fd73f996edfde2/src/ui/collection.rs#L328-L333), so it went on using an order built when the list was one row longer, and the first frame that painted that row indexed past the end of the shortened vector.

Only one index is ever out of range, the last in load order. Sorting by Added ascending puts it at the top of the view, which is why the crash is immediate with that sort and needs a scroll to the bottom without it.

Going through `PagedList::retain` moves the revision, so the table rebuilds its row order. That is what the other mutators on the list already do.

`PagedList::items` being public is what allowed the wrong call. Making it private is a mechanical change across ~40 call sites and the test fixtures, so I left it out of this pull request; happy to open it as a follow-up.

## Verification

All checks from `CONTRIBUTING.md` pass locally. Tested on Linux, Debian 13.

```bash
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets
cargo test --locked --all-targets --all-features
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
(cd docs && bundle exec jekyll build)
```

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
