### PR TITLE
perf(ui): cache table rows and share sorted URI lists with Arc

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4236,7 +4236,8 @@ impl App {
 
     pub fn open(&mut self, page: Page) {
         if *self.page() == page {
-            self.ensure_loaded(page);
+            self.ensure_loaded(page.clone());
+            self.retain_table_rows(&page);
             return;
         }
         self.history.truncate(self.history_index + 1);
@@ -4246,7 +4247,8 @@ impl App {
         }
         self.history_index = self.history.len() - 1;
         self.show_devices = false;
-        self.ensure_loaded(page);
+        self.ensure_loaded(page.clone());
+        self.retain_table_rows(&page);
     }
 
     /// Hands the app a Spotify link from outside, a canonical URI as
@@ -5285,14 +5287,16 @@ impl App {
                 if self.can_go_back() {
                     self.history_index -= 1;
                     let page = self.page().clone();
-                    self.ensure_loaded(page);
+                    self.ensure_loaded(page.clone());
+                    self.retain_table_rows(&page);
                 }
             }
             Action::Forward => {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
-                    self.ensure_loaded(page);
+                    self.ensure_loaded(page.clone());
+                    self.retain_table_rows(&page);
                 }
             }
             Action::PlayContext {

--- a/src/app.rs
+++ b/src/app.rs
@@ -987,10 +987,10 @@ impl App {
     }
 
     pub fn now_playing(&self) -> Option<NowPlaying> {
-self.now_playing_live().or_else(|| self.resume_preview())
+        self.now_playing_live().or_else(|| self.resume_preview())
     }
 
-/// What a device is actually playing, here or elsewhere.
+    /// What a device is actually playing, here or elsewhere.
     fn now_playing_live(&self) -> Option<NowPlaying> {
         if self.local.is_active() {
             let track = self.local.track.as_ref()?;
@@ -5225,14 +5225,14 @@ self.now_playing_live().or_else(|| self.resume_preview())
                     self.history_index -= 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                            }
+                }
             }
             Action::Forward => {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                            }
