### PR TITLE
Keep the main window visible after a monitor is disconnected

### DIFF
--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -42,6 +42,10 @@ The last good playlist folder tree is kept in `session.json`, scoped to the
 account that supplied it. This keeps folders visible when local playback is
 temporarily unavailable. Live session data is still required for edit grants.
 
+The session also remembers the main window's position. On Windows, a position
+whose title bar is no longer on an available monitor's work area is discarded
+when reopening the window, keeping its initial on-screen placement instead.
+
 Large playlist pages also have a **Go to song** control. Entering a song
 number loads its 50-item page directly, without requesting every earlier page.
 Filtering or sorting still covers the whole playlist, so either action returns

--- a/src/app.rs
+++ b/src/app.rs
@@ -700,15 +700,13 @@ impl App {
                 )));
             }
         }
-        if let Some(pos) = self.session_window_pos.take() {
-            // On Wayland this is a no-op. Validate against a large virtual
-            // desktop so a window that was on a now-disconnected monitor
-            // doesn't open off-screen.
-            if (-1000.0..=5000.0).contains(&pos[0]) && (-1000.0..=5000.0).contains(&pos[1]) {
-                ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(
-                    pos[0], pos[1],
-                )));
-            }
+        // If the saved position is off-screen, leave the window where eframe put it.
+        if let Some(pos) = self.session_window_pos.take()
+            && crate::window::can_restore(pos, ctx.pixels_per_point())
+        {
+            ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(
+                pos[0], pos[1],
+            )));
         }
         // egui's consensus wheel speed is 40 points per line, about a third
         // of what every other player scrolls per notch; trackpads report

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,4 +46,5 @@ pub mod updates;
 pub mod util;
 pub mod vis;
 pub mod winamp;
+pub mod window;
 pub mod zeroconf;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,0 +1,98 @@
+//! Checks saved window positions before restoring them.
+//!
+//! eframe already places the window on-screen. The session can still refer
+//! to a monitor that was unplugged, so check before moving the window there.
+
+/// Checks a position in egui points against the fixed coordinate limits.
+#[cfg(not(windows))]
+pub fn can_restore(pos: [f32; 2], _pixels_per_point: f32) -> bool {
+    // Wayland ignores window moves; keep the old limits on other platforms.
+    (-1000.0..=5000.0).contains(&pos[0]) && (-1000.0..=5000.0).contains(&pos[1])
+}
+
+#[cfg(any(windows, test))]
+fn titlebar_anchor(pos: [f32; 2], pixels_per_point: f32) -> Option<egui::Pos2> {
+    // A maximized window can start at (-8, -8), so check a point inside
+    // its title bar. Convert from egui points to pixels for Win32.
+    let anchor = (egui::pos2(pos[0], pos[1]) + egui::vec2(32.0, 16.0)) * pixels_per_point;
+    (pixels_per_point.is_finite() && pixels_per_point > 0.0 && anchor.is_finite()).then_some(anchor)
+}
+
+/// Checks that the saved position leaves the title bar in a monitor's work area.
+#[cfg(windows)]
+pub fn can_restore(pos: [f32; 2], pixels_per_point: f32) -> bool {
+    use windows_sys::Win32::Foundation::POINT;
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MONITOR_DEFAULTTONULL, MONITORINFO, MonitorFromPoint,
+    };
+
+    let Some(anchor) = titlebar_anchor(pos, pixels_per_point) else {
+        return false;
+    };
+    let point = POINT {
+        x: anchor.x as i32,
+        y: anchor.y as i32,
+    };
+    let mut info = MONITORINFO {
+        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+        ..Default::default()
+    };
+    unsafe {
+        // Asking for the nearest monitor would also accept off-screen positions.
+        let monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONULL);
+        if monitor.is_null() || GetMonitorInfoW(monitor, &mut info) == 0 {
+            return false;
+        }
+    }
+    // Use the work area so the title bar cannot end up behind the taskbar.
+    let area = info.rcWork;
+    egui::Rect::from_min_max(
+        egui::pos2(area.left as f32, area.top as f32),
+        egui::pos2(area.right as f32, area.bottom as f32),
+    )
+    .contains(anchor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reachable(pos: [f32; 2], scale: f32, area: [f32; 4]) -> bool {
+        let rect =
+            egui::Rect::from_min_max(egui::pos2(area[0], area[1]), egui::pos2(area[2], area[3]));
+        titlebar_anchor(pos, scale).is_some_and(|anchor| rect.contains(anchor))
+    }
+
+    #[test]
+    fn disconnected_monitor_position_is_not_restored() {
+        assert!(!reachable([1912.0, -8.0], 1.0, [0.0, 0.0, 1920.0, 1032.0]));
+        assert!(reachable(
+            [1912.0, -8.0],
+            1.0,
+            [1920.0, 0.0, 3840.0, 1080.0]
+        ));
+    }
+
+    #[test]
+    fn visible_positions_include_maximized_and_negative_coordinates() {
+        assert!(reachable([-8.0, -8.0], 1.0, [0.0, 0.0, 1920.0, 1032.0]));
+        assert!(reachable(
+            [-1920.0, 100.0],
+            1.0,
+            [-1920.0, 0.0, 0.0, 1080.0]
+        ));
+    }
+
+    #[test]
+    fn logical_coordinates_are_scaled_to_monitor_pixels() {
+        assert!(reachable([900.0, 100.0], 2.0, [0.0, 0.0, 1920.0, 1080.0]));
+        assert!(!reachable([1000.0, 100.0], 2.0, [0.0, 0.0, 1920.0, 1080.0]));
+    }
+
+    #[test]
+    fn invalid_coordinates_and_scale_are_rejected() {
+        assert!(titlebar_anchor([f32::NAN, 0.0], 1.0).is_none());
+        assert!(titlebar_anchor([0.0, f32::INFINITY], 1.0).is_none());
+        assert!(titlebar_anchor([0.0, 0.0], 0.0).is_none());
+    }
+}


