### PR TITLE
Read the Han fallback region from the Windows display language

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = ["std
 
 [target.'cfg(windows)'.dependencies]
 # A hidden window for the media controls to belong to, and message loops.
-windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_LibraryLoader", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Graphics_Gdi", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_LibraryLoader", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ksni = { version = "0.3", features = ["blocking"] }

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -423,14 +423,71 @@ fn covers_han_region(code_pages: Option<u32>, han: &str) -> bool {
         .is_some_and(|(bit, pages)| pages & (1 << bit) != 0)
 }
 
-/// The user's locale, lowercased, or an empty string when none is set. A
-/// variable that is set but empty does not count, as POSIX has it.
+/// The user's locale, in the shape [`han_region`] matches, or an empty
+/// string when none is set. A variable that is set but empty does not
+/// count, as POSIX has it.
 fn locale() -> String {
-    ["LC_ALL", "LC_CTYPE", "LANG"]
+    let named = ["LC_ALL", "LC_CTYPE", "LANG"]
         .iter()
-        .find_map(|key| std::env::var(key).ok().filter(|value| !value.is_empty()))
-        .unwrap_or_default()
-        .to_lowercase()
+        .find_map(|key| std::env::var(key).ok().filter(|value| !value.is_empty()));
+    // A Windows desktop sets none of those, so without asking the system
+    // every listener there would be shown the default cut, whatever they
+    // read. The variables still come first, so setting one overrides it.
+    #[cfg(windows)]
+    let named = named.or_else(windows_language);
+    normalise(named.unwrap_or_default())
+}
+
+/// A language name as [`HAN_REGIONS`] writes them: lowercase, with `_`
+/// between the language and its region. Windows and BCP 47 hyphenate.
+fn normalise(name: String) -> String {
+    name.to_lowercase().replace('-', "_")
+}
+
+/// The language a Windows desktop is read in.
+///
+/// The display language comes first, since that is what `LANG` names on the
+/// other two platforms. A machine whose display language is not one of the
+/// installed ones still has a user locale, which carries the region.
+#[cfg(windows)]
+fn windows_language() -> Option<String> {
+    use windows_sys::Win32::Globalization::{
+        GetUserDefaultLocaleName, GetUserPreferredUILanguages, MUI_LANGUAGE_NAME,
+    };
+
+    /// `LOCALE_NAME_MAX_LENGTH`, which windows-sys does not carry.
+    const NAME_LENGTH: usize = 85;
+
+    let mut names = [0u16; NAME_LENGTH * 8];
+    let mut count = 0u32;
+    let mut length = names.len() as u32;
+    // SAFETY: both calls write at most `length` (or `len`) units into the
+    // buffer they are handed, which is the buffer's own length.
+    let preferred = unsafe {
+        GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME,
+            &mut count,
+            names.as_mut_ptr(),
+            &mut length,
+        )
+    };
+    if preferred != 0
+        && count > 0
+        && let Some(first) = first_name(&names)
+    {
+        return Some(first);
+    }
+
+    let mut name = [0u16; NAME_LENGTH];
+    let read = unsafe { GetUserDefaultLocaleName(name.as_mut_ptr(), name.len() as i32) };
+    (read > 0).then(|| first_name(&name)).flatten()
+}
+
+/// The first string of a null-terminated list of them.
+#[cfg(windows)]
+fn first_name(names: &[u16]) -> Option<String> {
+    let end = names.iter().position(|unit| *unit == 0)?;
+    (end > 0).then(|| String::from_utf16_lossy(&names[..end]))
 }
 
 /// The pan-CJK cut a locale reads, defaulting to Simplified Chinese -- the
