### PR TITLE
fix(collection): play context when shuffle is active on sorted views

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5290,7 +5290,7 @@ impl App {
         }
     }
 
-    fn apply(&mut self, action: Action, ctx: &egui::Context) {
+    pub(crate) fn apply(&mut self, action: Action, ctx: &egui::Context) {
         match action {
             Action::Open(page) => self.open(page),
             Action::OpenUri(uri) => {
@@ -5389,7 +5389,7 @@ impl App {
                     self.note_recent_context(&context_uri);
                     self.assumed_context = Some(AssumedContext {
                         uri: context_uri,
-                        shuffle: None,
+                        shuffle: self.shuffle_wanted.then_some(true),
                         at: Instant::now(),
                     });
                 }

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -151,9 +151,12 @@ pub fn actions_row(
             )
             .clicked()
             {
+                let is_filtered = filter.as_ref().is_some_and(|f| !f.trim().is_empty());
                 if now_playing_here {
                     app.actions.push(Action::TogglePlay);
-                } else if let Some(uris) = actions.view.clone() {
+                } else if let Some(uris) = actions.view.clone()
+                    && (!app.playing_context_shuffle() || is_filtered)
+                {
                     app.actions.push(Action::PlayFromRow {
                         context: RowContext::View {
                             uris: Arc::clone(&uris),
@@ -1577,6 +1580,289 @@ mod tests {
         assert!(
             after > 80_000,
             "500 tracks with nested metadata should retain a substantial copy: {after}"
+        );
+    }
+
+    #[test]
+    fn sorted_collection_play_button_plays_context_when_shuffling() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.apply(Action::SetShuffle(true), &ctx);
+        app.actions.clear();
+
+        let input_layout = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            ..Default::default()
+        };
+        let mut out = ctx.run_ui(input_layout, |ui| {
+            actions_row(
+                &mut app,
+                ui,
+                Actions {
+                    play_uri: Some("spotify:playlist:test".into()),
+                    view: Some(Arc::from([
+                        "spotify:track:1".into(),
+                        "spotify:track:2".into(),
+                    ])),
+                    saved: None,
+                    saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
+                    saved_tooltips: ("", ""),
+                    owned_playlist: None,
+                    name: "Test",
+                },
+                None,
+            );
+        });
+        out.textures_delta.clear();
+
+        let click_pos = egui::pos2(28.0, 28.0);
+        let input_click = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            events: vec![
+                egui::Event::PointerMoved(click_pos),
+                egui::Event::PointerButton {
+                    pos: click_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::PointerButton {
+                    pos: click_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut output = ctx.run_ui(input_click, |ui| {
+            actions_row(
+                &mut app,
+                ui,
+                Actions {
+                    play_uri: Some("spotify:playlist:test".into()),
+                    view: Some(Arc::from([
+                        "spotify:track:1".into(),
+                        "spotify:track:2".into(),
+                    ])),
+                    saved: None,
+                    saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
+                    saved_tooltips: ("", ""),
+                    owned_playlist: None,
+                    name: "Test",
+                },
+                None,
+            );
+        });
+        output.textures_delta.clear();
+
+        assert!(
+            matches!(
+                app.actions.as_slice(),
+                [Action::PlayContext {
+                    uri,
+                    offset_uri: None,
+                    offset_index: None,
+                }] if uri == "spotify:playlist:test"
+            ),
+            "expected PlayContext, got {:?}",
+            app.actions
+        );
+    }
+
+    #[test]
+    fn sorted_collection_play_button_plays_from_top_when_not_shuffling() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.apply(Action::SetShuffle(false), &ctx);
+        app.actions.clear();
+
+        let input_layout = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            ..Default::default()
+        };
+        let mut out = ctx.run_ui(input_layout, |ui| {
+            actions_row(
+                &mut app,
+                ui,
+                Actions {
+                    play_uri: Some("spotify:playlist:test".into()),
+                    view: Some(Arc::from([
+                        "spotify:track:1".into(),
+                        "spotify:track:2".into(),
+                    ])),
+                    saved: None,
+                    saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
+                    saved_tooltips: ("", ""),
+                    owned_playlist: None,
+                    name: "Test",
+                },
+                None,
+            );
+        });
+        out.textures_delta.clear();
+
+        let click_pos = egui::pos2(28.0, 28.0);
+        let input_click = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            events: vec![
+                egui::Event::PointerMoved(click_pos),
+                egui::Event::PointerButton {
+                    pos: click_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::PointerButton {
+                    pos: click_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut output = ctx.run_ui(input_click, |ui| {
+            actions_row(
+                &mut app,
+                ui,
+                Actions {
+                    play_uri: Some("spotify:playlist:test".into()),
+                    view: Some(Arc::from([
+                        "spotify:track:1".into(),
+                        "spotify:track:2".into(),
+                    ])),
+                    saved: None,
+                    saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
+                    saved_tooltips: ("", ""),
+                    owned_playlist: None,
+                    name: "Test",
+                },
+                None,
+            );
+        });
+        output.textures_delta.clear();
+
+        assert!(
+            matches!(
+                app.actions.as_slice(),
+                [Action::PlayFromRow {
+                    context: RowContext::View { uris, context_uri },
+                    index: 0,
+                    ..
+                }] if uris.as_ref() == ["spotify:track:1", "spotify:track:2"] && context_uri == "spotify:playlist:test"
+            ),
+            "expected PlayFromRow, got {:?}",
+            app.actions
+        );
+    }
+
+    #[test]
+    fn sorted_collection_play_button_preserves_filtered_view_when_shuffling() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.apply(Action::SetShuffle(true), &ctx);
+        app.actions.clear();
+
+        let input_layout = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            ..Default::default()
+        };
+        let mut filter = "filter".to_string();
+        let mut out = ctx.run_ui(input_layout, |ui| {
+            actions_row(
+                &mut app,
+                ui,
+                Actions {
+                    play_uri: Some("spotify:playlist:test".into()),
+                    view: Some(Arc::from([
+                        "spotify:track:1".into(),
+                        "spotify:track:2".into(),
+                    ])),
+                    saved: None,
+                    saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
+                    saved_tooltips: ("", ""),
+                    owned_playlist: None,
+                    name: "Test",
+                },
+                Some(&mut filter),
+            );
+        });
+        out.textures_delta.clear();
+
+        let click_pos = egui::pos2(28.0, 28.0);
+        let input_click = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            events: vec![
+                egui::Event::PointerMoved(click_pos),
+                egui::Event::PointerButton {
+                    pos: click_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::PointerButton {
+                    pos: click_pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut output = ctx.run_ui(input_click, |ui| {
+            actions_row(
+                &mut app,
+                ui,
+                Actions {
+                    play_uri: Some("spotify:playlist:test".into()),
+                    view: Some(Arc::from([
+                        "spotify:track:1".into(),
+                        "spotify:track:2".into(),
+                    ])),
+                    saved: None,
+                    saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
+                    saved_tooltips: ("", ""),
+                    owned_playlist: None,
+                    name: "Test",
+                },
+                Some(&mut filter),
+            );
+        });
+        output.textures_delta.clear();
+
+        assert!(
+            matches!(
+                app.actions.as_slice(),
+                [Action::PlayFromRow {
+                    context: RowContext::View { uris, context_uri },
+                    index: 0,
+                    ..
+                }] if uris.as_ref() == ["spotify:track:1", "spotify:track:2"] && context_uri == "spotify:playlist:test"
+            ),
+            "expected PlayFromRow with filtered view, got {:?}",
+            app.actions
         );
     }
 


### PR DESCRIPTION
### Summary

When clicking the play button on a sorted playlist with shuffle enabled, `actions_row` previously fell through to `Action::PlayFromRow { index: 0 }`. In `App::start_playback`, starting at explicit index 0 bypassed `shuffle_start`, causing track 0 of the sorted view to always play first before shuffling, and constrained context to `RowContext::View` (capped at 500 tracks).

This change checks whether shuffle is active before routing to `actions.view`. If shuffle is enabled, it delegates to `Action::PlayContext` without an offset, letting playback select a random starting track and shuffle the complete context. Additionally, `RowContext::View` now preserves `shuffle_wanted` in `assumed_context`.

Fixes #312

### Changes

- `src/ui/collection.rs`: In `actions_row`, check `!app.playing_context_shuffle()` before using `actions.view` so shuffle playback dispatches `Action::PlayContext`.
- `src/ui/collection.rs`: Added unit tests verifying `actions_row` emits `PlayContext` when shuffle is enabled and `PlayFromRow { index: 0 }` when shuffle is disabled.
- `src/app.rs`: Updated `RowContext::View` playback handling to populate `assumed_context.shuffle` with `self.shuffle_wanted.then_some(true)` instead of `None`.
- `src/app.rs`: Made `App::apply` `pub(crate)` for UI action testing.

### Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets` (all 319 tests pass, including new UI regression tests)
