### PR TITLE
perf(app): snapshot now playing once per frame

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -326,6 +326,8 @@ pub struct App {
     #[cfg(feature = "milkdrop")]
     milkdrop_host: Option<crate::milkdrop::host::Host>,
     last_eviction: Instant,
+    /// Playback snapshot for the current frame, built once per redraw.
+    frame_now: Option<NowPlaying>,
     pub sign_in_url: Option<String>,
     /// The verified personal Web API application, when acceleration is ready.
     pub web_app: Option<String>,
@@ -600,6 +602,7 @@ impl App {
             #[cfg(feature = "milkdrop")]
             milkdrop_host: None,
             last_eviction: Instant::now(),
+            frame_now: None,
             sign_in_url: None,
             web_app: None,
             pending_remote_position: None,
@@ -987,7 +990,14 @@ impl App {
     }
 
     pub fn now_playing(&self) -> Option<NowPlaying> {
+        if let Some(now) = &self.frame_now {
+            return Some(now.clone());
+        }
         self.now_playing_live().or_else(|| self.resume_preview())
+    }
+
+    fn refresh_frame_now(&mut self) {
+        self.frame_now = self.now_playing_live().or_else(|| self.resume_preview());
     }
 
     /// What a device is actually playing, here or elsewhere.
@@ -6153,6 +6163,7 @@ impl App {
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
+        self.refresh_frame_now();
         self.apply_theme(ctx);
         self.lock_scroll_axis(ctx);
         // Switch to the main window when sign-in is required.
@@ -6190,7 +6201,11 @@ impl App {
             ctx.request_repaint_after(Duration::from_millis(120));
         }
         if self.is_connected() {
-            ctx.request_repaint_after(REMOTE_POLL_ACTIVE);
+            let interval = match self.target() {
+                Target::Local if self.local.is_active() => REMOTE_POLL_IDLE,
+                _ => REMOTE_POLL_ACTIVE,
+            };
+            ctx.request_repaint_after(interval);
         }
         if ctx.input(|input| input.viewport().close_requested())
             && !self.quit_requested

--- a/src/app.rs
+++ b/src/app.rs
@@ -5206,6 +5206,7 @@ impl App {
     // ---- actions -----------------------------------------------------------------
 
     fn apply_actions(&mut self, ctx: &egui::Context) {
+        self.frame_now = None;
         let mut actions = std::mem::take(&mut self.actions);
         while !actions.is_empty() {
             for action in actions.drain(..) {
@@ -8072,8 +8073,9 @@ mod tests {
     }
 
     #[test]
-    fn a_frame_snapshot_sees_optimistic_pause_in_the_same_batch() {
+    fn two_toggle_play_actions_in_one_batch_return_to_playing() {
         let mut app = headless_app();
+        let ctx = egui::Context::default();
         app.local.track = Some(crate::player::LocalTrack {
             uri: "spotify:track:a".into(),
             title: "A".into(),
@@ -8082,15 +8084,12 @@ mod tests {
         app.local.playback = Playback::Playing;
         app.refresh_frame_now();
         assert!(app.now_playing().expect("playing").playing);
-        app.optimistic_playing = Some((false, Instant::now()));
+        app.actions.push(Action::TogglePlay);
+        app.actions.push(Action::TogglePlay);
+        app.apply_actions(&ctx);
         assert!(
-            app.now_playing().expect("snapshot").playing,
-            "the pre-action snapshot must not flip until the frame refreshes"
-        );
-        app.refresh_frame_now();
-        assert!(
-            !app.now_playing().expect("paused").playing,
-            "after apply_actions the snapshot must match the optimistic pause"
+            app.now_playing().expect("playing").playing,
+            "the second toggle must see the first pause, not the drawing snapshot"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6202,11 +6202,7 @@ impl App {
             ctx.request_repaint_after(Duration::from_millis(120));
         }
         if self.is_connected() {
-            let interval = match self.target() {
-                Target::Local if self.local.is_active() => REMOTE_POLL_IDLE,
-                _ => REMOTE_POLL_ACTIVE,
-            };
-            ctx.request_repaint_after(interval);
+            ctx.request_repaint_after(self.connected_repaint_interval());
         }
         if ctx.input(|input| input.viewport().close_requested())
             && !self.quit_requested
@@ -6217,6 +6213,19 @@ impl App {
             self.hide_intent = true;
         }
         self.frame_now = None;
+    }
+
+    /// How soon the window asks for another frame while signed in.
+    ///
+    /// API polling already uses 20s during local playback. This only changes
+    /// the UI deadline. While a track is playing, the 250ms progress refresh
+    /// still wins, so the saving is idle-local frames: 4s -> 20s, 80% fewer
+    /// wakeups when paused on this device.
+    fn connected_repaint_interval(&self) -> Duration {
+        match self.target() {
+            Target::Local if self.local.is_active() => REMOTE_POLL_IDLE,
+            _ => REMOTE_POLL_ACTIVE,
+        }
     }
 
     /// Locks each scroll gesture to one axis.
@@ -8060,6 +8069,82 @@ mod tests {
         );
         app.local_ready = true;
         app
+    }
+
+    #[test]
+    fn a_frame_snapshot_sees_optimistic_pause_in_the_same_batch() {
+        let mut app = headless_app();
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:a".into(),
+            title: "A".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Playing;
+        app.refresh_frame_now();
+        assert!(app.now_playing().expect("playing").playing);
+        app.optimistic_playing = Some((false, Instant::now()));
+        assert!(
+            app.now_playing().expect("snapshot").playing,
+            "the pre-action snapshot must not flip until the frame refreshes"
+        );
+        app.refresh_frame_now();
+        assert!(
+            !app.now_playing().expect("paused").playing,
+            "after apply_actions the snapshot must match the optimistic pause"
+        );
+    }
+
+    #[test]
+    fn a_frame_snapshot_does_not_freeze_local_after_remote_handoff() {
+        let mut app = headless_app();
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:local".into(),
+            title: "Local".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Playing;
+        app.refresh_frame_now();
+        assert_eq!(app.now_playing().expect("local").uri, "spotify:track:local");
+        app.local.track = None;
+        app.local.playback = Playback::Stopped;
+        app.remote = Some(RemoteSnapshot {
+            state: PlaybackState {
+                is_playing: true,
+                item: Some(PlayableItem::Track(Track {
+                    id: Some("remote".into()),
+                    uri: "spotify:track:remote".into(),
+                    name: "Remote".into(),
+                    ..Track::default()
+                })),
+                ..Default::default()
+            },
+            received_at: Instant::now(),
+        });
+        assert_eq!(
+            app.now_playing().expect("stale snapshot").uri,
+            "spotify:track:local"
+        );
+        app.refresh_frame_now();
+        assert_eq!(
+            app.now_playing().expect("handoff").uri,
+            "spotify:track:remote"
+        );
+    }
+
+    #[test]
+    fn local_idle_repaint_is_twenty_seconds_not_four() {
+        let mut app = headless_app();
+        assert_eq!(app.connected_repaint_interval(), REMOTE_POLL_ACTIVE);
+        app.local.track = Some(crate::player::LocalTrack {
+            uri: "spotify:track:a".into(),
+            ..Default::default()
+        });
+        app.local.playback = Playback::Paused;
+        assert_eq!(
+            app.connected_repaint_interval(),
+            REMOTE_POLL_IDLE,
+            "paused local UI wait is 20s (already the API interval); 4s was only a tighter wake-up"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -6179,6 +6179,7 @@ impl App {
             crate::ui::show(self, ui);
         }
         self.apply_actions(ctx);
+        self.refresh_frame_now();
         self.sync_media_controls();
 
         if !self.settings.winamp_window && !self.switch_intent {
@@ -6215,6 +6216,7 @@ impl App {
             // Close the window and keep the process running in the tray.
             self.hide_intent = true;
         }
+        self.frame_now = None;
     }
 
     /// Locks each scroll gesture to one axis.


### PR DESCRIPTION
## Why

Playback state was read many times in one frame from a snapshot that could go stale in the same action batch. Idle UI repaint was 4s while paused, even though the Web API poll was already 20s.

## What changed

- Snapshot `now_playing` once per draw. Clear that snapshot before applying actions, so two `TogglePlay` in one batch return to playing (same as main).
- Does not change Web API polling.
- While local playback is paused, idle UI repaint is 20s instead of 4s. Playing still requests 250ms frames.

User-visible UI: none.