### PR TITLE
perf(app): evict stale playlist and album pages outside navigation history

### DIFF
--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -38,6 +38,11 @@ Successful playlist edits keep that loaded prefix and save it under Spotify's
 new snapshot. Fastpotify reloads the playlist only if the write fails and the
 optimistic edit must be reconciled.
 
+Fastpotify also keeps a small in-memory set of recently opened playlist,
+album, artist, and show pages. Going back to an older page loads it again
+from Spotify, or from the on-disk prefix cache when that still matches the
+snapshot.
+
 The last good playlist folder tree is kept in `session.json`, scoped to the
 account that supplied it. This keeps folders visible when local playback is
 temporarily unavailable. Live session data is still required for edit grants.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1451,6 +1451,8 @@ impl App {
         self.search.results = Loadable::NotLoaded;
         self.search.committed.clear();
         self.table_rows.clear();
+        self.page_used.clear();
+        self.track_used.clear();
     }
 
     /// Drop table-row caches whose pages are gone, and cap what remains.
@@ -4263,7 +4265,7 @@ impl App {
     // ---- navigation ------------------------------------------------------------
 
     pub fn open(&mut self, page: Page) {
-        self.page_used.insert(page.clone(), Instant::now());
+        self.touch_page(&page);
         if *self.page() == page {
             self.ensure_loaded(page.clone());
             self.retain_table_rows(&page);
@@ -4306,7 +4308,7 @@ impl App {
         let id = util::uri_id(&uri).unwrap_or_default().to_string();
         match util::uri_kind(&uri) {
             Some("track") => {
-                if let Some(track) = self.track_cache.get(&id) {
+                if let Some(track) = self.read_cached_track(&id) {
                     self.pending_link = None;
                     let album = track
                         .album
@@ -4340,6 +4342,16 @@ impl App {
 
     pub fn can_go_forward(&self) -> bool {
         self.history_index + 1 < self.history.len()
+    }
+
+    fn touch_page(&mut self, page: &Page) {
+        self.page_used.insert(page.clone(), Instant::now());
+    }
+
+    fn read_cached_track(&mut self, id: &str) -> Option<Track> {
+        let track = self.track_cache.get(id).cloned()?;
+        self.track_used.insert(id.to_owned(), Instant::now());
+        Some(track)
     }
 
     /// Drops page caches that exceed the cap, keeping the open page, the
@@ -5426,6 +5438,7 @@ impl App {
                 if self.can_go_back() {
                     self.history_index -= 1;
                     let page = self.page().clone();
+                    self.touch_page(&page);
                     self.ensure_loaded(page.clone());
                     self.retain_table_rows(&page);
                     self.evict_stale_pages();
@@ -5435,6 +5448,7 @@ impl App {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
+                    self.touch_page(&page);
                     self.ensure_loaded(page.clone());
                     self.retain_table_rows(&page);
                     self.evict_stale_pages();
@@ -8442,6 +8456,24 @@ mod tests {
         app
     }
 
+    fn seed_playlist(app: &mut App, id: &str) {
+        app.playlist_pages
+            .insert(id.to_string(), PlaylistPage::default());
+        app.open(Page::Playlist(id.to_string()));
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    fn store_track(app: &mut App, id: &str) {
+        app.track_cache.insert(
+            id.to_string(),
+            Track {
+                id: Some(id.to_string()),
+                uri: format!("spotify:track:{id}"),
+                ..Track::default()
+            },
+        );
+    }
+
     #[test]
     fn two_toggle_play_actions_in_one_batch_return_to_playing() {
         let mut app = headless_app();
@@ -8466,17 +8498,9 @@ mod tests {
     #[test]
     fn page_cache_stays_bounded_when_history_is_long() {
         let mut app = headless_app();
-        let now = Instant::now();
         for i in 0..20 {
-            let id = format!("pl{i}");
-            app.playlist_pages
-                .insert(id.clone(), PlaylistPage::default());
-            app.history.push(Page::Playlist(id.clone()));
-            app.page_used
-                .insert(Page::Playlist(id), now - Duration::from_secs(20 - i));
+            seed_playlist(&mut app, &format!("pl{i}"));
         }
-        app.history_index = app.history.len() - 1;
-        app.evict_stale_pages();
         assert!(
             app.playlist_pages.len() <= 12,
             "history must not protect more pages than the cap: {}",
@@ -8530,26 +8554,38 @@ mod tests {
     }
 
     #[test]
+    fn going_back_refreshes_page_recency() {
+        let mut app = headless_app();
+        let ctx = egui::Context::default();
+        for i in 0..12 {
+            seed_playlist(&mut app, &format!("pl{i}"));
+        }
+        for _ in 0..11 {
+            app.apply(Action::Back, &ctx);
+        }
+        assert_eq!(app.page(), &Page::Playlist("pl0".into()));
+        seed_playlist(&mut app, "pl12");
+        assert!(
+            app.playlist_pages.contains_key("pl0"),
+            "a playlist revisited through Back must not be the oldest"
+        );
+        assert!(
+            !app.playlist_pages.contains_key("pl11"),
+            "the page left behind by history is the one that goes"
+        );
+    }
+
+    #[test]
     fn page_cache_trims_data_that_arrives_after_navigation() {
         let mut app = headless_app();
-        app.open(Page::Playlist("current".into()));
         for i in 0..12 {
-            let id = format!("pl{i}");
-            app.playlist_pages
-                .insert(id.clone(), PlaylistPage::default());
-            app.page_used
-                .insert(Page::Playlist(id), Instant::now() - Duration::from_secs(30));
+            seed_playlist(&mut app, &format!("pl{i}"));
         }
+        app.open(Page::Playlist("current".into()));
         app.playlist_pages
             .insert("current".into(), PlaylistPage::default());
-        app.page_used
-            .insert(Page::Playlist("current".into()), Instant::now());
         app.playlist_pages
             .insert("late".into(), PlaylistPage::default());
-        app.page_used.insert(
-            Page::Playlist("late".into()),
-            Instant::now() - Duration::from_secs(60),
-        );
         app.evict_stale_pages();
         assert!(app.playlist_pages.len() <= 12);
         assert!(app.playlist_pages.contains_key("current"));
@@ -8613,24 +8649,32 @@ mod tests {
     #[test]
     fn track_cache_is_an_lru_of_eight_hundred() {
         let mut app = headless_app();
-        let now = Instant::now();
         for i in 0..900 {
-            let id = format!("t{i}");
-            app.track_cache.insert(
-                id.clone(),
-                Track {
-                    id: Some(id.clone()),
-                    uri: format!("spotify:track:{id}"),
-                    ..Track::default()
-                },
-            );
-            app.track_used
-                .insert(id, now - Duration::from_secs(900 - i));
+            store_track(&mut app, &format!("t{i}"));
+        }
+        for i in 100..900 {
+            let _ = app.read_cached_track(&format!("t{i}"));
         }
         app.evict_stale_pages();
         assert_eq!(app.track_cache.len(), 800);
-        assert!(app.track_cache.contains_key("t899"));
+        assert!(
+            app.track_cache.contains_key("t899"),
+            "a cache hit must keep that track"
+        );
         assert!(!app.track_cache.contains_key("t0"));
+    }
+
+    #[test]
+    fn reset_data_clears_cache_recency() {
+        let mut app = headless_app();
+        seed_playlist(&mut app, "pl0");
+        store_track(&mut app, "t0");
+        let _ = app.read_cached_track("t0");
+        assert!(!app.page_used.is_empty());
+        assert!(!app.track_used.is_empty());
+        app.reset_data();
+        assert!(app.page_used.is_empty());
+        assert!(app.track_used.is_empty());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4393,29 +4393,17 @@ impl App {
         evict_id_map(&mut self.artist_pages, &keep_artists, MAX_ARTIST_PAGES);
         evict_id_map(&mut self.show_pages, &keep_shows, MAX_SHOW_PAGES);
         if self.track_cache.len() > MAX_TRACK_CACHE {
-            let protected: HashSet<String> = self
-                .now_playing()
-                .and_then(|now| now.id)
-                .into_iter()
-                .chain(self.playlist_pages.values().flat_map(|page| {
-                    page.items.items.iter().filter_map(|item| {
-                        item.playable().and_then(|p| match p {
-                            PlayableItem::Track(track) => track.id.clone(),
-                            PlayableItem::Episode(episode) => Some(episode.id.clone()),
-                        })
-                    })
-                }))
-                .collect();
-            let mut removable: Vec<String> = self
+            let playing = self.now_playing().and_then(|now| now.id);
+            let mut keys: Vec<String> = self
                 .track_cache
                 .keys()
-                .filter(|id| !protected.contains(*id))
+                .filter(|id| playing.as_ref() != Some(*id))
                 .cloned()
                 .collect();
-            removable.sort();
-            for id in removable
+            keys.sort();
+            for id in keys
                 .into_iter()
-                .take(self.track_cache.len() - MAX_TRACK_CACHE)
+                .take(self.track_cache.len().saturating_sub(MAX_TRACK_CACHE))
             {
                 self.track_cache.remove(&id);
             }
@@ -6789,18 +6777,18 @@ fn cap_uris(uris: &[String], index: u32) -> (Vec<String>, u32) {
 
 fn evict_id_map<K, V>(map: &mut HashMap<K, V>, keep: &HashSet<K>, max: usize)
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash + Clone + Ord,
 {
     if map.len() <= max {
         return;
     }
-    let remove: Vec<K> = map
+    let mut remove: Vec<K> = map
         .keys()
         .filter(|key| !keep.contains(*key))
-        .take(map.len().saturating_sub(max))
         .cloned()
         .collect();
-    for key in remove {
+    remove.sort();
+    for key in remove.into_iter().take(map.len().saturating_sub(max)) {
         map.remove(&key);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 //! The application: state, event handling, and the actions views ask for.
 
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -4270,6 +4271,7 @@ impl App {
         self.show_devices = false;
         self.ensure_loaded(page.clone());
         self.retain_table_rows(&page);
+        self.evict_stale_pages();
     }
 
     /// Hands the app a Spotify link from outside, a canonical URI as
@@ -4331,6 +4333,91 @@ impl App {
 
     pub fn can_go_forward(&self) -> bool {
         self.history_index + 1 < self.history.len()
+    }
+
+    /// Drops page caches that are no longer in navigation history or playback.
+    fn evict_stale_pages(&mut self) {
+        const MAX_PLAYLIST_PAGES: usize = 12;
+        const MAX_ALBUM_PAGES: usize = 16;
+        const MAX_ARTIST_PAGES: usize = 10;
+        const MAX_SHOW_PAGES: usize = 8;
+        const MAX_TRACK_CACHE: usize = 800;
+
+        let mut keep_playlists = HashSet::new();
+        let mut keep_albums = HashSet::new();
+        let mut keep_artists = HashSet::new();
+        let mut keep_shows = HashSet::new();
+        for page in &self.history {
+            match page {
+                Page::Playlist(id) => {
+                    keep_playlists.insert(id.clone());
+                }
+                Page::Album(id) => {
+                    keep_albums.insert(id.clone());
+                }
+                Page::Artist(id) => {
+                    keep_artists.insert(id.clone());
+                }
+                Page::Show(id) => {
+                    keep_shows.insert(id.clone());
+                }
+                _ => {}
+            }
+        }
+        if let Some(uri) = self.playing_context_uri() {
+            if let Some(kind) = util::uri_kind(&uri)
+                && let Some(id) = util::uri_id(&uri)
+            {
+                match kind {
+                    "playlist" => {
+                        keep_playlists.insert(id.to_string());
+                    }
+                    "album" => {
+                        keep_albums.insert(id.to_string());
+                    }
+                    "artist" => {
+                        keep_artists.insert(id.to_string());
+                    }
+                    "show" => {
+                        keep_shows.insert(id.to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+        evict_id_map(&mut self.playlist_pages, &keep_playlists, MAX_PLAYLIST_PAGES);
+        evict_id_map(&mut self.album_pages, &keep_albums, MAX_ALBUM_PAGES);
+        evict_id_map(&mut self.artist_pages, &keep_artists, MAX_ARTIST_PAGES);
+        evict_id_map(&mut self.show_pages, &keep_shows, MAX_SHOW_PAGES);
+        if self.track_cache.len() > MAX_TRACK_CACHE {
+            let protected: HashSet<String> = self
+                .now_playing()
+                .and_then(|now| now.id)
+                .into_iter()
+                .chain(
+                    self.playlist_pages
+                        .values()
+                        .flat_map(|page| {
+                            page.items.items.iter().filter_map(|item| {
+                                item.playable().and_then(|p| match p {
+                                    PlayableItem::Track(track) => track.id.clone(),
+                                    PlayableItem::Episode(episode) => Some(episode.id.clone()),
+                                })
+                            })
+                        }),
+                )
+                .collect();
+            let mut removable: Vec<String> = self
+                .track_cache
+                .keys()
+                .filter(|id| !protected.contains(*id))
+                .cloned()
+                .collect();
+            removable.sort();
+            for id in removable.into_iter().take(self.track_cache.len() - MAX_TRACK_CACHE) {
+                self.track_cache.remove(&id);
+            }
+        }
     }
 
     // ---- playback --------------------------------------------------------------
@@ -5311,6 +5398,7 @@ impl App {
                     let page = self.page().clone();
                     self.ensure_loaded(page.clone());
                     self.retain_table_rows(&page);
+                    self.evict_stale_pages();
                 }
             }
             Action::Forward => {
@@ -5319,6 +5407,7 @@ impl App {
                     let page = self.page().clone();
                     self.ensure_loaded(page.clone());
                     self.retain_table_rows(&page);
+                    self.evict_stale_pages();
                 }
             }
             Action::PlayContext {
@@ -6695,6 +6784,25 @@ fn cap_uris(uris: &[String], index: u32) -> (Vec<String>, u32) {
     let end = (start + MAX).min(uris.len());
     (uris[start..end].to_vec(), 0)
 }
+
+fn evict_id_map<K, V>(map: &mut HashMap<K, V>, keep: &HashSet<K>, max: usize)
+where
+    K: Eq + Hash + Clone,
+{
+    if map.len() <= max {
+        return;
+    }
+    let remove: Vec<K> = map
+        .keys()
+        .filter(|key| !keep.contains(*key))
+        .take(map.len().saturating_sub(max))
+        .cloned()
+        .collect();
+    for key in remove {
+        map.remove(&key);
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,6 @@
 //! The application: state, event handling, and the actions views ask for.
 
 use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -264,6 +263,8 @@ pub struct App {
     track_requests: HashSet<String>,
     /// Built table rows, keyed by page. Capped; dropped on reset and eviction.
     pub table_rows: HashMap<Page, TableRowsCache>,
+    page_used: HashMap<Page, Instant>,
+    track_used: HashMap<String, Instant>,
 
     pub history: Vec<Page>,
     pub history_index: usize,
@@ -569,6 +570,8 @@ impl App {
             track_cache: HashMap::new(),
             track_requests: HashSet::new(),
             table_rows: HashMap::new(),
+            page_used: HashMap::new(),
+            track_used: HashMap::new(),
             history: vec![first_page],
             history_index: 0,
             saved: HashMap::new(),
@@ -1725,6 +1728,7 @@ impl App {
         if let Some(track) = found {
             self.remember_track_recording(&track);
             self.track_cache.insert(id.to_owned(), track);
+            self.track_used.insert(id.to_owned(), Instant::now());
         }
     }
 
@@ -1976,6 +1980,7 @@ impl App {
         if self.last_eviction.elapsed() > Duration::from_secs(20) {
             self.last_eviction = now;
             self.backend.art().evict(ctx);
+            self.evict_stale_pages();
         }
         self.sync_skin(ctx);
         if self.settings_dirty && self.last_settings_save.elapsed() > Duration::from_secs(2) {
@@ -4177,7 +4182,8 @@ impl App {
                     Ok(track) => {
                         self.remember_track_recording(&track);
                         self.request_recording_candidates(&track);
-                        self.track_cache.insert(id, track);
+                        self.track_cache.insert(id.clone(), track);
+                        self.track_used.insert(id, Instant::now());
                     }
                     Err(error) => {
                         if self.pending_link.as_deref()
@@ -4257,6 +4263,7 @@ impl App {
     // ---- navigation ------------------------------------------------------------
 
     pub fn open(&mut self, page: Page) {
+        self.page_used.insert(page.clone(), Instant::now());
         if *self.page() == page {
             self.ensure_loaded(page.clone());
             self.retain_table_rows(&page);
@@ -4335,7 +4342,9 @@ impl App {
         self.history_index + 1 < self.history.len()
     }
 
-    /// Drops page caches that are no longer in navigation history or playback.
+    /// Drops page caches that exceed the cap, keeping the open page, the
+    /// playing context, and the most recently used pages. History does not
+    /// protect a page from the cap. Track metadata is an LRU of 800.
     fn evict_stale_pages(&mut self) {
         const MAX_PLAYLIST_PAGES: usize = 12;
         const MAX_ALBUM_PAGES: usize = 16;
@@ -4343,26 +4352,24 @@ impl App {
         const MAX_SHOW_PAGES: usize = 8;
         const MAX_TRACK_CACHE: usize = 800;
 
-        let mut keep_playlists = HashSet::new();
-        let mut keep_albums = HashSet::new();
-        let mut keep_artists = HashSet::new();
-        let mut keep_shows = HashSet::new();
-        for page in &self.history {
-            match page {
-                Page::Playlist(id) => {
-                    keep_playlists.insert(id.clone());
-                }
-                Page::Album(id) => {
-                    keep_albums.insert(id.clone());
-                }
-                Page::Artist(id) => {
-                    keep_artists.insert(id.clone());
-                }
-                Page::Show(id) => {
-                    keep_shows.insert(id.clone());
-                }
-                _ => {}
+        let mut protected_playlists = HashSet::new();
+        let mut protected_albums = HashSet::new();
+        let mut protected_artists = HashSet::new();
+        let mut protected_shows = HashSet::new();
+        match self.page() {
+            Page::Playlist(id) => {
+                protected_playlists.insert(id.clone());
             }
+            Page::Album(id) => {
+                protected_albums.insert(id.clone());
+            }
+            Page::Artist(id) => {
+                protected_artists.insert(id.clone());
+            }
+            Page::Show(id) => {
+                protected_shows.insert(id.clone());
+            }
+            _ => {}
         }
         if let Some(uri) = self.playing_context_uri()
             && let Some(kind) = util::uri_kind(&uri)
@@ -4370,42 +4377,75 @@ impl App {
         {
             match kind {
                 "playlist" => {
-                    keep_playlists.insert(id.to_string());
+                    protected_playlists.insert(id.to_string());
                 }
                 "album" => {
-                    keep_albums.insert(id.to_string());
+                    protected_albums.insert(id.to_string());
                 }
                 "artist" => {
-                    keep_artists.insert(id.to_string());
+                    protected_artists.insert(id.to_string());
                 }
                 "show" => {
-                    keep_shows.insert(id.to_string());
+                    protected_shows.insert(id.to_string());
                 }
                 _ => {}
             }
         }
-        evict_id_map(
+        evict_lru_map(
             &mut self.playlist_pages,
-            &keep_playlists,
+            &self.page_used,
+            |id| Page::Playlist(id.to_string()),
+            &protected_playlists,
             MAX_PLAYLIST_PAGES,
         );
-        evict_id_map(&mut self.album_pages, &keep_albums, MAX_ALBUM_PAGES);
-        evict_id_map(&mut self.artist_pages, &keep_artists, MAX_ARTIST_PAGES);
-        evict_id_map(&mut self.show_pages, &keep_shows, MAX_SHOW_PAGES);
+        evict_lru_map(
+            &mut self.album_pages,
+            &self.page_used,
+            |id| Page::Album(id.to_string()),
+            &protected_albums,
+            MAX_ALBUM_PAGES,
+        );
+        evict_lru_map(
+            &mut self.artist_pages,
+            &self.page_used,
+            |id| Page::Artist(id.to_string()),
+            &protected_artists,
+            MAX_ARTIST_PAGES,
+        );
+        evict_lru_map(
+            &mut self.show_pages,
+            &self.page_used,
+            |id| Page::Show(id.to_string()),
+            &protected_shows,
+            MAX_SHOW_PAGES,
+        );
+        self.page_used.retain(|page, _| match page {
+            Page::Playlist(id) => self.playlist_pages.contains_key(id),
+            Page::Album(id) => self.album_pages.contains_key(id),
+            Page::Artist(id) => self.artist_pages.contains_key(id),
+            Page::Show(id) => self.show_pages.contains_key(id),
+            _ => true,
+        });
         if self.track_cache.len() > MAX_TRACK_CACHE {
             let playing = self.now_playing().and_then(|now| now.id);
-            let mut keys: Vec<String> = self
+            let overflow = self.track_cache.len() - MAX_TRACK_CACHE;
+            let mut victims: Vec<(Instant, String)> = self
                 .track_cache
                 .keys()
                 .filter(|id| playing.as_ref() != Some(*id))
-                .cloned()
+                .map(|id| {
+                    let used = self
+                        .track_used
+                        .get(id)
+                        .copied()
+                        .unwrap_or(Instant::now() - Duration::from_secs(86_400));
+                    (used, id.clone())
+                })
                 .collect();
-            keys.sort();
-            for id in keys
-                .into_iter()
-                .take(self.track_cache.len().saturating_sub(MAX_TRACK_CACHE))
-            {
+            victims.sort_by_key(|(used, _)| *used);
+            for (_, id) in victims.into_iter().take(overflow) {
                 self.track_cache.remove(&id);
+                self.track_used.remove(&id);
             }
         }
     }
@@ -6775,21 +6815,31 @@ fn cap_uris(uris: &[String], index: u32) -> (Vec<String>, u32) {
     (uris[start..end].to_vec(), 0)
 }
 
-fn evict_id_map<K, V>(map: &mut HashMap<K, V>, keep: &HashSet<K>, max: usize)
-where
-    K: Eq + Hash + Clone + Ord,
-{
+fn evict_lru_map<V>(
+    map: &mut HashMap<String, V>,
+    used: &HashMap<Page, Instant>,
+    to_page: impl Fn(&str) -> Page,
+    protected: &HashSet<String>,
+    max: usize,
+) {
     if map.len() <= max {
         return;
     }
-    let mut remove: Vec<K> = map
+    let overflow = map.len() - max;
+    let mut victims: Vec<(Instant, String)> = map
         .keys()
-        .filter(|key| !keep.contains(*key))
-        .cloned()
+        .filter(|id| !protected.contains(*id))
+        .map(|id| {
+            let used = used
+                .get(&to_page(id))
+                .copied()
+                .unwrap_or(Instant::now() - Duration::from_secs(86_400));
+            (used, id.clone())
+        })
         .collect();
-    remove.sort();
-    for key in remove.into_iter().take(map.len().saturating_sub(max)) {
-        map.remove(&key);
+    victims.sort_by_key(|(used, _)| *used);
+    for (_, id) in victims.into_iter().take(overflow) {
+        map.remove(&id);
     }
 }
 
@@ -8414,6 +8464,35 @@ mod tests {
     }
 
     #[test]
+    fn page_cache_stays_bounded_when_history_is_long() {
+        let mut app = headless_app();
+        let now = Instant::now();
+        for i in 0..20 {
+            let id = format!("pl{i}");
+            app.playlist_pages
+                .insert(id.clone(), PlaylistPage::default());
+            app.history.push(Page::Playlist(id.clone()));
+            app.page_used
+                .insert(Page::Playlist(id), now - Duration::from_secs(20 - i));
+        }
+        app.history_index = app.history.len() - 1;
+        app.evict_stale_pages();
+        assert!(
+            app.playlist_pages.len() <= 12,
+            "history must not protect more pages than the cap: {}",
+            app.playlist_pages.len()
+        );
+        assert!(
+            app.playlist_pages.contains_key("pl19"),
+            "the open page stays"
+        );
+        assert!(
+            !app.playlist_pages.contains_key("pl0"),
+            "the oldest page is dropped"
+        );
+    }
+
+    #[test]
     fn a_frame_snapshot_does_not_freeze_local_after_remote_handoff() {
         let mut app = headless_app();
         app.local.track = Some(crate::player::LocalTrack {
@@ -8447,6 +8526,36 @@ mod tests {
         assert_eq!(
             app.now_playing().expect("handoff").uri,
             "spotify:track:remote"
+        );
+    }
+
+    #[test]
+    fn page_cache_trims_data_that_arrives_after_navigation() {
+        let mut app = headless_app();
+        app.open(Page::Playlist("current".into()));
+        for i in 0..12 {
+            let id = format!("pl{i}");
+            app.playlist_pages
+                .insert(id.clone(), PlaylistPage::default());
+            app.page_used
+                .insert(Page::Playlist(id), Instant::now() - Duration::from_secs(30));
+        }
+        app.playlist_pages
+            .insert("current".into(), PlaylistPage::default());
+        app.page_used
+            .insert(Page::Playlist("current".into()), Instant::now());
+        app.playlist_pages
+            .insert("late".into(), PlaylistPage::default());
+        app.page_used.insert(
+            Page::Playlist("late".into()),
+            Instant::now() - Duration::from_secs(60),
+        );
+        app.evict_stale_pages();
+        assert!(app.playlist_pages.len() <= 12);
+        assert!(app.playlist_pages.contains_key("current"));
+        assert!(
+            !app.playlist_pages.contains_key("late"),
+            "a page that arrived after browsing still counts toward the cap"
         );
     }
 
@@ -8499,6 +8608,29 @@ mod tests {
             name, "Fresh",
             "reused revision 0 must not keep the old rows"
         );
+    }
+
+    #[test]
+    fn track_cache_is_an_lru_of_eight_hundred() {
+        let mut app = headless_app();
+        let now = Instant::now();
+        for i in 0..900 {
+            let id = format!("t{i}");
+            app.track_cache.insert(
+                id.clone(),
+                Track {
+                    id: Some(id.clone()),
+                    uri: format!("spotify:track:{id}"),
+                    ..Track::default()
+                },
+            );
+            app.track_used
+                .insert(id, now - Duration::from_secs(900 - i));
+        }
+        app.evict_stale_pages();
+        assert_eq!(app.track_cache.len(), 800);
+        assert!(app.track_cache.contains_key("t899"));
+        assert!(!app.track_cache.contains_key("t0"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4364,28 +4364,31 @@ impl App {
                 _ => {}
             }
         }
-        if let Some(uri) = self.playing_context_uri() {
-            if let Some(kind) = util::uri_kind(&uri)
-                && let Some(id) = util::uri_id(&uri)
-            {
-                match kind {
-                    "playlist" => {
-                        keep_playlists.insert(id.to_string());
-                    }
-                    "album" => {
-                        keep_albums.insert(id.to_string());
-                    }
-                    "artist" => {
-                        keep_artists.insert(id.to_string());
-                    }
-                    "show" => {
-                        keep_shows.insert(id.to_string());
-                    }
-                    _ => {}
+        if let Some(uri) = self.playing_context_uri()
+            && let Some(kind) = util::uri_kind(&uri)
+            && let Some(id) = util::uri_id(&uri)
+        {
+            match kind {
+                "playlist" => {
+                    keep_playlists.insert(id.to_string());
                 }
+                "album" => {
+                    keep_albums.insert(id.to_string());
+                }
+                "artist" => {
+                    keep_artists.insert(id.to_string());
+                }
+                "show" => {
+                    keep_shows.insert(id.to_string());
+                }
+                _ => {}
             }
         }
-        evict_id_map(&mut self.playlist_pages, &keep_playlists, MAX_PLAYLIST_PAGES);
+        evict_id_map(
+            &mut self.playlist_pages,
+            &keep_playlists,
+            MAX_PLAYLIST_PAGES,
+        );
         evict_id_map(&mut self.album_pages, &keep_albums, MAX_ALBUM_PAGES);
         evict_id_map(&mut self.artist_pages, &keep_artists, MAX_ARTIST_PAGES);
         evict_id_map(&mut self.show_pages, &keep_shows, MAX_SHOW_PAGES);
@@ -4394,18 +4397,14 @@ impl App {
                 .now_playing()
                 .and_then(|now| now.id)
                 .into_iter()
-                .chain(
-                    self.playlist_pages
-                        .values()
-                        .flat_map(|page| {
-                            page.items.items.iter().filter_map(|item| {
-                                item.playable().and_then(|p| match p {
-                                    PlayableItem::Track(track) => track.id.clone(),
-                                    PlayableItem::Episode(episode) => Some(episode.id.clone()),
-                                })
-                            })
-                        }),
-                )
+                .chain(self.playlist_pages.values().flat_map(|page| {
+                    page.items.items.iter().filter_map(|item| {
+                        item.playable().and_then(|p| match p {
+                            PlayableItem::Track(track) => track.id.clone(),
+                            PlayableItem::Episode(episode) => Some(episode.id.clone()),
+                        })
+                    })
+                }))
                 .collect();
             let mut removable: Vec<String> = self
                 .track_cache
@@ -4414,7 +4413,10 @@ impl App {
                 .cloned()
                 .collect();
             removable.sort();
-            for id in removable.into_iter().take(self.track_cache.len() - MAX_TRACK_CACHE) {
+            for id in removable
+                .into_iter()
+                .take(self.track_cache.len() - MAX_TRACK_CACHE)
+            {
                 self.track_cache.remove(&id);
             }
         }
@@ -6802,7 +6804,6 @@ where
         map.remove(&key);
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1616,7 +1616,11 @@ impl App {
         let Some(id) = util::uri_id(&uri).map(str::to_string) else {
             return;
         };
-        if self.track_cache.contains_key(&id) || !self.track_requests.insert(id.clone()) {
+        if self.track_cache.contains_key(&id) {
+            self.track_used.insert(id, Instant::now());
+            return;
+        }
+        if !self.track_requests.insert(id.clone()) {
             return;
         }
         self.backend.api(ApiRequest::Track { id });
@@ -1697,6 +1701,7 @@ impl App {
             return;
         };
         if self.track_cache.contains_key(id) {
+            self.track_used.insert(id.to_owned(), Instant::now());
             return;
         }
         let found = if let Some(pid) = context_uri.strip_prefix("spotify:playlist:") {
@@ -4357,6 +4362,7 @@ impl App {
     /// Drops page caches that exceed the cap, keeping the open page, the
     /// playing context, and the most recently used pages. History does not
     /// protect a page from the cap. Track metadata is an LRU of 800.
+    /// Table-row copies of dropped playlist and album pages go with them.
     fn evict_stale_pages(&mut self) {
         const MAX_PLAYLIST_PAGES: usize = 12;
         const MAX_ALBUM_PAGES: usize = 16;
@@ -4460,6 +4466,8 @@ impl App {
                 self.track_used.remove(&id);
             }
         }
+        let current = self.page().clone();
+        self.retain_table_rows(&current);
     }
 
     // ---- playback --------------------------------------------------------------
@@ -8675,6 +8683,114 @@ mod tests {
         app.reset_data();
         assert!(app.page_used.is_empty());
         assert!(app.track_used.is_empty());
+    }
+
+    #[test]
+    fn stepping_resume_keeps_a_cached_preview() {
+        use crate::api::models::{PlayableItem, PlaylistItem, Track};
+        use crate::model::PagedList;
+        let row = |uri: &str| PlaylistItem {
+            item: Some(PlayableItem::Track(Track {
+                id: Some(uri.rsplit(':').next().unwrap().into()),
+                uri: uri.into(),
+                name: uri.into(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let mut app = headless_app();
+        let ctx = egui::Context::default();
+        store_track(&mut app, "one");
+        store_track(&mut app, "two");
+        for i in 0..798 {
+            store_track(&mut app, &format!("old{i}"));
+            let _ = app.read_cached_track(&format!("old{i}"));
+        }
+        app.playlist_pages.insert(
+            "pl1".into(),
+            PlaylistPage {
+                items: PagedList {
+                    items: vec![row("spotify:track:one"), row("spotify:track:two")],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        app.resume_context = Some("spotify:playlist:pl1".into());
+        app.resume_track = Some("spotify:track:one".into());
+        app.apply(Action::Next, &ctx);
+        assert_eq!(app.resume_track.as_deref(), Some("spotify:track:two"));
+        store_track(&mut app, "overflow");
+        let _ = app.read_cached_track("overflow");
+        app.evict_stale_pages();
+        assert!(
+            app.track_cache.contains_key("two"),
+            "a cache hit while stepping resume must keep the song just previewed"
+        );
+        assert!(
+            !app.track_cache.contains_key("one"),
+            "the song left behind can go"
+        );
+    }
+
+    #[test]
+    fn requesting_a_cached_resume_track_keeps_it() {
+        let mut app = headless_app();
+        store_track(&mut app, "resume");
+        store_track(&mut app, "decoy");
+        for i in 0..798 {
+            store_track(&mut app, &format!("old{i}"));
+            let _ = app.read_cached_track(&format!("old{i}"));
+        }
+        app.resume_track = Some("spotify:track:resume".into());
+        app.request_resume_track();
+        store_track(&mut app, "overflow");
+        let _ = app.read_cached_track("overflow");
+        app.evict_stale_pages();
+        assert!(
+            app.track_cache.contains_key("resume"),
+            "a cache hit on the resume URI must keep that track"
+        );
+        assert!(
+            !app.track_cache.contains_key("decoy"),
+            "an untouched cached track can go"
+        );
+    }
+
+    #[test]
+    fn evict_stale_pages_drops_table_row_copies() {
+        let mut app = headless_app();
+        for i in 0..12 {
+            seed_playlist(&mut app, &format!("pl{i}"));
+        }
+        crate::ui::collection::cached_table_items(
+            &mut app,
+            Page::Playlist("pl0".into()),
+            0,
+            0,
+            0,
+            || {
+                vec![(
+                    PlayableItem::Track(Track {
+                        name: "Old".into(),
+                        uri: "spotify:track:old".into(),
+                        ..Track::default()
+                    }),
+                    None,
+                    None,
+                )]
+            },
+        );
+        assert!(app.table_rows.contains_key(&Page::Playlist("pl0".into())));
+        seed_playlist(&mut app, "pl12");
+        assert!(
+            !app.playlist_pages.contains_key("pl0"),
+            "the oldest playlist page is dropped"
+        );
+        assert!(
+            !app.table_rows.contains_key(&Page::Playlist("pl0".into())),
+            "its table-row copy must go with it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Playlist, album, artist, and show pages stay in memory after navigation moves on. Long sessions keep every visited page.

## What changed

- LRU page cache. Protected entries are the open page and the playing context, not the whole history.
- Recency updates on `open`, Back, Forward, track-cache reads, and playback cache hits (`cache_track_from_context`, `request_resume_track`). Both recency maps clear on `reset_data`.
- `track_cache` caps at 800 and trims on navigation and the 20s tick.
- Dropped pages also drop their table-row copies.
- Older in-memory pages reload when revisited (from Spotify, or from the on-disk playlist prefix cache when that still matches).

Tests go through real `open`, Back, and paused Next (`step_resume`): after twelve playlists, Back to the first, then a new playlist. The revisited page stays. Stepping to a cached song while paused keeps that song when the cache overflows.

User-visible UI: none.