+                }
             }
             Action::PlayContext {
                 uri,
@@ -6153,7 +6153,7 @@ impl App {
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
-self.apply_theme(ctx);
+        self.apply_theme(ctx);
         self.lock_scroll_axis(ctx);
         // Switch to the main window when sign-in is required.
         let needs_sign_in = !(self.is_connected() && self.user.is_some())

--- a/src/app.rs
+++ b/src/app.rs
@@ -987,10 +987,10 @@ impl App {
     }
 
     pub fn now_playing(&self) -> Option<NowPlaying> {
-        self.now_playing_live().or_else(|| self.resume_preview())
+self.now_playing_live().or_else(|| self.resume_preview())
     }
 
-    /// What a device is actually playing, here or elsewhere.
+/// What a device is actually playing, here or elsewhere.
     fn now_playing_live(&self) -> Option<NowPlaying> {
         if self.local.is_active() {
             let track = self.local.track.as_ref()?;
@@ -2849,7 +2849,7 @@ impl App {
             if uris.is_empty() {
                 return;
             }
-            let (uris, index) = cap_uris(uris, index as u32);
+            let (uris, index) = cap_uris(&uris, index as u32);
             self.play_request(PlayRequest::tracks(uris).starting_at_index(index), false);
             return;
         }
@@ -5225,14 +5225,14 @@ impl App {
                     self.history_index -= 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                }
+                            }
             }
             Action::Forward => {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                }
+                            }
             }
             Action::PlayContext {
                 uri,
@@ -5274,7 +5274,7 @@ impl App {
                 if uris.is_empty() {
                     return;
                 }
-                let (uris, index) = cap_uris(uris, index);
+                let (uris, index) = cap_uris(&uris, index);
                 let request = PlayRequest::tracks(uris).starting_at_index(index);
                 self.play_request(request, false);
             }
@@ -5290,13 +5290,13 @@ impl App {
                     self.play_request(request, false);
                 }
                 RowContext::Uris(uris) => {
-                    let (uris, index) = cap_uris(uris, index);
+                    let (uris, index) = cap_uris(uris.as_ref(), index);
                     let request = PlayRequest::tracks(uris).starting_at_index(index);
                     self.play_request(request, false);
                 }
                 RowContext::Queue => self.play_queue_item(index as usize, uri),
                 RowContext::View { uris, context_uri } => {
-                    let (uris, index) = cap_uris(uris, index);
+                    let (uris, index) = cap_uris(uris.as_ref(), index);
                     let request = PlayRequest::tracks(uris).starting_at_index(index);
                     self.play_request(request, false);
                     self.note_recent_context(&context_uri);
@@ -6153,7 +6153,7 @@ impl App {
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
-        self.apply_theme(ctx);
+self.apply_theme(ctx);
         self.lock_scroll_axis(ctx);
         // Switch to the main window when sign-in is required.
         let needs_sign_in = !(self.is_connected() && self.user.is_some())
@@ -6560,12 +6560,12 @@ fn autoplay_seed(
 }
 
 /// Caps large track lists at 500 items starting from the selected row.
-fn cap_uris(uris: Vec<String>, index: u32) -> (Vec<String>, u32) {
+fn cap_uris(uris: &[String], index: u32) -> (Vec<String>, u32) {
     const MAX: usize = 500;
     if uris.len() <= MAX {
-        return (uris, index);
+        return (uris.to_vec(), index);
     }
-    let start = (index as usize).min(uris.len() - 1);
+    let start = (index as usize).min(uris.len().saturating_sub(1));
     let end = (start + MAX).min(uris.len());
     (uris[start..end].to_vec(), 0)
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -261,6 +261,8 @@ pub struct App {
     pub show_pages: HashMap<String, ShowPage>,
     pub track_cache: HashMap<String, Track>,
     track_requests: HashSet<String>,
+    /// Built table rows, keyed by page. Capped; dropped on reset and eviction.
+    pub table_rows: HashMap<Page, TableRowsCache>,
 
     pub history: Vec<Page>,
     pub history_index: usize,
@@ -563,6 +565,7 @@ impl App {
             show_pages: HashMap::new(),
             track_cache: HashMap::new(),
             track_requests: HashSet::new(),
+            table_rows: HashMap::new(),
             history: vec![first_page],
             history_index: 0,
             saved: HashMap::new(),
@@ -1422,6 +1425,54 @@ impl App {
         self.devices_fetched_at = None;
         self.search.results = Loadable::NotLoaded;
         self.search.committed.clear();
+        self.table_rows.clear();
+    }
+
+    /// Drop table-row caches whose pages are gone, and cap what remains.
+    pub fn retain_table_rows(&mut self, current: &Page) {
+        const MAX_TABLE_ROW_CACHES: usize = 2;
+        self.table_rows.retain(|page, _| {
+            page == current
+                || match page {
+                    Page::Playlist(id) => self.playlist_pages.contains_key(id),
+                    Page::Album(id) => self.album_pages.contains_key(id),
+                    Page::LikedSongs | Page::TopSongs => true,
+                    _ => false,
+                }
+        });
+        if self.table_rows.len() <= MAX_TABLE_ROW_CACHES {
+            return;
+        }
+        let mut keep = HashSet::from([current.clone()]);
+        if let Some(page) = self.history.get(self.history_index) {
+            keep.insert(page.clone());
+        }
+        if self.history_index > 0
+            && let Some(page) = self.history.get(self.history_index - 1)
+        {
+            keep.insert(page.clone());
+        }
+        self.table_rows.retain(|page, _| keep.contains(page));
+        while self.table_rows.len() > MAX_TABLE_ROW_CACHES {
+            let drop = self
+                .table_rows
+                .keys()
+                .find(|page| *page != current)
+                .cloned();
+            match drop {
+                Some(page) => {
+                    self.table_rows.remove(&page);
+                }
+                None => break,
+            }
+        }
+    }
+
+    pub fn table_rows_retained_bytes(&self) -> usize {
+        self.table_rows
+            .values()
+            .map(TableRowsCache::retained_bytes)
+            .sum()
     }
 
     fn handle_local(&mut self, state: LocalState) {
@@ -2451,6 +2502,16 @@ impl App {
                 self.request_contains(vec![format!("spotify:playlist:{id}")]);
             }
             Page::Album(id) => {
+                if !self.album_pages.contains_key(&id) {
+                    self.load_generation = self.load_generation.wrapping_add(1);
+                    self.album_pages.insert(
+                        id.clone(),
+                        AlbumPage {
+                            generation: self.load_generation,
+                            ..Default::default()
+                        },
+                    );
+                }
                 let page = self.album_pages.entry(id.clone()).or_default();
                 if page.album.needs_load() {
                     page.album = Loadable::Loading;
@@ -8043,6 +8104,41 @@ mod tests {
         );
         app.local_ready = true;
         app
+    }
+
+    #[test]
+    fn reset_data_drops_table_row_caches() {
+        let mut app = headless_app();
+        crate::ui::collection::cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, || {
+            vec![(
+                PlayableItem::Track(Track {
+                    name: "Hold".into(),
+                    uri: "spotify:track:hold".into(),
+                    ..Track::default()
+                }),
+                None,
+                None,
+            )]
+        });
+        assert!(!app.table_rows.is_empty());
+        app.reset_data();
+        assert!(app.table_rows.is_empty());
+        crate::ui::collection::cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, || {
+            vec![(
+                PlayableItem::Track(Track {
+                    name: "Fresh".into(),
+                    uri: "spotify:track:fresh".into(),
+                    ..Track::default()
+                }),
+                None,
+                None,
+            )]
+        });
+        let name = app.table_rows[&Page::LikedSongs].items[0].0.name();
+        assert_eq!(
+            name, "Fresh",
+            "reused revision 0 must not keep the old rows"
+        );
     }
 
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -802,6 +802,7 @@ mod tests {
     use crate::app::AppOptions;
     use crate::paths::AppDirs;
     use crate::settings::Settings;
+    use std::sync::Arc;
 
     fn accessible_app(name: &str) -> (egui::Context, App) {
         let root =
@@ -1019,7 +1020,7 @@ mod tests {
         use egui::accesskit::{Action as AccessibleAction, Role};
         let (ctx, mut app) = accessible_app("rows");
         let item = app.queue.get().unwrap().queue[0].clone();
-        let context = crate::model::RowContext::Uris(vec![item.uri().to_string(); 2]);
+        let context = crate::model::RowContext::Uris(Arc::from(vec![item.uri().to_string(); 2]));
         let label = format!("Play {}, {}", item.name(), item.subtitle());
         let mut render = |first, events| {
             app.actions.clear();
@@ -1113,7 +1114,7 @@ mod tests {
         use egui::accesskit::{Action as AccessibleAction, Role};
         let (ctx, mut app) = accessible_app("scroll");
         let item = app.queue.get().unwrap().queue[0].clone();
-        let context = crate::model::RowContext::Uris(vec![item.uri().to_string(); 20]);
+        let context = crate::model::RowContext::Uris(Arc::from(vec![item.uri().to_string(); 20]));
         let label = format!("Play {}, {}", item.name(), item.subtitle());
         let mut reached_last = false;
         let mut render = |events| {
@@ -1184,7 +1185,7 @@ mod tests {
         let (ctx, mut app) = accessible_app("queued-copy");
         let item = app.queue.get().unwrap().currently_playing.clone().unwrap();
         let contexts = [
-            RowContext::Uris(vec![item.uri().to_string()]),
+            RowContext::Uris(Arc::from([item.uri().to_string()])),
             RowContext::Queue,
         ];
         let label = format!("Play {}, {}", item.name(), item.subtitle());

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,7 @@
 //! UI state, loaded data, and pending actions.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::api::models::*;
@@ -529,12 +530,12 @@ pub enum RowContext {
         editable_playlist: Option<(String, Option<String>)>,
     },
     /// A loose list of tracks, played as a queue of URIs.
-    Uris(Vec<String>),
+    Uris(Arc<[String]>),
     /// A Next up row. Playing it consumes that row and all rows before it.
     Queue,
     /// A sorted or filtered context view that plays the displayed rows.
     View {
-        uris: Vec<String>,
+        uris: Arc<[String]>,
         context_uri: String,
     },
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,37 @@ use std::time::Instant;
 
 use crate::api::models::*;
 
+/// One table row: the playable, when it was added, who added it.
+pub type TableItem = (PlayableItem, Option<String>, Option<String>);
+
+/// Cached track-table rows for one page.
+///
+/// Lives on the app, not in egui temp data, so it dies with page eviction,
+/// sign-out, and `reset_data`. A generation token stops a recreated page
+/// from reusing a stale copy that still has the old revision number.
+pub struct TableRowsCache {
+    pub generation: u64,
+    pub items_revision: u64,
+    pub user_names_revision: u64,
+    pub items: Arc<[TableItem]>,
+}
+
+impl TableRowsCache {
+    /// Heap-ish retained size: struct slots plus the URI/name strings we own.
+    pub fn retained_bytes(&self) -> usize {
+        self.items
+            .iter()
+            .map(|(item, added, by)| {
+                std::mem::size_of_val(item)
+                    + item.uri().len()
+                    + item.name().len()
+                    + added.as_ref().map(String::len).unwrap_or(0)
+                    + by.as_ref().map(String::len).unwrap_or(0)
+            })
+            .sum()
+    }
+}
+
 /// Every screen the central panel can show.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Page {
@@ -450,6 +481,7 @@ pub struct PlaylistCache {
 
 #[derive(Default)]
 pub struct AlbumPage {
+    pub generation: u64,
     pub album: Loadable<Album>,
     pub tracks: PagedList<Track>,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,19 +22,73 @@ pub struct TableRowsCache {
 }
 
 impl TableRowsCache {
-    /// Heap-ish retained size: struct slots plus the URI/name strings we own.
+    /// Retained heap for this cache: nested track/episode metadata, not just
+    /// the top-level URI and title.
     pub fn retained_bytes(&self) -> usize {
-        self.items
-            .iter()
-            .map(|(item, added, by)| {
-                std::mem::size_of_val(item)
-                    + item.uri().len()
-                    + item.name().len()
-                    + added.as_ref().map(String::len).unwrap_or(0)
-                    + by.as_ref().map(String::len).unwrap_or(0)
-            })
-            .sum()
+        std::mem::size_of::<Self>()
+            + self
+                .items
+                .iter()
+                .map(|(item, added, by)| {
+                    playable_retained_bytes(item)
+                        + added.as_ref().map(String::len).unwrap_or(0)
+                        + by.as_ref().map(String::len).unwrap_or(0)
+                })
+                .sum::<usize>()
     }
+}
+
+fn playable_retained_bytes(item: &PlayableItem) -> usize {
+    match item {
+        PlayableItem::Track(track) => track_retained_bytes(track),
+        PlayableItem::Episode(episode) => episode_retained_bytes(episode),
+    }
+}
+
+fn artist_ref_retained_bytes(artist: &ArtistRef) -> usize {
+    artist.name.len()
+        + artist.id.as_ref().map(String::len).unwrap_or(0)
+        + artist.uri.as_ref().map(String::len).unwrap_or(0)
+}
+
+fn image_retained_bytes(images: &[Image]) -> usize {
+    images.iter().map(|image| image.url.len()).sum()
+}
+
+fn album_retained_bytes(album: &Album) -> usize {
+    album.id.len()
+        + album.name.len()
+        + album.uri.len()
+        + album.album_type.as_ref().map(String::len).unwrap_or(0)
+        + album.release_date.as_ref().map(String::len).unwrap_or(0)
+        + image_retained_bytes(&album.images)
+        + album
+            .artists
+            .iter()
+            .map(artist_ref_retained_bytes)
+            .sum::<usize>()
+}
+
+fn track_retained_bytes(track: &Track) -> usize {
+    std::mem::size_of::<Track>()
+        + track.name.len()
+        + track.uri.len()
+        + track.id.as_ref().map(String::len).unwrap_or(0)
+        + track
+            .artists
+            .iter()
+            .map(artist_ref_retained_bytes)
+            .sum::<usize>()
+        + track.album.as_ref().map(album_retained_bytes).unwrap_or(0)
+}
+
+fn episode_retained_bytes(episode: &Episode) -> usize {
+    std::mem::size_of::<Episode>()
+        + episode.id.len()
+        + episode.name.len()
+        + episode.uri.len()
+        + episode.description.len()
+        + image_retained_bytes(&episode.images)
 }
 
 /// Every screen the central panel can show.

--- a/src/ui/artist.rs
+++ b/src/ui/artist.rs
@@ -1,5 +1,7 @@
 //! The artist page.
 
+use std::sync::Arc;
+
 use crate::api::models::{PlayableItem, pick_image};
 use crate::app::App;
 use crate::model::{Action, DiscographyFilter, Loadable, Page, RowContext};
@@ -102,8 +104,12 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, id: &str) {
             ui.add_space(4.0);
             match &page.top_tracks {
                 Loadable::Loaded(tracks) if !tracks.is_empty() => {
-                    let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
-                    let context = RowContext::Uris(uris);
+                    let uris: Arc<[String]> = tracks
+                        .iter()
+                        .map(|track| track.uri.clone())
+                        .collect::<Vec<_>>()
+                        .into();
+                    let context = RowContext::Uris(Arc::clone(&uris));
                     let items: Vec<PlayableItem> =
                         tracks.iter().cloned().map(PlayableItem::Track).collect();
                     let limit = if page.show_all_top { items.len() } else { 5 };

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -324,12 +324,10 @@ pub fn cached_table_items(
 ) -> Arc<[TableItem]> {
     let cache_id = egui::Id::new("table-items-cache").with(page);
     let cached = ui.data(|d| d.get_temp::<Arc<[TableItem]>>(cache_id));
-    let valid = cached.as_ref().is_some_and(|items| {
+    let valid = cached.as_ref().is_some_and(|_items| {
         ui.data(|d| {
             d.get_temp::<(u64, u64)>(cache_id.with("rev"))
-                .is_some_and(|(rev, names)| {
-                    rev == items_revision && names == user_names_revision
-                })
+                .is_some_and(|(rev, names)| rev == items_revision && names == user_names_revision)
         })
     });
     if let Some(items) = cached.filter(|_| valid) {
@@ -338,10 +336,7 @@ pub fn cached_table_items(
         let items: Arc<[TableItem]> = build().into();
         ui.data_mut(|d| {
             d.insert_temp(cache_id, Arc::clone(&items));
-            d.insert_temp(
-                cache_id.with("rev"),
-                (items_revision, user_names_revision),
-            );
+            d.insert_temp(cache_id.with("rev"), (items_revision, user_names_revision));
         });
         items
     }
@@ -887,10 +882,7 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.items.revision,
             );
-            let view_play = table_view
-                .view_uris
-                .as_ref()
-                .map(|uris| Arc::clone(uris));
+            let view_play = table_view.view_uris.as_ref().map(Arc::clone);
             let playlist_clone = playlist.clone();
             actions_row(
                 app,
@@ -1004,10 +996,7 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.tracks.revision,
             );
-            let album_view = table_view
-                .view_uris
-                .as_ref()
-                .map(|uris| Arc::clone(uris));
+            let album_view = table_view.view_uris.as_ref().map(Arc::clone);
             actions_row(
                 app,
                 ui,
@@ -1206,10 +1195,7 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         sort,
         app.library.liked.revision,
     );
-    let liked_view = table_view
-        .view_uris
-        .as_ref()
-        .map(|uris| Arc::clone(uris));
+    let liked_view = table_view.view_uris.as_ref().map(Arc::clone);
     actions_row(
         app,
         ui,

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -7,7 +7,8 @@ use egui::{Align, Layout, Rect, Sense, Vec2, pos2, vec2};
 use crate::api::models::{Album, PlayableItem, Playlist, pick_image};
 use crate::app::App;
 use crate::model::{
-    Action, Dialog, DragTrack, Loadable, Page, PagedList, RowContext, SortColumn, TableSort,
+    Action, Dialog, DragTrack, Loadable, Page, PagedList, RowContext, SortColumn, TableItem,
+    TableRowsCache, TableSort,
 };
 use crate::theme::{self, Icon, Palette};
 use crate::util;
@@ -282,9 +283,6 @@ fn playlist_position_jump(
     ui.add_space(8.0);
 }
 
-/// One table row's data: the item, when it was added, who added it.
-pub type TableItem = (PlayableItem, Option<String>, Option<String>);
-
 /// A track table with virtualised rows and paging.
 pub struct Table<'a> {
     pub items: &'a [TableItem],
@@ -313,33 +311,71 @@ pub struct TableCache {
     pub view_uris: Option<Arc<[String]>>,
 }
 
-/// Cached table rows for one page. Rebuilt only when the source list or
-/// contributor names change, not every frame.
-pub fn cached_table_items(
-    ui: &mut egui::Ui,
+pub fn table_items_hit(
+    app: &App,
     page: &Page,
+    generation: u64,
+    items_revision: u64,
+    user_names_revision: u64,
+) -> Option<Arc<[TableItem]>> {
+    app.table_rows.get(page).and_then(|cached| {
+        (cached.generation == generation
+            && cached.items_revision == items_revision
+            && cached.user_names_revision == user_names_revision)
+            .then(|| Arc::clone(&cached.items))
+    })
+}
+
+pub fn remember_table_items(
+    app: &mut App,
+    page: Page,
+    generation: u64,
+    items_revision: u64,
+    user_names_revision: u64,
+    items: Vec<TableItem>,
+) -> Arc<[TableItem]> {
+    let items: Arc<[TableItem]> = items.into();
+    app.table_rows.insert(
+        page.clone(),
+        TableRowsCache {
+            generation,
+            items_revision,
+            user_names_revision,
+            items: Arc::clone(&items),
+        },
+    );
+    app.retain_table_rows(&page);
+    items
+}
+
+/// Cached table rows for one page. Rebuilt only when the source list,
+/// contributor names, or page generation change, not every frame.
+///
+/// The cache lives on `App`, not in egui temp data. It is dropped when the
+/// page is evicted, when the account resets, and when more than two tables
+/// would be retained. Recreated pages get a new generation, so an old
+/// revision number cannot resurrect stale rows.
+pub fn cached_table_items(
+    app: &mut App,
+    page: Page,
+    generation: u64,
     items_revision: u64,
     user_names_revision: u64,
     build: impl FnOnce() -> Vec<TableItem>,
 ) -> Arc<[TableItem]> {
-    let cache_id = egui::Id::new("table-items-cache").with(page);
-    let cached = ui.data(|d| d.get_temp::<Arc<[TableItem]>>(cache_id));
-    let valid = cached.as_ref().is_some_and(|_items| {
-        ui.data(|d| {
-            d.get_temp::<(u64, u64)>(cache_id.with("rev"))
-                .is_some_and(|(rev, names)| rev == items_revision && names == user_names_revision)
-        })
-    });
-    if let Some(items) = cached.filter(|_| valid) {
-        items
-    } else {
-        let items: Arc<[TableItem]> = build().into();
-        ui.data_mut(|d| {
-            d.insert_temp(cache_id, Arc::clone(&items));
-            d.insert_temp(cache_id.with("rev"), (items_revision, user_names_revision));
-        });
-        items
+    if let Some(items) =
+        table_items_hit(app, &page, generation, items_revision, user_names_revision)
+    {
+        return items;
     }
+    remember_table_items(
+        app,
+        page,
+        generation,
+        items_revision,
+        user_names_revision,
+        build(),
+    )
 }
 
 pub fn prepare_table_view(
@@ -740,19 +776,19 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
             return;
         }
     };
-    let items = cached_table_items(
-        ui,
-        &Page::TopSongs,
-        app.home.top_songs_generation,
-        app.user_names_revision,
-        || {
-            tracks
+    let generation = app.home.top_songs_generation;
+    let names = app.user_names_revision;
+    let items =
+        if let Some(items) = table_items_hit(app, &Page::TopSongs, generation, generation, names) {
+            items
+        } else {
+            let rows = tracks
                 .iter()
                 .cloned()
                 .map(|track| (PlayableItem::Track(track), None, None))
-                .collect()
-        },
-    );
+                .collect();
+            remember_table_items(app, Page::TopSongs, generation, generation, names, rows)
+        };
     let uris: Arc<[String]> = items
         .iter()
         .map(|(item, _, _)| item.uri().to_string())
@@ -788,20 +824,22 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let user_id = app.user_id().unwrap_or("").to_string();
     match &page.playlist {
         Loadable::Loaded(playlist) => {
-            let items = cached_table_items(
-                ui,
-                &Page::Playlist(id.to_string()),
-                page.items.revision,
-                app.user_names_revision,
-                || {
-                    items_of(
-                        &page.items,
-                        playlist.owner.id.as_deref(),
-                        playlist.owner_name(),
-                        &app.user_names,
-                    )
-                },
-            );
+            let generation = page.generation;
+            let revision = page.items.revision;
+            let names = app.user_names_revision;
+            let key = Page::Playlist(id.to_string());
+            let items = if let Some(items) = table_items_hit(app, &key, generation, revision, names)
+            {
+                items
+            } else {
+                let rows = items_of(
+                    &page.items,
+                    playlist.owner.id.as_deref(),
+                    playlist.owner_name(),
+                    &app.user_names,
+                );
+                remember_table_items(app, key, generation, revision, names, rows)
+            };
             let count = playlist.track_total().max(items.len() as u32);
             // Spotify's collaborative flag covers secret collaborations; a
             // playlist made together today is recognised by who added songs.
@@ -960,31 +998,34 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
     match &page.album {
         Loadable::Loaded(album) => {
             album_hero(app, ui, album, &page.tracks);
-            let items = cached_table_items(
-                ui,
-                &Page::Album(id.to_string()),
-                page.tracks.revision,
-                app.user_names_revision,
-                || {
-                    page.tracks
-                        .items
-                        .iter()
-                        .cloned()
-                        .map(|mut track| {
-                            if track.album.is_none() {
-                                track.album = Some(Album {
-                                    id: album.id.clone(),
-                                    name: album.name.clone(),
-                                    uri: album.uri.clone(),
-                                    images: album.images.clone(),
-                                    ..Album::default()
-                                });
-                            }
-                            (PlayableItem::Track(track), None, None)
-                        })
-                        .collect()
-                },
-            );
+            let generation = page.generation;
+            let revision = page.tracks.revision;
+            let names = app.user_names_revision;
+            let key = Page::Album(id.to_string());
+            let items = if let Some(items) = table_items_hit(app, &key, generation, revision, names)
+            {
+                items
+            } else {
+                let rows = page
+                    .tracks
+                    .items
+                    .iter()
+                    .cloned()
+                    .map(|mut track| {
+                        if track.album.is_none() {
+                            track.album = Some(Album {
+                                id: album.id.clone(),
+                                name: album.name.clone(),
+                                uri: album.uri.clone(),
+                                images: album.images.clone(),
+                                ..Album::default()
+                            });
+                        }
+                        (PlayableItem::Track(track), None, None)
+                    })
+                    .collect();
+                remember_table_items(app, key, generation, revision, names, rows)
+            };
             let saved = app.is_saved(&album.uri).unwrap_or(false);
             let sort = app.table_sorts.get(&Page::Album(id.to_string())).copied();
             let table_view = prepare_table_view(
@@ -1128,13 +1169,14 @@ fn album_hero(
 
 pub fn liked(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let items = cached_table_items(
-        ui,
-        &Page::LikedSongs,
-        app.library.liked.revision,
-        app.user_names_revision,
-        || {
-            app.library
+    let revision = app.library.liked.revision;
+    let names = app.user_names_revision;
+    let items =
+        if let Some(items) = table_items_hit(app, &Page::LikedSongs, revision, revision, names) {
+            items
+        } else {
+            let rows = app
+                .library
                 .liked
                 .items
                 .iter()
@@ -1145,9 +1187,9 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
                         None,
                     )
                 })
-                .collect()
-        },
-    );
+                .collect();
+            remember_table_items(app, Page::LikedSongs, revision, revision, names, rows)
+        };
     let total = app.library.liked.total.unwrap_or(items.len() as u32);
     let user = app
         .user
@@ -1276,6 +1318,7 @@ fn palette_of(app: &App) -> Palette {
 mod tests {
     use super::*;
     use crate::api::models::{Album, ArtistRef, Track};
+    use crate::model::PlaylistPage;
 
     fn make_test_tracks() -> Vec<TableItem> {
         let titles = [
@@ -1420,5 +1463,84 @@ mod tests {
     fn a_direct_playlist_page_keeps_spotify_row_numbers() {
         assert_eq!(absolute_row_index(6_900, 0) + 1, 6_901);
         assert_eq!(absolute_row_index(6_900, 6) + 1, 6_907);
+    }
+
+    fn test_app() -> App {
+        let root = std::env::temp_dir().join(format!(
+            "fastpotify-table-cache-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        App::new(
+            &crate::backend::Waker::default(),
+            crate::paths::AppDirs {
+                config: root.join("config"),
+                state: root.join("state"),
+                cache: root.join("cache"),
+            },
+            crate::settings::Settings::default(),
+            crate::app::AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        )
+    }
+
+    #[test]
+    fn table_row_cache_hits_until_revision_or_generation_changes() {
+        let mut app = test_app();
+        let mut builds = 0;
+        let page = Page::LikedSongs;
+        cached_table_items(&mut app, page.clone(), 1, 0, 0, || {
+            builds += 1;
+            make_test_tracks()
+        });
+        cached_table_items(&mut app, page.clone(), 1, 0, 0, || {
+            builds += 1;
+            panic!("cache hit rebuilt the table");
+        });
+        assert_eq!(builds, 1);
+        cached_table_items(&mut app, page.clone(), 1, 1, 0, || {
+            builds += 1;
+            make_test_tracks()
+        });
+        assert_eq!(builds, 2, "revision change must rebuild");
+        cached_table_items(&mut app, page, 2, 1, 0, || {
+            builds += 1;
+            make_test_tracks()
+        });
+        assert_eq!(builds, 3, "generation change must rebuild");
+    }
+
+    #[test]
+    fn table_row_cache_dies_when_account_data_resets() {
+        let mut app = test_app();
+        cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, make_test_tracks);
+        assert!(!app.table_rows.is_empty());
+        let before = app.table_rows_retained_bytes();
+        assert!(before > 0, "cached rows should retain heap");
+        app.table_rows.clear();
+        assert_eq!(app.table_rows_retained_bytes(), 0);
+    }
+
+    #[test]
+    fn table_row_cache_keeps_at_most_two_pages() {
+        let mut app = test_app();
+        for i in 0..5 {
+            let page = Page::Playlist(format!("pl{i}"));
+            app.playlist_pages
+                .insert(format!("pl{i}"), PlaylistPage::default());
+            app.history.push(page.clone());
+            app.history_index = app.history.len() - 1;
+            cached_table_items(&mut app, page, 1, 0, 0, make_test_tracks);
+        }
+        assert_eq!(app.table_rows.len(), 2);
+        assert!(
+            app.table_rows.contains_key(&Page::Playlist("pl4".into())),
+            "the open page stays"
+        );
     }
 }

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -109,7 +109,7 @@ pub struct Actions<'a> {
     pub play_uri: Option<String>,
     /// A sorted or filtered view: the exact list on screen, which the big
     /// button plays instead of the context's own order.
-    pub view: Option<Vec<String>>,
+    pub view: Option<Arc<[String]>>,
     pub saved: Option<(String, bool)>,
     pub saved_icons: (Icon, Icon),
     pub saved_tooltips: (&'a str, &'a str),
@@ -154,7 +154,7 @@ pub fn actions_row(
                 } else if let Some(uris) = actions.view.clone() {
                     app.actions.push(Action::PlayFromRow {
                         context: RowContext::View {
-                            uris,
+                            uris: Arc::clone(&uris),
                             context_uri: uri.clone(),
                         },
                         uri: String::new(),
@@ -313,6 +313,40 @@ pub struct TableCache {
     pub view_uris: Option<Arc<[String]>>,
 }
 
+/// Cached table rows for one page. Rebuilt only when the source list or
+/// contributor names change, not every frame.
+pub fn cached_table_items(
+    ui: &mut egui::Ui,
+    page: &Page,
+    items_revision: u64,
+    user_names_revision: u64,
+    build: impl FnOnce() -> Vec<TableItem>,
+) -> Arc<[TableItem]> {
+    let cache_id = egui::Id::new("table-items-cache").with(page);
+    let cached = ui.data(|d| d.get_temp::<Arc<[TableItem]>>(cache_id));
+    let valid = cached.as_ref().is_some_and(|items| {
+        ui.data(|d| {
+            d.get_temp::<(u64, u64)>(cache_id.with("rev"))
+                .is_some_and(|(rev, names)| {
+                    rev == items_revision && names == user_names_revision
+                })
+        })
+    });
+    if let Some(items) = cached.filter(|_| valid) {
+        items
+    } else {
+        let items: Arc<[TableItem]> = build().into();
+        ui.data_mut(|d| {
+            d.insert_temp(cache_id, Arc::clone(&items));
+            d.insert_temp(
+                cache_id.with("rev"),
+                (items_revision, user_names_revision),
+            );
+        });
+        items
+    }
+}
+
 pub fn prepare_table_view(
     ui: &mut egui::Ui,
     app: &App,
@@ -423,10 +457,10 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
     let context = if let Some(uris) = &entry.view_uris {
         match &table.context {
             RowContext::Context { uri, .. } => RowContext::View {
-                uris: uris.to_vec(),
+                uris: Arc::clone(uris),
                 context_uri: uri.clone(),
             },
-            _ => RowContext::Uris(uris.to_vec()),
+            _ => RowContext::Uris(Arc::clone(uris)),
         }
     } else {
         table.context.clone()
@@ -700,7 +734,7 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
     ui.add_space(18.0);
 
     let tracks = match &app.home.top_songs {
-        Loadable::Loaded(tracks) => tracks.clone(),
+        Loadable::Loaded(tracks) => tracks,
         Loadable::Loading | Loadable::NotLoaded => {
             widgets::loading_row(ui, &palette);
             return;
@@ -711,19 +745,31 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
             return;
         }
     };
-    let items: Vec<TableItem> = tracks
+    let items = cached_table_items(
+        ui,
+        &Page::TopSongs,
+        app.home.top_songs_generation,
+        app.user_names_revision,
+        || {
+            tracks
+                .iter()
+                .cloned()
+                .map(|track| (PlayableItem::Track(track), None, None))
+                .collect()
+        },
+    );
+    let uris: Arc<[String]> = items
         .iter()
-        .cloned()
-        .map(|track| (PlayableItem::Track(track), None, None))
-        .collect();
-    let uris = tracks.into_iter().map(|track| track.uri).collect();
+        .map(|(item, _, _)| item.uri().to_string())
+        .collect::<Vec<_>>()
+        .into();
     table(
         app,
         ui,
         Table {
             items: &items,
             row_offset: 0,
-            context: RowContext::Uris(uris),
+            context: RowContext::Uris(Arc::clone(&uris)),
             show_album: true,
             show_cover: true,
             show_added: false,
@@ -747,11 +793,19 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let user_id = app.user_id().unwrap_or("").to_string();
     match &page.playlist {
         Loadable::Loaded(playlist) => {
-            let items = items_of(
-                &page.items,
-                playlist.owner.id.as_deref(),
-                playlist.owner_name(),
-                &app.user_names,
+            let items = cached_table_items(
+                ui,
+                &Page::Playlist(id.to_string()),
+                page.items.revision,
+                app.user_names_revision,
+                || {
+                    items_of(
+                        &page.items,
+                        playlist.owner.id.as_deref(),
+                        playlist.owner_name(),
+                        &app.user_names,
+                    )
+                },
             );
             let count = playlist.track_total().max(items.len() as u32);
             // Spotify's collaborative flag covers secret collaborations; a
@@ -833,7 +887,10 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.items.revision,
             );
-            let view_play = table_view.view_uris.as_ref().map(|uris| uris.to_vec());
+            let view_play = table_view
+                .view_uris
+                .as_ref()
+                .map(|uris| Arc::clone(uris));
             let playlist_clone = playlist.clone();
             actions_row(
                 app,
@@ -911,24 +968,31 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
     match &page.album {
         Loadable::Loaded(album) => {
             album_hero(app, ui, album, &page.tracks);
-            let items: Vec<TableItem> = page
-                .tracks
-                .items
-                .iter()
-                .cloned()
-                .map(|mut track| {
-                    if track.album.is_none() {
-                        track.album = Some(Album {
-                            id: album.id.clone(),
-                            name: album.name.clone(),
-                            uri: album.uri.clone(),
-                            images: album.images.clone(),
-                            ..Album::default()
-                        });
-                    }
-                    (PlayableItem::Track(track), None, None)
-                })
-                .collect();
+            let items = cached_table_items(
+                ui,
+                &Page::Album(id.to_string()),
+                page.tracks.revision,
+                app.user_names_revision,
+                || {
+                    page.tracks
+                        .items
+                        .iter()
+                        .cloned()
+                        .map(|mut track| {
+                            if track.album.is_none() {
+                                track.album = Some(Album {
+                                    id: album.id.clone(),
+                                    name: album.name.clone(),
+                                    uri: album.uri.clone(),
+                                    images: album.images.clone(),
+                                    ..Album::default()
+                                });
+                            }
+                            (PlayableItem::Track(track), None, None)
+                        })
+                        .collect()
+                },
+            );
             let saved = app.is_saved(&album.uri).unwrap_or(false);
             let sort = app.table_sorts.get(&Page::Album(id.to_string())).copied();
             let table_view = prepare_table_view(
@@ -940,7 +1004,10 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.tracks.revision,
             );
-            let album_view = table_view.view_uris.as_ref().map(|uris| uris.to_vec());
+            let album_view = table_view
+                .view_uris
+                .as_ref()
+                .map(|uris| Arc::clone(uris));
             actions_row(
                 app,
                 ui,
@@ -1072,19 +1139,26 @@ fn album_hero(
 
 pub fn liked(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let items: Vec<TableItem> = app
-        .library
-        .liked
-        .items
-        .iter()
-        .map(|saved| {
-            (
-                PlayableItem::Track(saved.track.clone()),
-                saved.added_at.clone(),
-                None,
-            )
-        })
-        .collect();
+    let items = cached_table_items(
+        ui,
+        &Page::LikedSongs,
+        app.library.liked.revision,
+        app.user_names_revision,
+        || {
+            app.library
+                .liked
+                .items
+                .iter()
+                .map(|saved| {
+                    (
+                        PlayableItem::Track(saved.track.clone()),
+                        saved.added_at.clone(),
+                        None,
+                    )
+                })
+                .collect()
+        },
+    );
     let total = app.library.liked.total.unwrap_or(items.len() as u32);
     let user = app
         .user
@@ -1132,7 +1206,10 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         sort,
         app.library.liked.revision,
     );
-    let liked_view = table_view.view_uris.as_ref().map(|uris| uris.to_vec());
+    let liked_view = table_view
+        .view_uris
+        .as_ref()
+        .map(|uris| Arc::clone(uris));
     actions_row(
         app,
         ui,
@@ -1148,10 +1225,11 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         Some(&mut filter),
     );
     ui.data_mut(|data| data.insert_temp(filter_id, filter.clone()));
-    let uris: Vec<String> = items
+    let uris: Arc<[String]> = items
         .iter()
         .map(|(item, _, _)| item.uri().to_string())
-        .collect();
+        .collect::<Vec<_>>()
+        .into();
     let context = match collection_uri {
         Some(uri) if app.library.liked.is_complete() => RowContext::Context {
             uri,

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -366,6 +366,7 @@ pub fn cached_table_items(
     if let Some(items) =
         table_items_hit(app, &page, generation, items_revision, user_names_revision)
     {
+        app.retain_table_rows(&page);
         return items;
     }
     remember_table_items(
@@ -1317,8 +1318,53 @@ fn palette_of(app: &App) -> Palette {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::models::{Album, ArtistRef, Track};
+    use crate::api::models::{Album, ArtistRef, Image, Track};
     use crate::model::PlaylistPage;
+
+    fn make_large_tracks(count: usize) -> Vec<TableItem> {
+        (0..count)
+            .map(|i| {
+                let track = Track {
+                    id: Some(format!("t_{i}")),
+                    name: format!("Nested metadata song {i} with a longer title"),
+                    uri: format!("spotify:track:large-{i}"),
+                    duration_ms: 180_000,
+                    artists: vec![ArtistRef {
+                        id: Some(format!("artist-{i}")),
+                        name: format!("Nested Artist Name {i}"),
+                        uri: Some(format!("spotify:artist:artist-{i}")),
+                    }],
+                    album: Some(Album {
+                        id: format!("alb-{i}"),
+                        name: format!("Nested Album Title {i}"),
+                        uri: format!("spotify:album:alb-{i}"),
+                        images: vec![
+                            Image {
+                                url: format!("https://i.scdn.co/image/large-{i}-640"),
+                                width: Some(640),
+                                height: Some(640),
+                            },
+                            Image {
+                                url: format!("https://i.scdn.co/image/large-{i}-300"),
+                                width: Some(300),
+                                height: Some(300),
+                            },
+                        ],
+                        ..Album::default()
+                    }),
+                    ..Track::default()
+                };
+                (PlayableItem::Track(track), None, None)
+            })
+            .collect()
+    }
+
+    fn names_only_bytes(items: &[TableItem]) -> usize {
+        items
+            .iter()
+            .map(|(item, ..)| item.uri().len() + item.name().len())
+            .sum()
+    }
 
     fn make_test_tracks() -> Vec<TableItem> {
         let titles = [
@@ -1516,14 +1562,37 @@ mod tests {
     }
 
     #[test]
-    fn table_row_cache_dies_when_account_data_resets() {
+    fn table_row_cache_memory_counts_nested_metadata_on_a_large_collection() {
         let mut app = test_app();
-        cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, make_test_tracks);
-        assert!(!app.table_rows.is_empty());
-        let before = app.table_rows_retained_bytes();
-        assert!(before > 0, "cached rows should retain heap");
-        app.table_rows.clear();
+        let items = make_large_tracks(500);
+        let names_only = names_only_bytes(&items);
         assert_eq!(app.table_rows_retained_bytes(), 0);
+        cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, || items);
+        let after = app.table_rows_retained_bytes();
+        assert!(
+            after > names_only,
+            "retained bytes must include nested album, artist, and image strings, not just titles: names_only={names_only} after={after}"
+        );
+        assert!(
+            after > 80_000,
+            "500 tracks with nested metadata should retain a substantial copy: {after}"
+        );
+    }
+
+    #[test]
+    fn table_row_cache_drops_when_the_backing_page_is_evicted() {
+        let mut app = test_app();
+        let page = Page::Playlist("pl-gone".into());
+        app.playlist_pages
+            .insert("pl-gone".into(), PlaylistPage::default());
+        cached_table_items(&mut app, page.clone(), 1, 0, 0, make_test_tracks);
+        assert!(app.table_rows.contains_key(&page));
+        app.playlist_pages.remove("pl-gone");
+        app.open(Page::LikedSongs);
+        assert!(
+            !app.table_rows.contains_key(&page),
+            "evicting the page map must drop the table-row copy"
+        );
     }
 
     #[test]

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -370,15 +370,15 @@ fn track_list(
         .collect::<Vec<_>>()
         .into();
     let context = RowContext::Uris(Arc::clone(&uris));
-    let items: Vec<PlayableItem> = tracks.iter().cloned().map(PlayableItem::Track).collect();
-    for (index, item) in items.iter().take(limit).enumerate() {
+    for (index, track) in tracks.iter().take(limit).enumerate() {
+        let item = PlayableItem::Track(track.clone());
         widgets::track_row(
             ui,
             app,
             TrackRow {
                 index,
                 number: None,
-                item,
+                item: &item,
                 context: &context,
                 show_cover: !app.settings.tracklist_compact,
                 show_album: true,
@@ -394,7 +394,7 @@ fn track_list(
         );
     }
     if let Some(label) = more_label
-        && items.len() > limit
+        && tracks.len() > limit
         && theme::link(ui, label, theme::semibold(14.0), palette.secondary).clicked()
     {
         app.actions.push(Action::Open(Page::TopSongs));

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -1,5 +1,7 @@
 //! The Home page.
 
+use std::sync::Arc;
+
 use egui::{CornerRadius, Rect, Sense, Vec2, pos2, vec2};
 
 use crate::api::models::{PlayableItem, Playlist, pick_image};
@@ -362,9 +364,13 @@ fn track_list(
         theme::section_title(ui, &palette, title);
     }
     ui.add_space(4.0);
-    let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
-    let context = RowContext::Uris(uris);
-    let items: Vec<PlayableItem> = tracks.into_iter().map(PlayableItem::Track).collect();
+    let uris: Arc<[String]> = tracks
+        .iter()
+        .map(|track| track.uri.clone())
+        .collect::<Vec<_>>()
+        .into();
+    let context = RowContext::Uris(Arc::clone(&uris));
+    let items: Vec<PlayableItem> = tracks.iter().cloned().map(PlayableItem::Track).collect();
     for (index, item) in items.iter().take(limit).enumerate() {
         widgets::track_row(
             ui,

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,5 +1,7 @@
 //! The playback queue, as a page or as a side panel.
 
+use std::sync::Arc;
+
 use egui::{Align, Frame, Layout, Margin};
 
 use crate::api::models::PlayableItem;
@@ -167,7 +169,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
     if let Some(current) = &current {
         theme::text(ui, "Now playing", theme::semibold(14.0), palette.text);
         ui.add_space(4.0);
-        let context = RowContext::Uris(vec![current.uri().to_string()]);
+        let context = RowContext::Uris(Arc::from([current.uri().to_string()]));
         widgets::track_row(
             ui,
             app,
@@ -293,7 +295,7 @@ fn recents_contents(app: &mut App, ui: &mut egui::Ui) {
         let entry = &items[index];
         // Need owned PlayableItem for track_row; clone track.
         let item = PlayableItem::Track(entry.track.clone());
-        let context = RowContext::Uris(vec![entry.track.uri.clone()]);
+        let context = RowContext::Uris(Arc::from([entry.track.uri.clone()]));
         widgets::track_row(
             ui,
             app,

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,5 +1,7 @@
 //! The Search page.
 
+use std::sync::Arc;
+
 use egui::{Align, CornerRadius, Layout, Rect, Sense, Vec2, pos2, vec2};
 
 use crate::api::models::{Artist, PlayableItem, SearchResults, pick_image};
@@ -315,8 +317,13 @@ fn songs(app: &mut App, ui: &mut egui::Ui, results: &SearchResults, limit: usize
     }
     theme::section_title(ui, &palette, "Songs");
     ui.add_space(4.0);
-    let uris: Vec<String> = page.items.iter().map(|track| track.uri.clone()).collect();
-    let context = RowContext::Uris(uris);
+    let uris: Arc<[String]> = page
+        .items
+        .iter()
+        .map(|track| track.uri.clone())
+        .collect::<Vec<_>>()
+        .into();
+    let context = RowContext::Uris(Arc::clone(&uris));
     let items: Vec<PlayableItem> = page
         .items
         .iter()

--- a/src/ui/show.rs
+++ b/src/ui/show.rs
@@ -1,5 +1,7 @@
 //! Podcast pages and episode rows.
 
+use std::sync::Arc;
+
 use egui::{CornerRadius, Layout, Rect, Sense, UiBuilder, Vec2, pos2, vec2};
 
 use crate::api::models::{Episode, PlayableItem, pick_image};
@@ -332,5 +334,5 @@ pub fn episode_row(
             index: 0,
         });
     }
-    let _ = RowContext::Uris(Vec::new());
+    let _ = RowContext::Uris(Arc::from([]));
 }


### PR DESCRIPTION
## Why

Collection tables rebuild every track row and clone sorted URI lists on each frame. That adds CPU and heap churn on large playlists.

## What changed

- Cache built table rows on `App`, keyed by page, generation, and revisions. At most two tables.
- Drop a cache when its page is evicted, including on `open`, Back, Forward, and cache hits, and on `reset_data`.
- Share sorted URI lists as `Arc<[String]>`.
- Retained size includes nested album, artist, and image strings. The test measures a 500-track collection against names-only, then dropping that page drops the table cache.

User-visible UI: none.