### PR DESCRIPTION
## Why

Fastpotify remembers the main window position between sessions. If the window
was closed on a second monitor and that monitor was later disconnected,
Fastpotify restored the old coordinates and opened outside the visible desktop.

This happened with a 1920x1080 primary display and a saved position of
`[1912, -8]`. The existing coordinate range check accepted that position even
though no connected monitor contained it.

## What changed

On Windows, Fastpotify now checks whether a point inside the saved title bar is
within a connected monitor's work area before restoring the window position.
The coordinates are converted from egui points to physical pixels so the check
also works with display scaling.

If the position is no longer reachable, Fastpotify leaves the window at the
on-screen position chosen by eframe. Valid positions on monitors to the left of
the primary display and the small negative offsets used by maximized windows
are still accepted.

Other platforms keep the previous coordinate range check. The saved session
format is unchanged.

Regression tests cover:

- a saved position on a disconnected right-hand monitor;
- valid negative coordinates on a left-hand monitor;
- the negative frame offset of a maximized window;
- conversion from egui points to physical pixels;
- invalid coordinates and scale values.

## Verification

The full project checks were run in WSL Ubuntu with Rust 1.98.0:

```text
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets
cargo test --locked --all-targets --all-features
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
(cd docs && bundle exec jekyll build)
```

Both test configurations passed 318 library tests and 3 binary tests.

The Windows-specific module was also cross-compiled for
`x86_64-pc-windows-gnu`. Its four regression tests were then run as Windows
executables and passed.

The original saved position, `[1912, -8]`, was checked against the current
single-monitor Windows setup and rejected. A visible position, `[100, 100]`,
was accepted.

Finally, a portable Windows x64 release build was compiled from commit
`1ed35af` with `--no-default-features` and launched successfully with
`--version`. This build excludes MilkDrop because its Windows build requires
the native MSVC and vcpkg setup.

No screenshots are included because the change only affects native window
placement during startup and does not change the application layout or theme.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.