### PR TITLE
Reject a skin colour with a multi-byte character instead of panicking

### DIFF
--- a/src/skin/config.rs
+++ b/src/skin/config.rs
@@ -230,13 +230,14 @@ impl PlaylistStyle {
 }
 
 /// A `#RRGGBB` colour. Winamp accepted the hash missing and extra digits
-/// after the six, so both are taken here.
+/// after the six, so both are taken here. Anything but six hex digits at
+/// the front is no colour, a multi-byte character included: this reads
+/// bytes, since slicing the text two bytes at a time would panic inside
+/// one.
 pub fn hex(value: &str) -> Option<Rgb> {
-    let digits = value.trim().trim_start_matches('#');
-    if digits.len() < 6 || !digits.is_char_boundary(6) {
-        return None;
-    }
-    let channel = |at: usize| u8::from_str_radix(&digits[at..at + 2], 16).ok();
+    let digits = value.trim().trim_start_matches('#').as_bytes();
+    let nibble = |at: usize| digits.get(at).and_then(|byte| (*byte as char).to_digit(16));
+    let channel = |at: usize| Some((nibble(at)? << 4 | nibble(at + 1)?) as u8);
     Some([channel(0)?, channel(2)?, channel(4)?])
 }
 
@@ -324,6 +325,22 @@ mod tests {
             style.normal_background,
             PlaylistStyle::default().normal_background
         );
+    }
+
+    #[test]
+    fn a_colour_with_a_multibyte_character_is_no_colour() {
+        // A byte no UTF-8 decoder accepts, such as a Cyrillic А typed for a
+        // Latin A in a Windows-1251 file, comes through the lossy decode as
+        // a three-byte replacement character. Slicing two bytes into it
+        // panicked the skin loader.
+        let style = PlaylistStyle::parse(&String::from_utf8_lossy(
+            b"[Text]\nNormal=#\xC00B0C0\nCurrent=#FFFFFF\n",
+        ));
+        assert_eq!(style.normal, PlaylistStyle::default().normal);
+        assert_eq!(style.current, [0xff, 0xff, 0xff]);
+        assert_eq!(hex("ab\u{fffd}c"), None);
+        assert_eq!(hex("#0\u{0410}0B0C"), None);
+        assert_eq!(hex("\u{fffd}"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Why

`skin::config::hex` guards `digits.is_char_boundary(6)` and then slices `&digits[0..2]`, `[2..4]`, `[4..6]`. The guard checks the one boundary the slices never need and none of the two they do, so a multi-byte character inside the first six bytes panics with `byte index N is not a char boundary`.

That input is not exotic. `pledit.txt` is read with `String::from_utf8_lossy`, so any byte a UTF-8 decoder rejects becomes the three-byte replacement character. A `Normal=#А0B0C0` typed with a Cyrillic А for the Latin one, saved in Windows-1251 as skins from that part of the world were, is exactly such a byte and slices straight into it. The parse runs on the `skin-loader` thread (`src/winamp.rs`), and release builds set `panic = "abort"`, so picking that skin takes the whole app down. A debug build loses the thread instead: `poll` sees `Disconnected`, clears the job, and the skin silently never applies.

## What changed

`hex` reads bytes instead of slicing text: each channel takes two ASCII hex digits or is no colour, which is what the existing `#zz0000` handling already does for a bad digit. Behaviour for every valid colour, a missing hash, and extra digits after the six is unchanged, and the existing tests for those still pass.

## Tests

`a_colour_with_a_multibyte_character_is_no_colour` feeds the parser the Windows-1251 line through `from_utf8_lossy`, plus a replacement character and a Cyrillic А directly. Before the fix:

```text
thread 'skin::config::tests::a_colour_with_a_multibyte_character_is_no_colour' panicked at src\skin\config.rs:239:57:
end byte index 4 is not a char boundary; it is inside '\u{fffd}' (bytes 2..5 of string)
```

After the fix the value is rejected and the default colour stays, as for any other unreadable value.

## How I tested

Windows 11, toolchain 1.98.0 from `rust-toolchain.toml`. `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked --all-targets`, and `cargo doc` with `-D warnings`, all with `--no-default-features` because this machine has no vcpkg for MilkDrop; the change does not touch that feature. No platform-specific code; CI covers Linux and macOS.

No user-visible setting, file, or network access changes, so no documentation change.
