### PR TITLE
Stop left-click from opening the tray menu on Windows

### DIFF
--- a/src/tray_native.rs
+++ b/src/tray_native.rs
@@ -78,12 +78,12 @@ fn build(sender: Sender<TrayCommand>, wake: Wake) -> Result<Item, Box<dyn std::e
         .with_icon(icon)
         .with_tooltip("Fastpotify")
         .with_menu(Box::new(menu));
-    // A plain click shows or hides the window on every platform; the menu
-    // stays on right click.
+    // On Windows and macOS, a plain click shows or hides the window; the
+    // menu stays on right click.
+    #[cfg(any(windows, target_os = "macos"))]
+    let builder = builder.with_menu_on_left_click(false);
     #[cfg(target_os = "macos")]
-    let builder = builder
-        .with_icon_as_template(true)
-        .with_menu_on_left_click(false);
+    let builder = builder.with_icon_as_template(true);
     let icon = builder.build()?;
 
     let menu_sender = sender.clone();


### PR DESCRIPTION
User-visible change: on Windows, left-clicking the tray icon now only shows or hides Fastpotify. The context menu remains on right-click.

## What changed

- Apply the existing macOS `with_menu_on_left_click(false)` setting to Windows, explicitly scoped to those two native tray targets.
- Keep the existing left-click show/hide action and macOS template-icon behavior unchanged.

Fixes #309.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --no-default-features -- -D warnings`
- `cargo test --locked --all-targets --no-default-features`