@@ -501,6 +558,35 @@ mod tests {
         assert_eq!(han_region("ko_kr.utf-8"), "kr");
         assert_eq!(han_region("en_us.utf-8"), "sc", "the default");
         assert_eq!(han_region(""), "sc", "no locale set");
+    }
+
+    /// Windows and BCP 47 write `ko-KR` where POSIX writes `ko_KR`, and the
+    /// prefixes above are POSIX-shaped.
+    #[test]
+    fn hyphenated_language_names_choose_a_cut_too() {
+        let cut = |name: &str| han_region(&normalise(name.to_owned()));
+        assert_eq!(cut("ko-KR"), "kr");
+        assert_eq!(cut("ja-JP"), "jp");
+        assert_eq!(cut("zh-TW"), "tc");
+        assert_eq!(cut("zh-Hant-TW"), "tc");
+        assert_eq!(cut("zh-HK"), "hk");
+        assert_eq!(cut("zh-CN"), "sc");
+        assert_eq!(cut("en-US"), "sc", "the default");
+    }
+
+    /// A Windows desktop sets none of the POSIX variables, so the language
+    /// has to come from the system. An empty answer puts every Japanese and
+    /// Korean listener on the Simplified Chinese cut.
+    #[cfg(windows)]
+    #[test]
+    fn windows_names_the_language_it_is_read_in() {
+        let locale = locale();
+        assert!(!locale.is_empty(), "Windows named no language");
+        assert!(
+            !locale.contains('-'),
+            "{locale} keeps a hyphen no region prefix matches"
+        );
+        assert_eq!(locale, locale.to_lowercase());
     }
 
     #[test]


### PR DESCRIPTION
## Why

`system_fonts::locale()` reads `LC_ALL`, `LC_CTYPE`, and `LANG` to decide which regional cut of a pan-CJK font a listener should see. A Windows desktop sets none of those, so `locale()` comes back empty and `han_region("")` is `"sc"` for everyone.

Since c3ba1d7 (Prefer a Han fallback face from the reader's region) that default decides the face outright: a Japanese or Korean face declares no GB 2312 code page, so it counts as `foreign` and loses to any face that does. On a Japanese or Korean Windows install the Han fallback is therefore always a Simplified Chinese face, while kana and hangul come from other files, so one title mixes three fonts and 直, 骨, 誤 and friends take their Chinese shapes. Both earlier Japanese reports (#28, #104) came from Windows, so this is the audience the regional cut was meant for.

## What changed

- `locale()` still reads the POSIX variables first, so setting one keeps overriding the system. When none is set, Windows is asked: `GetUserPreferredUILanguages` for the display language (the equivalent of what `LANG` names elsewhere), then `GetUserDefaultLocaleName` as a fallback for a machine whose display language is not installed.
- Windows and BCP 47 hyphenate (`ko-KR`, `zh-Hant-TW`) where `HAN_REGIONS` is written POSIX-style (`ko_kr`, `zh_hant`). A small `normalise` lowercases and turns `-` into `_` before matching. Without it a Windows `zh-TW` or `zh-HK` falls through to the plain `zh` prefix and gets the Simplified cut.
- `Cargo.toml` enables the `Win32_Globalization` feature of the `windows-sys` crate already in use. No new dependency, lockfile unchanged.

Everything Windows-specific sits behind `cfg(windows)`; the other two targets only gain `normalise`.

## Tests

- `hyphenated_language_names_choose_a_cut_too`: `zh-TW`, `zh-Hant-TW`, `zh-HK` resolve to the Traditional cuts, `ko-KR` and `ja-JP` to theirs, `en-US` to the default.
- `windows_names_the_language_it_is_read_in` (Windows only): the locale is non-empty, lowercase, and hyphen-free. Before this change it fails with `Windows named no language`.

## How I tested

Windows 11 (Korean display language), toolchain 1.98.0 from `rust-toolchain.toml`. `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked --all-targets`, and `cargo doc` with `-D warnings`, all with `--no-default-features` because this machine has no vcpkg for MilkDrop; the change does not touch that feature. Not run on Linux or macOS; CI covers those.

A throwaway probe (not committed) printed the faces `load()` picks on this desktop:

```text
before (locale "" -> sc)
  han:    C:\Windows\Fonts\msyh.ttc      (Microsoft YaHei, Simplified Chinese)
  kana:   C:\Windows\Fonts\YuGothM.ttc   (Yu Gothic)
  hangul: C:\Windows\Fonts\batang.ttc    (Batang)

after (locale "ko_kr" -> kr)
  han:    C:\Windows\Fonts\NotoSansKR-VF.ttf
  kana:   C:\Windows\Fonts\NotoSansKR-VF.ttf
  hangul: C:\Windows\Fonts\NotoSansKR-VF.ttf
```

No user-visible setting, file, or network access changes, so no documentation change.
