### PR TITLE
perf(ui): virtualize queue playing-next rows and library card grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ cargo run --features demo -- --demo --demo-page playlist:pl1 --demo-show queue
 
 Demo mode never writes settings. `--demo-shot <PATH>` writes the window to a
 PNG and exits, which is useful for reproducible interface screenshots.
+`--demo-size WIDTHxHEIGHT` sets the window size for that shot.
 
 ## Contributing
 

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -140,5 +140,6 @@ cargo run --release --features demo -- \
   --demo-shot docs/screenshot.png --demo-page playlist:pl1 --demo-show queue
 ```
 
-The image uses the current window size. `--demo-shot-delay <MS>` sets how long
-to wait for cover art before taking it.
+The image uses the current window size. `--demo-size WIDTHxHEIGHT` sets that
+size for a shot (for example `760x800` or `1240x800`). `--demo-shot-delay <MS>`
+sets how long to wait for cover art before taking it.

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -129,7 +129,7 @@ settings.
 
 `--demo-page` opens a page, such as `home`, `playlist:pl1`, or `artist:art0`,
 and `--demo-show` adds surfaces on top of it: a comma separated list of
-`queue`, `devices`, `shortcuts`, `premium`, `create`, `duplicate`, `light`,
+`queue`, `playing-next`, `devices`, `shortcuts`, `premium`, `create`, `duplicate`, `light`,
 `focus`, `winamp`, `playlist`, `eq`, `eq-shade`, and `compact`.
 
 `--demo-shot <PATH>` writes the window to a PNG and exits, which is useful for

--- a/src/app.rs
+++ b/src/app.rs
@@ -4236,7 +4236,8 @@ impl App {
 
     pub fn open(&mut self, page: Page) {
         if *self.page() == page {
-            self.ensure_loaded(page);
+            self.ensure_loaded(page.clone());
+            self.retain_table_rows(&page);
             return;
         }
         self.history.truncate(self.history_index + 1);
@@ -4246,7 +4247,8 @@ impl App {
         }
         self.history_index = self.history.len() - 1;
         self.show_devices = false;
-        self.ensure_loaded(page);
+        self.ensure_loaded(page.clone());
+        self.retain_table_rows(&page);
     }
 
     /// Hands the app a Spotify link from outside, a canonical URI as
@@ -5285,14 +5287,16 @@ impl App {
                 if self.can_go_back() {
                     self.history_index -= 1;
                     let page = self.page().clone();
-                    self.ensure_loaded(page);
+                    self.ensure_loaded(page.clone());
+                    self.retain_table_rows(&page);
                 }
             }
             Action::Forward => {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
-                    self.ensure_loaded(page);
+                    self.ensure_loaded(page.clone());
+                    self.retain_table_rows(&page);
                 }
             }
             Action::PlayContext {

--- a/src/app.rs
+++ b/src/app.rs
@@ -987,10 +987,10 @@ impl App {
     }
 
     pub fn now_playing(&self) -> Option<NowPlaying> {
-self.now_playing_live().or_else(|| self.resume_preview())
+        self.now_playing_live().or_else(|| self.resume_preview())
     }
 
-/// What a device is actually playing, here or elsewhere.
+    /// What a device is actually playing, here or elsewhere.
     fn now_playing_live(&self) -> Option<NowPlaying> {
         if self.local.is_active() {
             let track = self.local.track.as_ref()?;
@@ -5225,14 +5225,14 @@ self.now_playing_live().or_else(|| self.resume_preview())
                     self.history_index -= 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                            }
+                }
             }
             Action::Forward => {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                            }
+                }
             }
             Action::PlayContext {
                 uri,
@@ -6153,7 +6153,7 @@ impl App {
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
-self.apply_theme(ctx);
+        self.apply_theme(ctx);
         self.lock_scroll_axis(ctx);
         // Switch to the main window when sign-in is required.
         let needs_sign_in = !(self.is_connected() && self.user.is_some())

--- a/src/app.rs
+++ b/src/app.rs
@@ -987,10 +987,10 @@ impl App {
     }
 
     pub fn now_playing(&self) -> Option<NowPlaying> {
-        self.now_playing_live().or_else(|| self.resume_preview())
+self.now_playing_live().or_else(|| self.resume_preview())
     }
 
-    /// What a device is actually playing, here or elsewhere.
+/// What a device is actually playing, here or elsewhere.
     fn now_playing_live(&self) -> Option<NowPlaying> {
         if self.local.is_active() {
             let track = self.local.track.as_ref()?;
@@ -2849,7 +2849,7 @@ impl App {
             if uris.is_empty() {
                 return;
             }
-            let (uris, index) = cap_uris(uris, index as u32);
+            let (uris, index) = cap_uris(&uris, index as u32);
             self.play_request(PlayRequest::tracks(uris).starting_at_index(index), false);
             return;
         }
@@ -5225,14 +5225,14 @@ impl App {
                     self.history_index -= 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                }
+                            }
             }
             Action::Forward => {
                 if self.can_go_forward() {
                     self.history_index += 1;
                     let page = self.page().clone();
                     self.ensure_loaded(page);
-                }
+                            }
             }
             Action::PlayContext {
                 uri,
@@ -5274,7 +5274,7 @@ impl App {
                 if uris.is_empty() {
                     return;
                 }
-                let (uris, index) = cap_uris(uris, index);
+                let (uris, index) = cap_uris(&uris, index);
                 let request = PlayRequest::tracks(uris).starting_at_index(index);
                 self.play_request(request, false);
             }
@@ -5290,13 +5290,13 @@ impl App {
                     self.play_request(request, false);
                 }
                 RowContext::Uris(uris) => {
-                    let (uris, index) = cap_uris(uris, index);
+                    let (uris, index) = cap_uris(uris.as_ref(), index);
                     let request = PlayRequest::tracks(uris).starting_at_index(index);
                     self.play_request(request, false);
                 }
                 RowContext::Queue => self.play_queue_item(index as usize, uri),
                 RowContext::View { uris, context_uri } => {
-                    let (uris, index) = cap_uris(uris, index);
+                    let (uris, index) = cap_uris(uris.as_ref(), index);
                     let request = PlayRequest::tracks(uris).starting_at_index(index);
                     self.play_request(request, false);
                     self.note_recent_context(&context_uri);
@@ -6153,7 +6153,7 @@ impl App {
     pub fn frame_ui(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
-        self.apply_theme(ctx);
+self.apply_theme(ctx);
         self.lock_scroll_axis(ctx);
         // Switch to the main window when sign-in is required.
         let needs_sign_in = !(self.is_connected() && self.user.is_some())
@@ -6560,12 +6560,12 @@ fn autoplay_seed(
 }
 
 /// Caps large track lists at 500 items starting from the selected row.
-fn cap_uris(uris: Vec<String>, index: u32) -> (Vec<String>, u32) {
+fn cap_uris(uris: &[String], index: u32) -> (Vec<String>, u32) {
     const MAX: usize = 500;
     if uris.len() <= MAX {
-        return (uris, index);
+        return (uris.to_vec(), index);
     }
-    let start = (index as usize).min(uris.len() - 1);
+    let start = (index as usize).min(uris.len().saturating_sub(1));
     let end = (start + MAX).min(uris.len());
     (uris[start..end].to_vec(), 0)
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -261,6 +261,8 @@ pub struct App {
     pub show_pages: HashMap<String, ShowPage>,
     pub track_cache: HashMap<String, Track>,
     track_requests: HashSet<String>,
+    /// Built table rows, keyed by page. Capped; dropped on reset and eviction.
+    pub table_rows: HashMap<Page, TableRowsCache>,
 
     pub history: Vec<Page>,
     pub history_index: usize,
@@ -563,6 +565,7 @@ impl App {
             show_pages: HashMap::new(),
             track_cache: HashMap::new(),
             track_requests: HashSet::new(),
+            table_rows: HashMap::new(),
             history: vec![first_page],
             history_index: 0,
             saved: HashMap::new(),
@@ -1422,6 +1425,54 @@ impl App {
         self.devices_fetched_at = None;
         self.search.results = Loadable::NotLoaded;
         self.search.committed.clear();
+        self.table_rows.clear();
+    }
+
+    /// Drop table-row caches whose pages are gone, and cap what remains.
+    pub fn retain_table_rows(&mut self, current: &Page) {
+        const MAX_TABLE_ROW_CACHES: usize = 2;
+        self.table_rows.retain(|page, _| {
+            page == current
+                || match page {
+                    Page::Playlist(id) => self.playlist_pages.contains_key(id),
+                    Page::Album(id) => self.album_pages.contains_key(id),
+                    Page::LikedSongs | Page::TopSongs => true,
+                    _ => false,
+                }
+        });
+        if self.table_rows.len() <= MAX_TABLE_ROW_CACHES {
+            return;
+        }
+        let mut keep = HashSet::from([current.clone()]);
+        if let Some(page) = self.history.get(self.history_index) {
+            keep.insert(page.clone());
+        }
+        if self.history_index > 0
+            && let Some(page) = self.history.get(self.history_index - 1)
+        {
+            keep.insert(page.clone());
+        }
+        self.table_rows.retain(|page, _| keep.contains(page));
+        while self.table_rows.len() > MAX_TABLE_ROW_CACHES {
+            let drop = self
+                .table_rows
+                .keys()
+                .find(|page| *page != current)
+                .cloned();
+            match drop {
+                Some(page) => {
+                    self.table_rows.remove(&page);
+                }
+                None => break,
+            }
+        }
+    }
+
+    pub fn table_rows_retained_bytes(&self) -> usize {
+        self.table_rows
+            .values()
+            .map(TableRowsCache::retained_bytes)
+            .sum()
     }
 
     fn handle_local(&mut self, state: LocalState) {
@@ -2451,6 +2502,16 @@ impl App {
                 self.request_contains(vec![format!("spotify:playlist:{id}")]);
             }
             Page::Album(id) => {
+                if !self.album_pages.contains_key(&id) {
+                    self.load_generation = self.load_generation.wrapping_add(1);
+                    self.album_pages.insert(
+                        id.clone(),
+                        AlbumPage {
+                            generation: self.load_generation,
+                            ..Default::default()
+                        },
+                    );
+                }
                 let page = self.album_pages.entry(id.clone()).or_default();
                 if page.album.needs_load() {
                     page.album = Loadable::Loading;
@@ -8043,6 +8104,41 @@ mod tests {
         );
         app.local_ready = true;
         app
+    }
+
+    #[test]
+    fn reset_data_drops_table_row_caches() {
+        let mut app = headless_app();
+        crate::ui::collection::cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, || {
+            vec![(
+                PlayableItem::Track(Track {
+                    name: "Hold".into(),
+                    uri: "spotify:track:hold".into(),
+                    ..Track::default()
+                }),
+                None,
+                None,
+            )]
+        });
+        assert!(!app.table_rows.is_empty());
+        app.reset_data();
+        assert!(app.table_rows.is_empty());
+        crate::ui::collection::cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, || {
+            vec![(
+                PlayableItem::Track(Track {
+                    name: "Fresh".into(),
+                    uri: "spotify:track:fresh".into(),
+                    ..Track::default()
+                }),
+                None,
+                None,
+            )]
+        });
+        let name = app.table_rows[&Page::LikedSongs].items[0].0.name();
+        assert_eq!(
+            name, "Fresh",
+            "reused revision 0 must not keep the old rows"
+        );
     }
 
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -802,6 +802,7 @@ mod tests {
     use crate::app::AppOptions;
     use crate::paths::AppDirs;
     use crate::settings::Settings;
+    use std::sync::Arc;
 
     fn accessible_app(name: &str) -> (egui::Context, App) {
         let root =
@@ -1019,7 +1020,7 @@ mod tests {
         use egui::accesskit::{Action as AccessibleAction, Role};
         let (ctx, mut app) = accessible_app("rows");
         let item = app.queue.get().unwrap().queue[0].clone();
-        let context = crate::model::RowContext::Uris(vec![item.uri().to_string(); 2]);
+        let context = crate::model::RowContext::Uris(Arc::from(vec![item.uri().to_string(); 2]));
         let label = format!("Play {}, {}", item.name(), item.subtitle());
         let mut render = |first, events| {
             app.actions.clear();
@@ -1113,7 +1114,7 @@ mod tests {
         use egui::accesskit::{Action as AccessibleAction, Role};
         let (ctx, mut app) = accessible_app("scroll");
         let item = app.queue.get().unwrap().queue[0].clone();
-        let context = crate::model::RowContext::Uris(vec![item.uri().to_string(); 20]);
+        let context = crate::model::RowContext::Uris(Arc::from(vec![item.uri().to_string(); 20]));
         let label = format!("Play {}, {}", item.name(), item.subtitle());
         let mut reached_last = false;
         let mut render = |events| {
@@ -1184,7 +1185,7 @@ mod tests {
         let (ctx, mut app) = accessible_app("queued-copy");
         let item = app.queue.get().unwrap().currently_playing.clone().unwrap();
         let contexts = [
-            RowContext::Uris(vec![item.uri().to_string()]),
+            RowContext::Uris(Arc::from([item.uri().to_string()])),
             RowContext::Queue,
         ];
         let label = format!("Play {}, {}", item.name(), item.subtitle());

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -607,6 +607,17 @@ pub fn apply_flags(app: &mut App, page: Option<&str>, show: Option<&str>) {
     for surface in show.unwrap_or("").split(',').map(str::trim) {
         match surface {
             "queue" => app.show_queue_panel = true,
+            "playing-next" => {
+                app.show_queue_panel = true;
+                if let Loadable::Loaded(queue) = &app.queue {
+                    app.manual_queue = queue
+                        .queue
+                        .iter()
+                        .take(6)
+                        .map(|item| item.uri().to_string())
+                        .collect();
+                }
+            }
             "recents" => {
                 app.show_queue_panel = true;
                 app.queue_tab = QueueTab::Recents;

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1768,6 +1768,62 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    /// Virtual queue rows and library cards still draw a long list, and the
+    /// library still asks for the next page when the end is near.
+    #[test]
+    fn a_long_virtual_queue_and_library_still_draw() {
+        let root =
+            std::env::temp_dir().join(format!("fastpotify-virtual-long-{}", std::process::id()));
+        let dirs = AppDirs {
+            config: root.join("config"),
+            state: root.join("state"),
+            cache: root.join("cache"),
+        };
+        let ctx = egui::Context::default();
+        let waker = crate::backend::Waker::default();
+        waker.attach(&ctx);
+        let mut app = App::new(
+            &waker,
+            dirs,
+            Settings::default(),
+            AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        );
+        app.attach(&ctx);
+        populate(&mut app);
+        if let Loadable::Loaded(queue) = &mut app.queue {
+            let seed = queue.queue.clone();
+            queue.queue = seed.iter().cloned().cycle().take(200).collect();
+            app.manual_queue = queue
+                .queue
+                .iter()
+                .take(80)
+                .map(|item| item.uri().to_string())
+                .collect();
+        }
+        app.show_queue_panel = true;
+        for _ in 0..3 {
+            frame(&ctx, &mut app);
+        }
+        app.library.albums.items = (0..80)
+            .map(|index| SavedAlbum {
+                added_at: None,
+                album: album(index % 8),
+            })
+            .collect();
+        app.library.albums.next_offset = Some(80);
+        app.library.albums.loaded_once = true;
+        app.open(Page::Albums);
+        app.actions.clear();
+        for _ in 0..3 {
+            frame(&ctx, &mut app);
+        }
+        app.backend.shutdown();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     /// A drag in flight renders, and releasing it over an owned playlist
     /// row lands in the same add-to-playlist plumbing the row menu uses.
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1189,6 +1189,62 @@ mod tests {
     }
 
     #[test]
+    fn accessible_tab_reaches_cards_beyond_the_visible_grid() {
+        use crate::ui::widgets::{card, card_row_height, virtual_wrapped_cards};
+        use egui::accesskit::{Action as AccessibleAction, Role};
+        let (ctx, mut app) = accessible_app("card-grid");
+        let mut reached_last = false;
+        let mut render = |events| {
+            let mut output = ctx.run_ui(
+                egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::vec2(400.0, 280.0),
+                    )),
+                    events,
+                    ..Default::default()
+                },
+                |ui| {
+                    egui::ScrollArea::vertical().animated(false).show(ui, |ui| {
+                        let height = card_row_height(ui);
+                        virtual_wrapped_cards(ui, 24, height, |ui, index| {
+                            if index == 23 && ui.cursor().top() < ui.clip_rect().bottom() {
+                                reached_last = true;
+                            }
+                            card(
+                                ui,
+                                &mut app,
+                                None,
+                                &format!("Album {index}"),
+                                "Artist",
+                                false,
+                                false,
+                            );
+                        });
+                    });
+                },
+            );
+            output.textures_delta.clear();
+            output.platform_output.accesskit_update.unwrap()
+        };
+        let tree = render(vec![]);
+        let first = accessible_node(&tree, "Album 0, Artist", Role::Button);
+        render(vec![accessible_action(
+            first,
+            AccessibleAction::Focus,
+            None,
+        )]);
+        for _ in 0..80 {
+            render(vec![keyboard(egui::Key::Tab, egui::Modifiers::NONE)]);
+        }
+        assert!(
+            reached_last,
+            "Tab must scroll through the virtual card grid instead of trapping focus in its first visible row"
+        );
+        app.backend.shutdown();
+    }
+
+    #[test]
     fn accessible_playing_and_queued_copies_target_their_own_context() {
         use crate::model::RowContext;
         use crate::ui::widgets::{TrackRow, track_row};

--- a/src/images.rs
+++ b/src/images.rs
@@ -16,6 +16,8 @@ use sha1::{Digest, Sha1};
 ///
 /// Size-based eviction keeps visible images stable.
 const HELD_BYTES: usize = 64 * 1024 * 1024;
+/// Rough footprint kept for textures whose JPEG bytes were already dropped.
+const TEXTURE_BYTES: usize = 32 * 1024;
 const MAX_ART_BYTES: usize = 8 * 1024 * 1024;
 
 enum Entry {
@@ -81,8 +83,8 @@ impl ArtLoader {
                     // Forget failures so a later request can retry.
                     Entry::Failed(_) => failed.push(url.clone()),
                     Entry::Ready { bytes, last_used } => {
-                        let bytes = bytes.as_ref().map_or(0, |bytes| bytes.len());
-                        held.push((url.clone(), *last_used, bytes));
+                        let size = bytes.as_ref().map_or(TEXTURE_BYTES, |bytes| bytes.len());
+                        held.push((url.clone(), *last_used, size));
                     }
                     Entry::Pending => {}
                 }
@@ -285,18 +287,29 @@ impl BytesLoader for ArtLoader {
                 last_used,
             }) => {
                 *last_used = Instant::now();
-                if let Some(bytes) = self.inner.read_disk(uri) {
-                    Ok(BytesPoll::Ready {
+                let url = uri.to_string();
+                drop(entries);
+                if let Some(bytes) = self.inner.read_disk(&url) {
+                    let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
+                    if let Some(Entry::Ready {
+                        bytes: slot,
+                        last_used,
+                    }) = entries.get_mut(&url)
+                    {
+                        *slot = Some(Arc::clone(&bytes));
+                        *last_used = Instant::now();
+                    }
+                    return Ok(BytesPoll::Ready {
                         size: None,
                         bytes: Bytes::Shared(bytes),
                         mime: None,
-                    })
-                } else {
-                    entries.insert(uri.to_string(), Entry::Pending);
-                    drop(entries);
-                    self.inner.start(ctx, uri.to_string());
-                    Ok(BytesPoll::Pending { size: None })
+                    });
                 }
+                let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
+                entries.insert(url, Entry::Pending);
+                drop(entries);
+                self.inner.start(ctx, uri.to_string());
+                Ok(BytesPoll::Pending { size: None })
             }
             Some(Entry::Pending) => Ok(BytesPoll::Pending { size: None }),
             Some(Entry::Failed(error)) => Err(LoadError::Loading(error.clone())),

--- a/src/images.rs
+++ b/src/images.rs
@@ -333,8 +333,7 @@ impl BytesLoader for ArtLoader {
             .values()
             .map(|entry| match entry {
                 Entry::Ready {
-                    bytes: Some(bytes),
-                    ..
+                    bytes: Some(bytes), ..
                 } => bytes.len(),
                 _ => 0,
             })

--- a/src/images.rs
+++ b/src/images.rs
@@ -1,8 +1,4 @@
 //! Album art: fetched once, kept on disk, decoded by egui on demand.
-//!
-//! [`ArtLoader`] handles `http(s)` URIs in egui's image pipeline. The first
-//! request starts a background download or disk-cache read. A size limit keeps
-//! long sessions from retaining unlimited textures.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -25,7 +21,7 @@ const MAX_ART_BYTES: usize = 8 * 1024 * 1024;
 enum Entry {
     Pending,
     Ready {
-        bytes: Arc<[u8]>,
+        bytes: Option<Arc<[u8]>>,
         last_used: Instant,
     },
     Failed(String),
@@ -61,6 +57,19 @@ impl ArtLoader {
         self.inner.fetch(url).await
     }
 
+    /// Marks artwork as visible so size-based eviction keeps it stable.
+    pub fn touch(&self, url: &str) {
+        if let Some(Entry::Ready { last_used, .. }) = self
+            .inner
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get_mut(url)
+        {
+            *last_used = Instant::now();
+        }
+    }
+
     /// Evicts failed entries and the oldest artwork above the memory limit.
     pub fn evict(&self, ctx: &egui::Context) {
         let letting_go: Vec<String> = {
@@ -72,7 +81,8 @@ impl ArtLoader {
                     // Forget failures so a later request can retry.
                     Entry::Failed(_) => failed.push(url.clone()),
                     Entry::Ready { bytes, last_used } => {
-                        held.push((url.clone(), *last_used, bytes.len()))
+                        let bytes = bytes.as_ref().map_or(0, |bytes| bytes.len());
+                        held.push((url.clone(), *last_used, bytes));
                     }
                     Entry::Pending => {}
                 }
@@ -82,6 +92,7 @@ impl ArtLoader {
         };
         for url in letting_go {
             ctx.forget_image(&url);
+            self.inner.drop_bytes(&url);
         }
     }
 
@@ -97,6 +108,12 @@ impl ArtLoader {
         std::fs::metadata(&path)
             .is_ok_and(|meta| meta.is_file() && meta.len() > 0)
             .then_some(path)
+    }
+
+    /// Drops held JPEG bytes once egui has made a texture. The disk cache
+    /// remains for later reloads.
+    pub fn release_bytes(&self, url: &str) {
+        self.inner.drop_bytes(url);
     }
 
     pub fn clear_disk_cache(&self) -> std::io::Result<u64> {
@@ -150,7 +167,9 @@ impl Inner {
     }
 
     async fn fetch(self: &Arc<Self>, url: &str) -> Result<Arc<[u8]>, String> {
-        if let Some(Entry::Ready { bytes, .. }) = self
+        if let Some(Entry::Ready {
+            bytes: Some(bytes), ..
+        }) = self
             .entries
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -204,7 +223,7 @@ impl Inner {
             let result = loader.fetch(&url).await;
             let entry = match result {
                 Ok(bytes) => Entry::Ready {
-                    bytes,
+                    bytes: Some(bytes),
                     last_used: Instant::now(),
                 },
                 Err(error) => Entry::Failed(error),
@@ -216,6 +235,26 @@ impl Inner {
                 .insert(url, entry);
             ctx.request_repaint();
         });
+    }
+
+    fn drop_bytes(&self, url: &str) {
+        if let Some(entry) = self
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get_mut(url)
+            && let Entry::Ready { bytes, .. } = entry
+        {
+            *bytes = None;
+        }
+    }
+
+    fn read_disk(&self, url: &str) -> Option<Arc<[u8]>> {
+        let path = self.cache_path(url);
+        std::fs::read(path)
+            .ok()
+            .filter(|bytes| !bytes.is_empty())
+            .map(Arc::from)
     }
 }
 
@@ -230,13 +269,34 @@ impl BytesLoader for ArtLoader {
         }
         let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
         match entries.get_mut(uri) {
-            Some(Entry::Ready { bytes, last_used }) => {
+            Some(Entry::Ready {
+                bytes: Some(bytes),
+                last_used,
+            }) => {
                 *last_used = Instant::now();
                 Ok(BytesPoll::Ready {
                     size: None,
                     bytes: Bytes::Shared(Arc::clone(bytes)),
                     mime: None,
                 })
+            }
+            Some(Entry::Ready {
+                bytes: None,
+                last_used,
+            }) => {
+                *last_used = Instant::now();
+                if let Some(bytes) = self.inner.read_disk(uri) {
+                    Ok(BytesPoll::Ready {
+                        size: None,
+                        bytes: Bytes::Shared(bytes),
+                        mime: None,
+                    })
+                } else {
+                    entries.insert(uri.to_string(), Entry::Pending);
+                    drop(entries);
+                    self.inner.start(ctx, uri.to_string());
+                    Ok(BytesPoll::Pending { size: None })
+                }
             }
             Some(Entry::Pending) => Ok(BytesPoll::Pending { size: None }),
             Some(Entry::Failed(error)) => Err(LoadError::Loading(error.clone())),
@@ -272,7 +332,10 @@ impl BytesLoader for ArtLoader {
             .unwrap_or_else(|p| p.into_inner())
             .values()
             .map(|entry| match entry {
-                Entry::Ready { bytes, .. } => bytes.len(),
+                Entry::Ready {
+                    bytes: Some(bytes),
+                    ..
+                } => bytes.len(),
                 _ => 0,
             })
             .sum()

--- a/src/images.rs
+++ b/src/images.rs
@@ -16,8 +16,10 @@ use sha1::{Digest, Sha1};
 ///
 /// Size-based eviction keeps visible images stable.
 const HELD_BYTES: usize = 64 * 1024 * 1024;
-/// Rough footprint kept for textures whose JPEG bytes were already dropped.
-const TEXTURE_BYTES: usize = 32 * 1024;
+/// After JPEG bytes are dropped, eviction still needs a size. Spotify list
+/// covers are typically 300×300; a GPU texture is RGBA, so 256×256×4 = 256 KiB
+/// is a lower-bound stand-in. Counting them as 0 would stop eviction.
+const TEXTURE_BYTES: usize = 256 * 256 * 4;
 const MAX_ART_BYTES: usize = 8 * 1024 * 1024;
 
 enum Entry {
@@ -250,14 +252,6 @@ impl Inner {
             *bytes = None;
         }
     }
-
-    fn read_disk(&self, url: &str) -> Option<Arc<[u8]>> {
-        let path = self.cache_path(url);
-        std::fs::read(path)
-            .ok()
-            .filter(|bytes| !bytes.is_empty())
-            .map(Arc::from)
-    }
 }
 
 impl BytesLoader for ArtLoader {
@@ -287,26 +281,7 @@ impl BytesLoader for ArtLoader {
                 last_used,
             }) => {
                 *last_used = Instant::now();
-                let url = uri.to_string();
-                drop(entries);
-                if let Some(bytes) = self.inner.read_disk(&url) {
-                    let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
-                    if let Some(Entry::Ready {
-                        bytes: slot,
-                        last_used,
-                    }) = entries.get_mut(&url)
-                    {
-                        *slot = Some(Arc::clone(&bytes));
-                        *last_used = Instant::now();
-                    }
-                    return Ok(BytesPoll::Ready {
-                        size: None,
-                        bytes: Bytes::Shared(bytes),
-                        mime: None,
-                    });
-                }
-                let mut entries = self.inner.entries.lock().unwrap_or_else(|p| p.into_inner());
-                entries.insert(url, Entry::Pending);
+                entries.insert(uri.to_string(), Entry::Pending);
                 drop(entries);
                 self.inner.start(ctx, uri.to_string());
                 Ok(BytesPoll::Pending { size: None })
@@ -390,6 +365,7 @@ pub fn accent_color(bytes: &[u8]) -> Option<[u8; 3]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     /// The media controls ask for a file rather than a URL, and have to be
     /// told "not yet" rather than handed a path to nothing: macOS loads cover
@@ -496,5 +472,76 @@ mod tests {
     #[test]
     fn nothing_held_lets_nothing_go() {
         assert!(over_budget(Vec::new(), 0).is_empty());
+    }
+
+    #[test]
+    fn texture_only_entries_still_count_toward_the_budget() {
+        assert_eq!(TEXTURE_BYTES, 256 * 256 * 4);
+        let many = (0..300)
+            .map(|i| {
+                (
+                    format!("https://i.scdn.co/image/{i}"),
+                    Instant::now() - Duration::from_secs(i),
+                    TEXTURE_BYTES,
+                )
+            })
+            .collect();
+        let dropped = over_budget(many, HELD_BYTES);
+        assert!(
+            !dropped.is_empty(),
+            "256 KiB stand-in must still evict once the 64 MiB budget is full"
+        );
+    }
+
+    #[test]
+    fn releasing_bytes_reloads_from_disk_off_the_ui_thread() {
+        use egui::load::BytesLoader;
+        use std::time::Duration as StdDuration;
+
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-art-reload-{}-{}",
+            std::process::id(),
+            Instant::now().elapsed().as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("a runtime for disk reload");
+        let loader = ArtLoader::new(
+            reqwest::Client::new(),
+            runtime.handle().clone(),
+            dir.clone(),
+        );
+        let url = "https://i.scdn.co/image/reload";
+        let path = loader.inner.cache_path(url);
+        std::fs::create_dir_all(path.parent().expect("cache dir")).expect("cache dir");
+        std::fs::write(&path, b"\xff\xd8\xff jpeg-ish").expect("cached jpeg");
+        loader.inner.entries.lock().expect("lock").insert(
+            url.to_string(),
+            Entry::Ready {
+                bytes: None,
+                last_used: Instant::now(),
+            },
+        );
+        let ctx = egui::Context::default();
+        let first = loader.load(&ctx, url).expect("load");
+        assert!(
+            matches!(first, BytesPoll::Pending { .. }),
+            "disk reload must not block the UI thread"
+        );
+        let deadline = Instant::now() + StdDuration::from_secs(2);
+        loop {
+            std::thread::sleep(StdDuration::from_millis(20));
+            match loader.load(&ctx, url) {
+                Ok(BytesPoll::Ready { .. }) => break,
+                Ok(BytesPoll::Pending { .. }) if Instant::now() < deadline => continue,
+                _ => panic!("reload did not finish"),
+            }
+        }
+        loader.forget_all();
+        assert!(loader.inner.entries.lock().expect("lock").is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/images.rs
+++ b/src/images.rs
@@ -16,17 +16,20 @@ use sha1::{Digest, Sha1};
 ///
 /// Size-based eviction keeps visible images stable.
 const HELD_BYTES: usize = 64 * 1024 * 1024;
-/// After JPEG bytes are dropped, eviction still needs a size. Spotify list
-/// covers are typically 300×300; a GPU texture is RGBA, so 256×256×4 = 256 KiB
-/// is a lower-bound stand-in. Counting them as 0 would stop eviction.
-const TEXTURE_BYTES: usize = 256 * 256 * 4;
 const MAX_ART_BYTES: usize = 8 * 1024 * 1024;
+
+/// Decoded ColorImage plus the GPU texture, both RGBA.
+fn decoded_and_texture_bytes(width: usize, height: usize) -> usize {
+    2 * width.saturating_mul(height).saturating_mul(4)
+}
 
 enum Entry {
     Pending,
     Ready {
         bytes: Option<Arc<[u8]>>,
         last_used: Instant,
+        /// JPEG bytes still held, plus decoded image and texture once painted.
+        retained: usize,
     },
     Failed(String),
 }
@@ -84,9 +87,12 @@ impl ArtLoader {
                 match entry {
                     // Forget failures so a later request can retry.
                     Entry::Failed(_) => failed.push(url.clone()),
-                    Entry::Ready { bytes, last_used } => {
-                        let size = bytes.as_ref().map_or(TEXTURE_BYTES, |bytes| bytes.len());
-                        held.push((url.clone(), *last_used, size));
+                    Entry::Ready {
+                        last_used,
+                        retained,
+                        ..
+                    } => {
+                        held.push((url.clone(), *last_used, *retained));
                     }
                     Entry::Pending => {}
                 }
@@ -96,7 +102,7 @@ impl ArtLoader {
         };
         for url in letting_go {
             ctx.forget_image(&url);
-            self.inner.drop_bytes(&url);
+            self.forget(&url);
         }
     }
 
@@ -118,6 +124,22 @@ impl ArtLoader {
     /// remains for later reloads.
     pub fn release_bytes(&self, url: &str) {
         self.inner.drop_bytes(url);
+    }
+
+    /// Record decoded image + texture size after egui has uploaded the cover.
+    pub fn note_decoded(&self, url: &str, width: usize, height: usize) {
+        if let Some(Entry::Ready {
+            bytes, retained, ..
+        }) = self
+            .inner
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get_mut(url)
+        {
+            let jpeg = bytes.as_ref().map(|bytes| bytes.len()).unwrap_or(0);
+            *retained = jpeg + decoded_and_texture_bytes(width, height);
+        }
     }
 
     pub fn clear_disk_cache(&self) -> std::io::Result<u64> {
@@ -227,6 +249,7 @@ impl Inner {
             let result = loader.fetch(&url).await;
             let entry = match result {
                 Ok(bytes) => Entry::Ready {
+                    retained: bytes.len(),
                     bytes: Some(bytes),
                     last_used: Instant::now(),
                 },
@@ -242,14 +265,16 @@ impl Inner {
     }
 
     fn drop_bytes(&self, url: &str) {
-        if let Some(entry) = self
+        if let Some(Entry::Ready {
+            bytes, retained, ..
+        }) = self
             .entries
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .get_mut(url)
-            && let Entry::Ready { bytes, .. } = entry
+            && let Some(held) = bytes.take()
         {
-            *bytes = None;
+            *retained = retained.saturating_sub(held.len());
         }
     }
 }
@@ -268,6 +293,7 @@ impl BytesLoader for ArtLoader {
             Some(Entry::Ready {
                 bytes: Some(bytes),
                 last_used,
+                ..
             }) => {
                 *last_used = Instant::now();
                 Ok(BytesPoll::Ready {
@@ -279,6 +305,7 @@ impl BytesLoader for ArtLoader {
             Some(Entry::Ready {
                 bytes: None,
                 last_used,
+                ..
             }) => {
                 *last_used = Instant::now();
                 entries.insert(uri.to_string(), Entry::Pending);
@@ -474,23 +501,92 @@ mod tests {
         assert!(over_budget(Vec::new(), 0).is_empty());
     }
 
-    #[test]
-    fn texture_only_entries_still_count_toward_the_budget() {
-        assert_eq!(TEXTURE_BYTES, 256 * 256 * 4);
-        let many = (0..300)
-            .map(|i| {
-                (
-                    format!("https://i.scdn.co/image/{i}"),
-                    Instant::now() - Duration::from_secs(i),
-                    TEXTURE_BYTES,
-                )
+    fn retained_total(loader: &ArtLoader) -> usize {
+        loader
+            .inner
+            .entries
+            .lock()
+            .expect("lock")
+            .values()
+            .map(|entry| match entry {
+                Entry::Ready { retained, .. } => *retained,
+                _ => 0,
             })
-            .collect();
-        let dropped = over_budget(many, HELD_BYTES);
-        assert!(
-            !dropped.is_empty(),
-            "256 KiB stand-in must still evict once the 64 MiB budget is full"
+            .sum()
+    }
+
+    #[test]
+    fn large_covers_evict_using_decoded_and_texture_sizes() {
+        let one = decoded_and_texture_bytes(640, 640);
+        assert_eq!(one, 2 * 640 * 640 * 4);
+        let jpeg = 50_000usize;
+        let dir = std::env::temp_dir().join(format!(
+            "fastpotify-art-budget-{}-{}",
+            std::process::id(),
+            Instant::now().elapsed().as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("a runtime for eviction");
+        let loader = ArtLoader::new(
+            reqwest::Client::new(),
+            runtime.handle().clone(),
+            dir.clone(),
         );
+        let now = Instant::now();
+        for i in 0..40 {
+            let url = format!("https://i.scdn.co/image/{i}");
+            loader.inner.entries.lock().expect("lock").insert(
+                url,
+                Entry::Ready {
+                    bytes: Some(Arc::from(vec![0u8; jpeg])),
+                    last_used: now - Duration::from_secs(40 - i),
+                    retained: jpeg,
+                },
+            );
+        }
+        let jpeg_total = retained_total(&loader);
+        assert!(
+            jpeg_total < HELD_BYTES,
+            "JPEG-only covers must still fit the budget: {jpeg_total}"
+        );
+        for i in 0..40 {
+            let url = format!("https://i.scdn.co/image/{i}");
+            loader.release_bytes(&url);
+            loader.note_decoded(&url, 640, 640);
+        }
+        let before = retained_total(&loader);
+        assert_eq!(before, 40 * one);
+        assert!(
+            before > HELD_BYTES,
+            "decoded 640×640 covers plus textures must exceed 64 MiB: {before}"
+        );
+        let ctx = egui::Context::default();
+        loader.evict(&ctx);
+        let after = retained_total(&loader);
+        assert!(
+            after <= HELD_BYTES,
+            "eviction must bring retained decoded+texture bytes under budget: after={after}"
+        );
+        assert!(
+            after < before,
+            "a long scroll of large covers must free memory: before={before} after={after}"
+        );
+        let entries = loader.inner.entries.lock().expect("lock");
+        assert!(
+            !entries.contains_key("https://i.scdn.co/image/0"),
+            "the oldest scrolled-away cover must go first"
+        );
+        assert!(
+            entries.contains_key("https://i.scdn.co/image/39"),
+            "the cover just scrolled into view must stay"
+        );
+        drop(entries);
+        loader.forget_all();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -523,6 +619,7 @@ mod tests {
             Entry::Ready {
                 bytes: None,
                 last_used: Instant::now(),
+                retained: 0,
             },
         );
         let ctx = egui::Context::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,11 @@ struct Cli {
     #[cfg(feature = "demo")]
     #[arg(long, value_name = "MS", default_value_t = 6000)]
     demo_shot_delay: u64,
+
+    /// Inner window size for `--demo-shot`, as `WIDTHxHEIGHT`.
+    #[cfg(feature = "demo")]
+    #[arg(long, value_name = "WIDTHxHEIGHT", value_parser = parse_demo_size)]
+    demo_size: Option<[f32; 2]>,
 }
 
 /// Remote control of the running instance, for Raycast scripts, launchers,
@@ -388,6 +393,8 @@ fn main() -> eframe::Result<()> {
         due: std::time::Instant::now() + std::time::Duration::from_millis(cli.demo_shot_delay),
         asked: false,
     });
+    #[cfg(feature = "demo")]
+    let demo_inner = cli.demo_size;
     let slot = std::sync::Arc::new(std::sync::Mutex::new(Some(app)));
     loop {
         let creator_slot = std::sync::Arc::clone(&slot);
@@ -399,9 +406,9 @@ fn main() -> eframe::Result<()> {
             MiniWindow::wanted(guard.as_ref().expect("application state present"))
         };
         #[cfg(feature = "demo")]
-        let options = native_options(shot.is_some() && mini.is_none(), mini);
+        let options = native_options(shot.is_some() && mini.is_none(), mini, demo_inner);
         #[cfg(not(feature = "demo"))]
-        let options = native_options(false, mini);
+        let options = native_options(false, mini, None);
         eframe::run_native(
             "Fastpotify",
             options,
@@ -549,7 +556,30 @@ const fn main_window_decorated(on_windows: bool) -> bool {
     !on_windows
 }
 
-fn native_options(fullscreen: bool, mini: Option<MiniWindow>) -> eframe::NativeOptions {
+#[cfg(any(test, feature = "demo"))]
+fn parse_demo_size(spec: &str) -> Result<[f32; 2], String> {
+    let (width, height) = spec
+        .split_once(['x', 'X'])
+        .ok_or_else(|| format!("expected WIDTHxHEIGHT, got {spec}"))?;
+    let width: f32 = width
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid width in {spec}"))?;
+    let height: f32 = height
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid height in {spec}"))?;
+    if width < 1.0 || height < 1.0 {
+        return Err(format!("size must be at least 1x1, got {spec}"));
+    }
+    Ok([width, height])
+}
+
+fn native_options(
+    fullscreen: bool,
+    mini: Option<MiniWindow>,
+    inner_size: Option<[f32; 2]>,
+) -> eframe::NativeOptions {
     let icon = if cfg!(target_os = "macos") {
         // macOS takes the dock icon from the bundle's .icns, which is the
         // 1024px drawing with the platform's rounding. Setting a window
@@ -593,8 +623,8 @@ fn native_options(fullscreen: bool, mini: Option<MiniWindow>) -> eframe::NativeO
             // Windows has no equivalent to macOS's floating traffic lights.
             // Removing its decorations lets the app surface fill the window.
             .with_decorations(main_window_decorated(cfg!(windows)))
-            .with_inner_size([1240.0, 800.0])
-            .with_min_inner_size([760.0, 520.0])
+            .with_inner_size(inner_size.unwrap_or([1240.0, 800.0]))
+            .with_min_inner_size(inner_size.unwrap_or([760.0, 520.0]))
             .with_fullscreen(fullscreen),
     };
     eframe::NativeOptions {
@@ -616,11 +646,17 @@ mod native_window_tests {
 
     #[test]
     fn main_window_uses_the_platform_decoration_policy() {
-        let options = native_options(false, None);
+        let options = native_options(false, None, None);
         assert_eq!(options.viewport.decorations, Some(!cfg!(windows)));
         assert_eq!(options.viewport.fullsize_content_view, Some(true));
         assert_eq!(options.viewport.titlebar_shown, Some(false));
         assert_eq!(options.viewport.title_shown, Some(false));
+    }
+
+    #[test]
+    fn demo_size_parses_width_by_height() {
+        assert_eq!(parse_demo_size("760x800").unwrap(), [760.0, 800.0]);
+        assert!(parse_demo_size("wide").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,17 +38,16 @@ struct Cli {
     #[arg(long)]
     demo_page: Option<String>,
 
-    /// Extra demo surfaces: a comma-separated list of `queue`, `devices`,
-    /// `shortcuts`, `create`, `light`, `focus`.
+    /// Extra demo surfaces: a comma-separated list of `queue`, `playing-next`,
+    /// `devices`, `shortcuts`, `create`, `light`, `focus`.
     #[cfg(feature = "demo")]
     #[arg(long)]
     demo_show: Option<String>,
 
     /// Write a PNG of the demo window to this path and exit. Implies
-    /// `--demo`. The shot is the window's own frame buffer, so it is however
-    /// large the window is: full screen where that request is honoured, and
-    /// the size of the tile under a tiling window manager, which decides for
-    /// itself.
+    /// `--demo`. Without `--demo-size`, the shot is the window's own frame
+    /// buffer: full screen where that request is honoured, and the size of
+    /// the tile under a tiling window manager, which decides for itself.
     #[cfg(feature = "demo")]
     #[arg(long, value_name = "PATH")]
     demo_shot: Option<std::path::PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,11 @@ fn main() -> eframe::Result<()> {
             MiniWindow::wanted(guard.as_ref().expect("application state present"))
         };
         #[cfg(feature = "demo")]
-        let options = native_options(shot.is_some() && mini.is_none(), mini, demo_inner);
+        let options = native_options(
+            shot.is_some() && mini.is_none() && demo_inner.is_none(),
+            mini,
+            demo_inner,
+        );
         #[cfg(not(feature = "demo"))]
         let options = native_options(false, mini, None);
         eframe::run_native(
@@ -657,6 +661,12 @@ mod native_window_tests {
     fn demo_size_parses_width_by_height() {
         assert_eq!(parse_demo_size("760x800").unwrap(), [760.0, 800.0]);
         assert!(parse_demo_size("wide").is_err());
+        let options = native_options(false, None, Some([760.0, 800.0]));
+        assert_eq!(options.viewport.inner_size, Some(egui::vec2(760.0, 800.0)));
+        assert_eq!(
+            options.viewport.min_inner_size,
+            Some(egui::vec2(760.0, 800.0))
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,20 +615,27 @@ fn native_options(
                 None => viewport,
             }
         }
-        None => viewport
-            // macOS: no title bar strip above the app. The content runs to
-            // the top edge and the traffic lights float over it, the way
-            // every other music player on the platform looks; the interface
-            // leaves room for them with `theme::titlebar_inset`.
-            .with_fullsize_content_view(true)
-            .with_titlebar_shown(false)
-            .with_title_shown(false)
-            // Windows has no equivalent to macOS's floating traffic lights.
-            // Removing its decorations lets the app surface fill the window.
-            .with_decorations(main_window_decorated(cfg!(windows)))
-            .with_inner_size(inner_size.unwrap_or([1240.0, 800.0]))
-            .with_min_inner_size(inner_size.unwrap_or([760.0, 520.0]))
-            .with_fullscreen(fullscreen),
+        None => {
+            let size = inner_size.unwrap_or([1240.0, 800.0]);
+            let mut viewport = viewport
+                // macOS: no title bar strip above the app. The content runs to
+                // the top edge and the traffic lights float over it, the way
+                // every other music player on the platform looks; the interface
+                // leaves room for them with `theme::titlebar_inset`.
+                .with_fullsize_content_view(true)
+                .with_titlebar_shown(false)
+                .with_title_shown(false)
+                // Windows has no equivalent to macOS's floating traffic lights.
+                // Removing its decorations lets the app surface fill the window.
+                .with_decorations(main_window_decorated(cfg!(windows)))
+                .with_inner_size(size)
+                .with_min_inner_size(inner_size.unwrap_or([760.0, 520.0]))
+                .with_fullscreen(fullscreen);
+            if inner_size.is_some() {
+                viewport = viewport.with_max_inner_size(size);
+            }
+            viewport
+        }
     };
     eframe::NativeOptions {
         viewport,
@@ -664,6 +671,10 @@ mod native_window_tests {
         assert_eq!(options.viewport.inner_size, Some(egui::vec2(760.0, 800.0)));
         assert_eq!(
             options.viewport.min_inner_size,
+            Some(egui::vec2(760.0, 800.0))
+        );
+        assert_eq!(
+            options.viewport.max_inner_size,
             Some(egui::vec2(760.0, 800.0))
         );
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,7 @@
 //! UI state, loaded data, and pending actions.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::api::models::*;
@@ -529,12 +530,12 @@ pub enum RowContext {
         editable_playlist: Option<(String, Option<String>)>,
     },
     /// A loose list of tracks, played as a queue of URIs.
-    Uris(Vec<String>),
+    Uris(Arc<[String]>),
     /// A Next up row. Playing it consumes that row and all rows before it.
     Queue,
     /// A sorted or filtered context view that plays the displayed rows.
     View {
-        uris: Vec<String>,
+        uris: Arc<[String]>,
         context_uri: String,
     },
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,37 @@ use std::time::Instant;
 
 use crate::api::models::*;
 
+/// One table row: the playable, when it was added, who added it.
+pub type TableItem = (PlayableItem, Option<String>, Option<String>);
+
+/// Cached track-table rows for one page.
+///
+/// Lives on the app, not in egui temp data, so it dies with page eviction,
+/// sign-out, and `reset_data`. A generation token stops a recreated page
+/// from reusing a stale copy that still has the old revision number.
+pub struct TableRowsCache {
+    pub generation: u64,
+    pub items_revision: u64,
+    pub user_names_revision: u64,
+    pub items: Arc<[TableItem]>,
+}
+
+impl TableRowsCache {
+    /// Heap-ish retained size: struct slots plus the URI/name strings we own.
+    pub fn retained_bytes(&self) -> usize {
+        self.items
+            .iter()
+            .map(|(item, added, by)| {
+                std::mem::size_of_val(item)
+                    + item.uri().len()
+                    + item.name().len()
+                    + added.as_ref().map(String::len).unwrap_or(0)
+                    + by.as_ref().map(String::len).unwrap_or(0)
+            })
+            .sum()
+    }
+}
+
 /// Every screen the central panel can show.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Page {
@@ -450,6 +481,7 @@ pub struct PlaylistCache {
 
 #[derive(Default)]
 pub struct AlbumPage {
+    pub generation: u64,
     pub album: Loadable<Album>,
     pub tracks: PagedList<Track>,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,19 +22,73 @@ pub struct TableRowsCache {
 }
 
 impl TableRowsCache {
-    /// Heap-ish retained size: struct slots plus the URI/name strings we own.
+    /// Retained heap for this cache: nested track/episode metadata, not just
+    /// the top-level URI and title.
     pub fn retained_bytes(&self) -> usize {
-        self.items
-            .iter()
-            .map(|(item, added, by)| {
-                std::mem::size_of_val(item)
-                    + item.uri().len()
-                    + item.name().len()
-                    + added.as_ref().map(String::len).unwrap_or(0)
-                    + by.as_ref().map(String::len).unwrap_or(0)
-            })
-            .sum()
+        std::mem::size_of::<Self>()
+            + self
+                .items
+                .iter()
+                .map(|(item, added, by)| {
+                    playable_retained_bytes(item)
+                        + added.as_ref().map(String::len).unwrap_or(0)
+                        + by.as_ref().map(String::len).unwrap_or(0)
+                })
+                .sum::<usize>()
     }
+}
+
+fn playable_retained_bytes(item: &PlayableItem) -> usize {
+    match item {
+        PlayableItem::Track(track) => track_retained_bytes(track),
+        PlayableItem::Episode(episode) => episode_retained_bytes(episode),
+    }
+}
+
+fn artist_ref_retained_bytes(artist: &ArtistRef) -> usize {
+    artist.name.len()
+        + artist.id.as_ref().map(String::len).unwrap_or(0)
+        + artist.uri.as_ref().map(String::len).unwrap_or(0)
+}
+
+fn image_retained_bytes(images: &[Image]) -> usize {
+    images.iter().map(|image| image.url.len()).sum()
+}
+
+fn album_retained_bytes(album: &Album) -> usize {
+    album.id.len()
+        + album.name.len()
+        + album.uri.len()
+        + album.album_type.as_ref().map(String::len).unwrap_or(0)
+        + album.release_date.as_ref().map(String::len).unwrap_or(0)
+        + image_retained_bytes(&album.images)
+        + album
+            .artists
+            .iter()
+            .map(artist_ref_retained_bytes)
+            .sum::<usize>()
+}
+
+fn track_retained_bytes(track: &Track) -> usize {
+    std::mem::size_of::<Track>()
+        + track.name.len()
+        + track.uri.len()
+        + track.id.as_ref().map(String::len).unwrap_or(0)
+        + track
+            .artists
+            .iter()
+            .map(artist_ref_retained_bytes)
+            .sum::<usize>()
+        + track.album.as_ref().map(album_retained_bytes).unwrap_or(0)
+}
+
+fn episode_retained_bytes(episode: &Episode) -> usize {
+    std::mem::size_of::<Episode>()
+        + episode.id.len()
+        + episode.name.len()
+        + episode.uri.len()
+        + episode.description.len()
+        + image_retained_bytes(&episode.images)
 }
 
 /// Every screen the central panel can show.

--- a/src/ui/artist.rs
+++ b/src/ui/artist.rs
@@ -1,5 +1,7 @@
 //! The artist page.
 
+use std::sync::Arc;
+
 use crate::api::models::{PlayableItem, pick_image};
 use crate::app::App;
 use crate::model::{Action, DiscographyFilter, Loadable, Page, RowContext};
@@ -102,8 +104,12 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, id: &str) {
             ui.add_space(4.0);
             match &page.top_tracks {
                 Loadable::Loaded(tracks) if !tracks.is_empty() => {
-                    let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
-                    let context = RowContext::Uris(uris);
+                    let uris: Arc<[String]> = tracks
+                        .iter()
+                        .map(|track| track.uri.clone())
+                        .collect::<Vec<_>>()
+                        .into();
+                    let context = RowContext::Uris(Arc::clone(&uris));
                     let items: Vec<PlayableItem> =
                         tracks.iter().cloned().map(PlayableItem::Track).collect();
                     let limit = if page.show_all_top { items.len() } else { 5 };

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -48,6 +48,7 @@ pub fn hero(app: &mut App, ui: &mut egui::Ui, hero: Hero<'_>) {
                 rect,
                 radius,
                 if hero.round { Icon::User } else { Icon::Music },
+                Some(app.backend.art()),
             );
         }
         ui.vertical(|ui| {

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -324,12 +324,10 @@ pub fn cached_table_items(
 ) -> Arc<[TableItem]> {
     let cache_id = egui::Id::new("table-items-cache").with(page);
     let cached = ui.data(|d| d.get_temp::<Arc<[TableItem]>>(cache_id));
-    let valid = cached.as_ref().is_some_and(|items| {
+    let valid = cached.as_ref().is_some_and(|_items| {
         ui.data(|d| {
             d.get_temp::<(u64, u64)>(cache_id.with("rev"))
-                .is_some_and(|(rev, names)| {
-                    rev == items_revision && names == user_names_revision
-                })
+                .is_some_and(|(rev, names)| rev == items_revision && names == user_names_revision)
         })
     });
     if let Some(items) = cached.filter(|_| valid) {
@@ -338,10 +336,7 @@ pub fn cached_table_items(
         let items: Arc<[TableItem]> = build().into();
         ui.data_mut(|d| {
             d.insert_temp(cache_id, Arc::clone(&items));
-            d.insert_temp(
-                cache_id.with("rev"),
-                (items_revision, user_names_revision),
-            );
+            d.insert_temp(cache_id.with("rev"), (items_revision, user_names_revision));
         });
         items
     }
@@ -887,10 +882,7 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.items.revision,
             );
-            let view_play = table_view
-                .view_uris
-                .as_ref()
-                .map(|uris| Arc::clone(uris));
+            let view_play = table_view.view_uris.as_ref().map(Arc::clone);
             let playlist_clone = playlist.clone();
             actions_row(
                 app,
@@ -1004,10 +996,7 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.tracks.revision,
             );
-            let album_view = table_view
-                .view_uris
-                .as_ref()
-                .map(|uris| Arc::clone(uris));
+            let album_view = table_view.view_uris.as_ref().map(Arc::clone);
             actions_row(
                 app,
                 ui,
@@ -1206,10 +1195,7 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         sort,
         app.library.liked.revision,
     );
-    let liked_view = table_view
-        .view_uris
-        .as_ref()
-        .map(|uris| Arc::clone(uris));
+    let liked_view = table_view.view_uris.as_ref().map(Arc::clone);
     actions_row(
         app,
         ui,

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -7,7 +7,8 @@ use egui::{Align, Layout, Rect, Sense, Vec2, pos2, vec2};
 use crate::api::models::{Album, PlayableItem, Playlist, pick_image};
 use crate::app::App;
 use crate::model::{
-    Action, Dialog, DragTrack, Loadable, Page, PagedList, RowContext, SortColumn, TableSort,
+    Action, Dialog, DragTrack, Loadable, Page, PagedList, RowContext, SortColumn, TableItem,
+    TableRowsCache, TableSort,
 };
 use crate::theme::{self, Icon, Palette};
 use crate::util;
@@ -282,9 +283,6 @@ fn playlist_position_jump(
     ui.add_space(8.0);
 }
 
-/// One table row's data: the item, when it was added, who added it.
-pub type TableItem = (PlayableItem, Option<String>, Option<String>);
-
 /// A track table with virtualised rows and paging.
 pub struct Table<'a> {
     pub items: &'a [TableItem],
@@ -313,33 +311,71 @@ pub struct TableCache {
     pub view_uris: Option<Arc<[String]>>,
 }
 
-/// Cached table rows for one page. Rebuilt only when the source list or
-/// contributor names change, not every frame.
-pub fn cached_table_items(
-    ui: &mut egui::Ui,
+pub fn table_items_hit(
+    app: &App,
     page: &Page,
+    generation: u64,
+    items_revision: u64,
+    user_names_revision: u64,
+) -> Option<Arc<[TableItem]>> {
+    app.table_rows.get(page).and_then(|cached| {
+        (cached.generation == generation
+            && cached.items_revision == items_revision
+            && cached.user_names_revision == user_names_revision)
+            .then(|| Arc::clone(&cached.items))
+    })
+}
+
+pub fn remember_table_items(
+    app: &mut App,
+    page: Page,
+    generation: u64,
+    items_revision: u64,
+    user_names_revision: u64,
+    items: Vec<TableItem>,
+) -> Arc<[TableItem]> {
+    let items: Arc<[TableItem]> = items.into();
+    app.table_rows.insert(
+        page.clone(),
+        TableRowsCache {
+            generation,
+            items_revision,
+            user_names_revision,
+            items: Arc::clone(&items),
+        },
+    );
+    app.retain_table_rows(&page);
+    items
+}
+
+/// Cached table rows for one page. Rebuilt only when the source list,
+/// contributor names, or page generation change, not every frame.
+///
+/// The cache lives on `App`, not in egui temp data. It is dropped when the
+/// page is evicted, when the account resets, and when more than two tables
+/// would be retained. Recreated pages get a new generation, so an old
+/// revision number cannot resurrect stale rows.
+pub fn cached_table_items(
+    app: &mut App,
+    page: Page,
+    generation: u64,
     items_revision: u64,
     user_names_revision: u64,
     build: impl FnOnce() -> Vec<TableItem>,
 ) -> Arc<[TableItem]> {
-    let cache_id = egui::Id::new("table-items-cache").with(page);
-    let cached = ui.data(|d| d.get_temp::<Arc<[TableItem]>>(cache_id));
-    let valid = cached.as_ref().is_some_and(|_items| {
-        ui.data(|d| {
-            d.get_temp::<(u64, u64)>(cache_id.with("rev"))
-                .is_some_and(|(rev, names)| rev == items_revision && names == user_names_revision)
-        })
-    });
-    if let Some(items) = cached.filter(|_| valid) {
-        items
-    } else {
-        let items: Arc<[TableItem]> = build().into();
-        ui.data_mut(|d| {
-            d.insert_temp(cache_id, Arc::clone(&items));
-            d.insert_temp(cache_id.with("rev"), (items_revision, user_names_revision));
-        });
-        items
+    if let Some(items) =
+        table_items_hit(app, &page, generation, items_revision, user_names_revision)
+    {
+        return items;
     }
+    remember_table_items(
+        app,
+        page,
+        generation,
+        items_revision,
+        user_names_revision,
+        build(),
+    )
 }
 
 pub fn prepare_table_view(
@@ -740,19 +776,19 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
             return;
         }
     };
-    let items = cached_table_items(
-        ui,
-        &Page::TopSongs,
-        app.home.top_songs_generation,
-        app.user_names_revision,
-        || {
-            tracks
+    let generation = app.home.top_songs_generation;
+    let names = app.user_names_revision;
+    let items =
+        if let Some(items) = table_items_hit(app, &Page::TopSongs, generation, generation, names) {
+            items
+        } else {
+            let rows = tracks
                 .iter()
                 .cloned()
                 .map(|track| (PlayableItem::Track(track), None, None))
-                .collect()
-        },
-    );
+                .collect();
+            remember_table_items(app, Page::TopSongs, generation, generation, names, rows)
+        };
     let uris: Arc<[String]> = items
         .iter()
         .map(|(item, _, _)| item.uri().to_string())
@@ -788,20 +824,22 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let user_id = app.user_id().unwrap_or("").to_string();
     match &page.playlist {
         Loadable::Loaded(playlist) => {
-            let items = cached_table_items(
-                ui,
-                &Page::Playlist(id.to_string()),
-                page.items.revision,
-                app.user_names_revision,
-                || {
-                    items_of(
-                        &page.items,
-                        playlist.owner.id.as_deref(),
-                        playlist.owner_name(),
-                        &app.user_names,
-                    )
-                },
-            );
+            let generation = page.generation;
+            let revision = page.items.revision;
+            let names = app.user_names_revision;
+            let key = Page::Playlist(id.to_string());
+            let items = if let Some(items) = table_items_hit(app, &key, generation, revision, names)
+            {
+                items
+            } else {
+                let rows = items_of(
+                    &page.items,
+                    playlist.owner.id.as_deref(),
+                    playlist.owner_name(),
+                    &app.user_names,
+                );
+                remember_table_items(app, key, generation, revision, names, rows)
+            };
             let count = playlist.track_total().max(items.len() as u32);
             // Spotify's collaborative flag covers secret collaborations; a
             // playlist made together today is recognised by who added songs.
@@ -960,31 +998,34 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
     match &page.album {
         Loadable::Loaded(album) => {
             album_hero(app, ui, album, &page.tracks);
-            let items = cached_table_items(
-                ui,
-                &Page::Album(id.to_string()),
-                page.tracks.revision,
-                app.user_names_revision,
-                || {
-                    page.tracks
-                        .items
-                        .iter()
-                        .cloned()
-                        .map(|mut track| {
-                            if track.album.is_none() {
-                                track.album = Some(Album {
-                                    id: album.id.clone(),
-                                    name: album.name.clone(),
-                                    uri: album.uri.clone(),
-                                    images: album.images.clone(),
-                                    ..Album::default()
-                                });
-                            }
-                            (PlayableItem::Track(track), None, None)
-                        })
-                        .collect()
-                },
-            );
+            let generation = page.generation;
+            let revision = page.tracks.revision;
+            let names = app.user_names_revision;
+            let key = Page::Album(id.to_string());
+            let items = if let Some(items) = table_items_hit(app, &key, generation, revision, names)
+            {
+                items
+            } else {
+                let rows = page
+                    .tracks
+                    .items
+                    .iter()
+                    .cloned()
+                    .map(|mut track| {
+                        if track.album.is_none() {
+                            track.album = Some(Album {
+                                id: album.id.clone(),
+                                name: album.name.clone(),
+                                uri: album.uri.clone(),
+                                images: album.images.clone(),
+                                ..Album::default()
+                            });
+                        }
+                        (PlayableItem::Track(track), None, None)
+                    })
+                    .collect();
+                remember_table_items(app, key, generation, revision, names, rows)
+            };
             let saved = app.is_saved(&album.uri).unwrap_or(false);
             let sort = app.table_sorts.get(&Page::Album(id.to_string())).copied();
             let table_view = prepare_table_view(
@@ -1128,13 +1169,14 @@ fn album_hero(
 
 pub fn liked(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let items = cached_table_items(
-        ui,
-        &Page::LikedSongs,
-        app.library.liked.revision,
-        app.user_names_revision,
-        || {
-            app.library
+    let revision = app.library.liked.revision;
+    let names = app.user_names_revision;
+    let items =
+        if let Some(items) = table_items_hit(app, &Page::LikedSongs, revision, revision, names) {
+            items
+        } else {
+            let rows = app
+                .library
                 .liked
                 .items
                 .iter()
@@ -1145,9 +1187,9 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
                         None,
                     )
                 })
-                .collect()
-        },
-    );
+                .collect();
+            remember_table_items(app, Page::LikedSongs, revision, revision, names, rows)
+        };
     let total = app.library.liked.total.unwrap_or(items.len() as u32);
     let user = app
         .user
@@ -1276,6 +1318,7 @@ fn palette_of(app: &App) -> Palette {
 mod tests {
     use super::*;
     use crate::api::models::{Album, ArtistRef, Track};
+    use crate::model::PlaylistPage;
 
     fn make_test_tracks() -> Vec<TableItem> {
         let titles = [
@@ -1420,5 +1463,84 @@ mod tests {
     fn a_direct_playlist_page_keeps_spotify_row_numbers() {
         assert_eq!(absolute_row_index(6_900, 0) + 1, 6_901);
         assert_eq!(absolute_row_index(6_900, 6) + 1, 6_907);
+    }
+
+    fn test_app() -> App {
+        let root = std::env::temp_dir().join(format!(
+            "fastpotify-table-cache-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        App::new(
+            &crate::backend::Waker::default(),
+            crate::paths::AppDirs {
+                config: root.join("config"),
+                state: root.join("state"),
+                cache: root.join("cache"),
+            },
+            crate::settings::Settings::default(),
+            crate::app::AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        )
+    }
+
+    #[test]
+    fn table_row_cache_hits_until_revision_or_generation_changes() {
+        let mut app = test_app();
+        let mut builds = 0;
+        let page = Page::LikedSongs;
+        cached_table_items(&mut app, page.clone(), 1, 0, 0, || {
+            builds += 1;
+            make_test_tracks()
+        });
+        cached_table_items(&mut app, page.clone(), 1, 0, 0, || {
+            builds += 1;
+            panic!("cache hit rebuilt the table");
+        });
+        assert_eq!(builds, 1);
+        cached_table_items(&mut app, page.clone(), 1, 1, 0, || {
+            builds += 1;
+            make_test_tracks()
+        });
+        assert_eq!(builds, 2, "revision change must rebuild");
+        cached_table_items(&mut app, page, 2, 1, 0, || {
+            builds += 1;
+            make_test_tracks()
+        });
+        assert_eq!(builds, 3, "generation change must rebuild");
+    }
+
+    #[test]
+    fn table_row_cache_dies_when_account_data_resets() {
+        let mut app = test_app();
+        cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, make_test_tracks);
+        assert!(!app.table_rows.is_empty());
+        let before = app.table_rows_retained_bytes();
+        assert!(before > 0, "cached rows should retain heap");
+        app.table_rows.clear();
+        assert_eq!(app.table_rows_retained_bytes(), 0);
+    }
+
+    #[test]
+    fn table_row_cache_keeps_at_most_two_pages() {
+        let mut app = test_app();
+        for i in 0..5 {
+            let page = Page::Playlist(format!("pl{i}"));
+            app.playlist_pages
+                .insert(format!("pl{i}"), PlaylistPage::default());
+            app.history.push(page.clone());
+            app.history_index = app.history.len() - 1;
+            cached_table_items(&mut app, page, 1, 0, 0, make_test_tracks);
+        }
+        assert_eq!(app.table_rows.len(), 2);
+        assert!(
+            app.table_rows.contains_key(&Page::Playlist("pl4".into())),
+            "the open page stays"
+        );
     }
 }

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -109,7 +109,7 @@ pub struct Actions<'a> {
     pub play_uri: Option<String>,
     /// A sorted or filtered view: the exact list on screen, which the big
     /// button plays instead of the context's own order.
-    pub view: Option<Vec<String>>,
+    pub view: Option<Arc<[String]>>,
     pub saved: Option<(String, bool)>,
     pub saved_icons: (Icon, Icon),
     pub saved_tooltips: (&'a str, &'a str),
@@ -154,7 +154,7 @@ pub fn actions_row(
                 } else if let Some(uris) = actions.view.clone() {
                     app.actions.push(Action::PlayFromRow {
                         context: RowContext::View {
-                            uris,
+                            uris: Arc::clone(&uris),
                             context_uri: uri.clone(),
                         },
                         uri: String::new(),
@@ -313,6 +313,40 @@ pub struct TableCache {
     pub view_uris: Option<Arc<[String]>>,
 }
 
+/// Cached table rows for one page. Rebuilt only when the source list or
+/// contributor names change, not every frame.
+pub fn cached_table_items(
+    ui: &mut egui::Ui,
+    page: &Page,
+    items_revision: u64,
+    user_names_revision: u64,
+    build: impl FnOnce() -> Vec<TableItem>,
+) -> Arc<[TableItem]> {
+    let cache_id = egui::Id::new("table-items-cache").with(page);
+    let cached = ui.data(|d| d.get_temp::<Arc<[TableItem]>>(cache_id));
+    let valid = cached.as_ref().is_some_and(|items| {
+        ui.data(|d| {
+            d.get_temp::<(u64, u64)>(cache_id.with("rev"))
+                .is_some_and(|(rev, names)| {
+                    rev == items_revision && names == user_names_revision
+                })
+        })
+    });
+    if let Some(items) = cached.filter(|_| valid) {
+        items
+    } else {
+        let items: Arc<[TableItem]> = build().into();
+        ui.data_mut(|d| {
+            d.insert_temp(cache_id, Arc::clone(&items));
+            d.insert_temp(
+                cache_id.with("rev"),
+                (items_revision, user_names_revision),
+            );
+        });
+        items
+    }
+}
+
 pub fn prepare_table_view(
     ui: &mut egui::Ui,
     app: &App,
@@ -423,10 +457,10 @@ pub fn table(app: &mut App, ui: &mut egui::Ui, table: Table<'_>) {
     let context = if let Some(uris) = &entry.view_uris {
         match &table.context {
             RowContext::Context { uri, .. } => RowContext::View {
-                uris: uris.to_vec(),
+                uris: Arc::clone(uris),
                 context_uri: uri.clone(),
             },
-            _ => RowContext::Uris(uris.to_vec()),
+            _ => RowContext::Uris(Arc::clone(uris)),
         }
     } else {
         table.context.clone()
@@ -700,7 +734,7 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
     ui.add_space(18.0);
 
     let tracks = match &app.home.top_songs {
-        Loadable::Loaded(tracks) => tracks.clone(),
+        Loadable::Loaded(tracks) => tracks,
         Loadable::Loading | Loadable::NotLoaded => {
             widgets::loading_row(ui, &palette);
             return;
@@ -711,19 +745,31 @@ pub fn top_songs(app: &mut App, ui: &mut egui::Ui) {
             return;
         }
     };
-    let items: Vec<TableItem> = tracks
+    let items = cached_table_items(
+        ui,
+        &Page::TopSongs,
+        app.home.top_songs_generation,
+        app.user_names_revision,
+        || {
+            tracks
+                .iter()
+                .cloned()
+                .map(|track| (PlayableItem::Track(track), None, None))
+                .collect()
+        },
+    );
+    let uris: Arc<[String]> = items
         .iter()
-        .cloned()
-        .map(|track| (PlayableItem::Track(track), None, None))
-        .collect();
-    let uris = tracks.into_iter().map(|track| track.uri).collect();
+        .map(|(item, _, _)| item.uri().to_string())
+        .collect::<Vec<_>>()
+        .into();
     table(
         app,
         ui,
         Table {
             items: &items,
             row_offset: 0,
-            context: RowContext::Uris(uris),
+            context: RowContext::Uris(Arc::clone(&uris)),
             show_album: true,
             show_cover: true,
             show_added: false,
@@ -747,11 +793,19 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
     let user_id = app.user_id().unwrap_or("").to_string();
     match &page.playlist {
         Loadable::Loaded(playlist) => {
-            let items = items_of(
-                &page.items,
-                playlist.owner.id.as_deref(),
-                playlist.owner_name(),
-                &app.user_names,
+            let items = cached_table_items(
+                ui,
+                &Page::Playlist(id.to_string()),
+                page.items.revision,
+                app.user_names_revision,
+                || {
+                    items_of(
+                        &page.items,
+                        playlist.owner.id.as_deref(),
+                        playlist.owner_name(),
+                        &app.user_names,
+                    )
+                },
             );
             let count = playlist.track_total().max(items.len() as u32);
             // Spotify's collaborative flag covers secret collaborations; a
@@ -833,7 +887,10 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.items.revision,
             );
-            let view_play = table_view.view_uris.as_ref().map(|uris| uris.to_vec());
+            let view_play = table_view
+                .view_uris
+                .as_ref()
+                .map(|uris| Arc::clone(uris));
             let playlist_clone = playlist.clone();
             actions_row(
                 app,
@@ -911,24 +968,31 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
     match &page.album {
         Loadable::Loaded(album) => {
             album_hero(app, ui, album, &page.tracks);
-            let items: Vec<TableItem> = page
-                .tracks
-                .items
-                .iter()
-                .cloned()
-                .map(|mut track| {
-                    if track.album.is_none() {
-                        track.album = Some(Album {
-                            id: album.id.clone(),
-                            name: album.name.clone(),
-                            uri: album.uri.clone(),
-                            images: album.images.clone(),
-                            ..Album::default()
-                        });
-                    }
-                    (PlayableItem::Track(track), None, None)
-                })
-                .collect();
+            let items = cached_table_items(
+                ui,
+                &Page::Album(id.to_string()),
+                page.tracks.revision,
+                app.user_names_revision,
+                || {
+                    page.tracks
+                        .items
+                        .iter()
+                        .cloned()
+                        .map(|mut track| {
+                            if track.album.is_none() {
+                                track.album = Some(Album {
+                                    id: album.id.clone(),
+                                    name: album.name.clone(),
+                                    uri: album.uri.clone(),
+                                    images: album.images.clone(),
+                                    ..Album::default()
+                                });
+                            }
+                            (PlayableItem::Track(track), None, None)
+                        })
+                        .collect()
+                },
+            );
             let saved = app.is_saved(&album.uri).unwrap_or(false);
             let sort = app.table_sorts.get(&Page::Album(id.to_string())).copied();
             let table_view = prepare_table_view(
@@ -940,7 +1004,10 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                 sort,
                 page.tracks.revision,
             );
-            let album_view = table_view.view_uris.as_ref().map(|uris| uris.to_vec());
+            let album_view = table_view
+                .view_uris
+                .as_ref()
+                .map(|uris| Arc::clone(uris));
             actions_row(
                 app,
                 ui,
@@ -1072,19 +1139,26 @@ fn album_hero(
 
 pub fn liked(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let items: Vec<TableItem> = app
-        .library
-        .liked
-        .items
-        .iter()
-        .map(|saved| {
-            (
-                PlayableItem::Track(saved.track.clone()),
-                saved.added_at.clone(),
-                None,
-            )
-        })
-        .collect();
+    let items = cached_table_items(
+        ui,
+        &Page::LikedSongs,
+        app.library.liked.revision,
+        app.user_names_revision,
+        || {
+            app.library
+                .liked
+                .items
+                .iter()
+                .map(|saved| {
+                    (
+                        PlayableItem::Track(saved.track.clone()),
+                        saved.added_at.clone(),
+                        None,
+                    )
+                })
+                .collect()
+        },
+    );
     let total = app.library.liked.total.unwrap_or(items.len() as u32);
     let user = app
         .user
@@ -1132,7 +1206,10 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         sort,
         app.library.liked.revision,
     );
-    let liked_view = table_view.view_uris.as_ref().map(|uris| uris.to_vec());
+    let liked_view = table_view
+        .view_uris
+        .as_ref()
+        .map(|uris| Arc::clone(uris));
     actions_row(
         app,
         ui,
@@ -1148,10 +1225,11 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
         Some(&mut filter),
     );
     ui.data_mut(|data| data.insert_temp(filter_id, filter.clone()));
-    let uris: Vec<String> = items
+    let uris: Arc<[String]> = items
         .iter()
         .map(|(item, _, _)| item.uri().to_string())
-        .collect();
+        .collect::<Vec<_>>()
+        .into();
     let context = match collection_uri {
         Some(uri) if app.library.liked.is_complete() => RowContext::Context {
             uri,

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -366,6 +366,7 @@ pub fn cached_table_items(
     if let Some(items) =
         table_items_hit(app, &page, generation, items_revision, user_names_revision)
     {
+        app.retain_table_rows(&page);
         return items;
     }
     remember_table_items(
@@ -1317,8 +1318,53 @@ fn palette_of(app: &App) -> Palette {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::models::{Album, ArtistRef, Track};
+    use crate::api::models::{Album, ArtistRef, Image, Track};
     use crate::model::PlaylistPage;
+
+    fn make_large_tracks(count: usize) -> Vec<TableItem> {
+        (0..count)
+            .map(|i| {
+                let track = Track {
+                    id: Some(format!("t_{i}")),
+                    name: format!("Nested metadata song {i} with a longer title"),
+                    uri: format!("spotify:track:large-{i}"),
+                    duration_ms: 180_000,
+                    artists: vec![ArtistRef {
+                        id: Some(format!("artist-{i}")),
+                        name: format!("Nested Artist Name {i}"),
+                        uri: Some(format!("spotify:artist:artist-{i}")),
+                    }],
+                    album: Some(Album {
+                        id: format!("alb-{i}"),
+                        name: format!("Nested Album Title {i}"),
+                        uri: format!("spotify:album:alb-{i}"),
+                        images: vec![
+                            Image {
+                                url: format!("https://i.scdn.co/image/large-{i}-640"),
+                                width: Some(640),
+                                height: Some(640),
+                            },
+                            Image {
+                                url: format!("https://i.scdn.co/image/large-{i}-300"),
+                                width: Some(300),
+                                height: Some(300),
+                            },
+                        ],
+                        ..Album::default()
+                    }),
+                    ..Track::default()
+                };
+                (PlayableItem::Track(track), None, None)
+            })
+            .collect()
+    }
+
+    fn names_only_bytes(items: &[TableItem]) -> usize {
+        items
+            .iter()
+            .map(|(item, ..)| item.uri().len() + item.name().len())
+            .sum()
+    }
 
     fn make_test_tracks() -> Vec<TableItem> {
         let titles = [
@@ -1516,14 +1562,37 @@ mod tests {
     }
 
     #[test]
-    fn table_row_cache_dies_when_account_data_resets() {
+    fn table_row_cache_memory_counts_nested_metadata_on_a_large_collection() {
         let mut app = test_app();
-        cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, make_test_tracks);
-        assert!(!app.table_rows.is_empty());
-        let before = app.table_rows_retained_bytes();
-        assert!(before > 0, "cached rows should retain heap");
-        app.table_rows.clear();
+        let items = make_large_tracks(500);
+        let names_only = names_only_bytes(&items);
         assert_eq!(app.table_rows_retained_bytes(), 0);
+        cached_table_items(&mut app, Page::LikedSongs, 0, 0, 0, || items);
+        let after = app.table_rows_retained_bytes();
+        assert!(
+            after > names_only,
+            "retained bytes must include nested album, artist, and image strings, not just titles: names_only={names_only} after={after}"
+        );
+        assert!(
+            after > 80_000,
+            "500 tracks with nested metadata should retain a substantial copy: {after}"
+        );
+    }
+
+    #[test]
+    fn table_row_cache_drops_when_the_backing_page_is_evicted() {
+        let mut app = test_app();
+        let page = Page::Playlist("pl-gone".into());
+        app.playlist_pages
+            .insert("pl-gone".into(), PlaylistPage::default());
+        cached_table_items(&mut app, page.clone(), 1, 0, 0, make_test_tracks);
+        assert!(app.table_rows.contains_key(&page));
+        app.playlist_pages.remove("pl-gone");
+        app.open(Page::LikedSongs);
+        assert!(
+            !app.table_rows.contains_key(&page),
+            "evicting the page map must drop the table-row copy"
+        );
     }
 
     #[test]

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -97,6 +97,7 @@ fn quick_access(app: &mut App, ui: &mut egui::Ui) {
                             cover,
                             6.0,
                             Icon::Music,
+                            Some(app.backend.art()),
                         );
                     }
                     let play_room = if hovered && uri.is_some() { 52.0 } else { 12.0 };

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -370,15 +370,15 @@ fn track_list(
         .collect::<Vec<_>>()
         .into();
     let context = RowContext::Uris(Arc::clone(&uris));
-    let items: Vec<PlayableItem> = tracks.iter().cloned().map(PlayableItem::Track).collect();
-    for (index, item) in items.iter().take(limit).enumerate() {
+    for (index, track) in tracks.iter().take(limit).enumerate() {
+        let item = PlayableItem::Track(track.clone());
         widgets::track_row(
             ui,
             app,
             TrackRow {
                 index,
                 number: None,
-                item,
+                item: &item,
                 context: &context,
                 show_cover: !app.settings.tracklist_compact,
                 show_album: true,
@@ -394,7 +394,7 @@ fn track_list(
         );
     }
     if let Some(label) = more_label
-        && items.len() > limit
+        && tracks.len() > limit
         && theme::link(ui, label, theme::semibold(14.0), palette.secondary).clicked()
     {
         app.actions.push(Action::Open(Page::TopSongs));

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -1,5 +1,7 @@
 //! The Home page.
 
+use std::sync::Arc;
+
 use egui::{CornerRadius, Rect, Sense, Vec2, pos2, vec2};
 
 use crate::api::models::{PlayableItem, Playlist, pick_image};
@@ -362,9 +364,13 @@ fn track_list(
         theme::section_title(ui, &palette, title);
     }
     ui.add_space(4.0);
-    let uris: Vec<String> = tracks.iter().map(|track| track.uri.clone()).collect();
-    let context = RowContext::Uris(uris);
-    let items: Vec<PlayableItem> = tracks.into_iter().map(PlayableItem::Track).collect();
+    let uris: Arc<[String]> = tracks
+        .iter()
+        .map(|track| track.uri.clone())
+        .collect::<Vec<_>>()
+        .into();
+    let context = RowContext::Uris(Arc::clone(&uris));
+    let items: Vec<PlayableItem> = tracks.iter().cloned().map(PlayableItem::Track).collect();
     for (index, item) in items.iter().take(limit).enumerate() {
         widgets::track_row(
             ui,

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -32,37 +32,32 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, page: Page) {
     ui.add_space(14.0);
     match page {
         Page::Albums => {
-            let albums: Vec<_> = app
-                .library
-                .albums
-                .items
-                .iter()
-                .map(|saved| saved.album.clone())
-                .collect();
-            widgets::grid(ui, |ui| {
-                for album in &albums {
-                    let subtitle =
-                        join_names(album.artists.iter().map(|artist| artist.name.as_str()));
-                    let card = widgets::card(
-                        ui,
-                        app,
-                        pick_image(&album.images, 300),
-                        &album.name,
-                        &subtitle,
-                        false,
-                        true,
-                    );
-                    if card.play {
-                        app.actions.push(Action::PlayContext {
-                            uri: album.uri.clone(),
-                            offset_uri: None,
-                            offset_index: None,
-                        });
-                    }
-                    if card.clicked {
-                        app.actions
-                            .push(Action::Open(Page::Album(album.id.clone())));
-                    }
+            let card_height = widgets::card_row_height(ui);
+            let count = app.library.albums.items.len();
+            widgets::virtual_wrapped_cards(ui, count, card_height, |ui, index| {
+                let album = app.library.albums.items[index].album.clone();
+                let id = album.id.clone();
+                let uri = album.uri.clone();
+                let subtitle =
+                    join_names(album.artists.iter().map(|artist| artist.name.as_str()));
+                let card = widgets::card(
+                    ui,
+                    app,
+                    pick_image(&album.images, 300),
+                    &album.name,
+                    &subtitle,
+                    false,
+                    true,
+                );
+                if card.play {
+                    app.actions.push(Action::PlayContext {
+                        uri,
+                        offset_uri: None,
+                        offset_index: None,
+                    });
+                }
+                if card.clicked {
+                    app.actions.push(Action::Open(Page::Album(id)));
                 }
             });
             let list = &app.library.albums;
@@ -86,29 +81,30 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, page: Page) {
             );
         }
         Page::Artists => {
-            let artists = app.library.artists.items.clone();
-            widgets::grid(ui, |ui| {
-                for artist in &artists {
-                    let card = widgets::card(
-                        ui,
-                        app,
-                        pick_image(&artist.images, 300),
-                        &artist.name,
-                        "Artist",
-                        true,
-                        true,
-                    );
-                    if card.play {
-                        app.actions.push(Action::PlayContext {
-                            uri: artist.uri.clone(),
-                            offset_uri: None,
-                            offset_index: None,
-                        });
-                    }
-                    if card.clicked {
-                        app.actions
-                            .push(Action::Open(Page::Artist(artist.id.clone())));
-                    }
+            let card_height = widgets::card_row_height(ui);
+            let count = app.library.artists.items.len();
+            widgets::virtual_wrapped_cards(ui, count, card_height, |ui, index| {
+                let artist = app.library.artists.items[index].clone();
+                let id = artist.id.clone();
+                let uri = artist.uri.clone();
+                let card = widgets::card(
+                    ui,
+                    app,
+                    pick_image(&artist.images, 300),
+                    &artist.name,
+                    "Artist",
+                    true,
+                    true,
+                );
+                if card.play {
+                    app.actions.push(Action::PlayContext {
+                        uri,
+                        offset_uri: None,
+                        offset_index: None,
+                    });
+                }
+                if card.clicked {
+                    app.actions.push(Action::Open(Page::Artist(id)));
                 }
             });
             let list = &app.library.artists;
@@ -132,27 +128,22 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, page: Page) {
             );
         }
         Page::Podcasts => {
-            let shows: Vec<_> = app
-                .library
-                .shows
-                .items
-                .iter()
-                .map(|saved| saved.show.clone())
-                .collect();
-            widgets::grid(ui, |ui| {
-                for show in &shows {
-                    let card = widgets::card(
-                        ui,
-                        app,
-                        pick_image(&show.images, 300),
-                        &show.name,
-                        &show.publisher,
-                        false,
-                        false,
-                    );
-                    if card.clicked {
-                        app.actions.push(Action::Open(Page::Show(show.id.clone())));
-                    }
+            let card_height = widgets::card_row_height(ui);
+            let count = app.library.shows.items.len();
+            widgets::virtual_wrapped_cards(ui, count, card_height, |ui, index| {
+                let show = app.library.shows.items[index].show.clone();
+                let id = show.id.clone();
+                let card = widgets::card(
+                    ui,
+                    app,
+                    pick_image(&show.images, 300),
+                    &show.name,
+                    &show.publisher,
+                    false,
+                    false,
+                );
+                if card.clicked {
+                    app.actions.push(Action::Open(Page::Show(id)));
                 }
             });
             let list = &app.library.shows;

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -38,8 +38,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, page: Page) {
                 let album = app.library.albums.items[index].album.clone();
                 let id = album.id.clone();
                 let uri = album.uri.clone();
-                let subtitle =
-                    join_names(album.artists.iter().map(|artist| artist.name.as_str()));
+                let subtitle = join_names(album.artists.iter().map(|artist| artist.name.as_str()));
                 let card = widgets::card(
                     ui,
                     app,

--- a/src/ui/player_bar.rs
+++ b/src/ui/player_bar.rs
@@ -67,7 +67,7 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
     let cover_rect = Rect::from_min_size(pos2(region.left() + 4.0, cy - 28.0), Vec2::splat(56.0));
 
     let Some(now) = now else {
-        super::widgets::paint_cover(ui, &palette, None, cover_rect, 6.0, Icon::Music);
+        super::widgets::paint_cover(ui, &palette, None, cover_rect, 6.0, Icon::Music, None);
         let text_left = cover_rect.right() + 12.0;
         let text_rect = Rect::from_min_size(
             pos2(text_left, cy - 17.0),
@@ -101,6 +101,7 @@ fn now_playing_block(app: &mut App, ui: &mut egui::Ui, region: Rect, now: Option
         cover_rect,
         6.0,
         Icon::Music,
+        Some(app.backend.art()),
     );
     let song = app.now_playing_item();
     let drag_sense = if song.is_some() {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,5 +1,7 @@
 //! The playback queue, as a page or as a side panel.
 
+use std::sync::Arc;
+
 use egui::{Align, Frame, Layout, Margin};
 
 use crate::api::models::PlayableItem;
@@ -167,7 +169,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
     if let Some(current) = &current {
         theme::text(ui, "Now playing", theme::semibold(14.0), palette.text);
         ui.add_space(4.0);
-        let context = RowContext::Uris(vec![current.uri().to_string()]);
+        let context = RowContext::Uris(Arc::from([current.uri().to_string()]));
         widgets::track_row(
             ui,
             app,
@@ -293,7 +295,7 @@ fn recents_contents(app: &mut App, ui: &mut egui::Ui) {
         let entry = &items[index];
         // Need owned PlayableItem for track_row; clone track.
         let item = PlayableItem::Track(entry.track.clone());
-        let context = RowContext::Uris(vec![entry.track.uri.clone()]);
+        let context = RowContext::Uris(Arc::from([entry.track.uri.clone()]));
         widgets::track_row(
             ui,
             app,

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -143,8 +143,8 @@ fn clear_button(app: &mut App, ui: &mut egui::Ui) {
 
 fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
     let palette = app.palette;
-    let queue = match &app.queue {
-        Loadable::Loaded(queue) => queue.clone(),
+    match &app.queue {
+        Loadable::Loaded(_) => {}
         Loadable::Loading | Loadable::NotLoaded => {
             widgets::loading_row(ui, &palette);
             return;
@@ -159,14 +159,18 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
     // Prefer the player's current track because the Web API can lag after a
     // skip.
     let current: Option<PlayableItem> = match &now {
-        Some(now) => queue
-            .currently_playing
-            .clone()
+        Some(now) => app
+            .queue
+            .get()
+            .and_then(|queue| queue.currently_playing.clone())
             .filter(|item| item.uri() == now.uri)
             .or_else(|| app.now_playing_item()),
-        None => queue.currently_playing.clone(),
+        None => app
+            .queue
+            .get()
+            .and_then(|queue| queue.currently_playing.clone()),
     };
-    if let Some(current) = &current {
+    if let Some(current) = current.as_ref() {
         theme::text(ui, "Now playing", theme::semibold(14.0), palette.text);
         ui.add_space(4.0);
         let context = RowContext::Uris(Arc::from([current.uri().to_string()]));
@@ -192,7 +196,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
         );
         ui.add_space(14.0);
     }
-    if queue.queue.is_empty() {
+    if queue_is_empty(app) {
         widgets::empty_state(
             ui,
             &palette,
@@ -207,11 +211,11 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
     } else {
         theme::ROW_HEIGHT
     };
-    let items = queue.queue.clone();
+    let queue_len = app.queue.get().map(|queue| queue.queue.len()).unwrap_or(0);
     // The user's own songs get their own section on top; the playing
     // context's rows follow under the usual heading. One numbering runs
     // through both, because that is the order things play.
-    let queued_len = app.queued_rows_len().min(items.len());
+    let queued_len = app.queued_rows_len().min(queue_len);
     if queued_len > 0 {
         // The trash sits with the songs it removes: only this section is
         // the user's to clear, the context below plays itself.
@@ -222,18 +226,24 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
             });
         });
         ui.add_space(4.0);
-        for index in 0..queued_len {
-            queue_row(app, ui, &items, index, compact);
-        }
+        widgets::virtual_rows(ui, queued_len, row_height, |ui, index| {
+            queue_row(app, ui, index, compact);
+        });
         ui.add_space(14.0);
     }
-    if items.len() > queued_len {
+    if queue_len > queued_len {
         theme::text(ui, "Next up", theme::semibold(14.0), palette.text);
         ui.add_space(4.0);
-        widgets::virtual_rows(ui, items.len() - queued_len, row_height, |ui, index| {
-            queue_row(app, ui, &items, queued_len + index, compact);
+        widgets::virtual_rows(ui, queue_len - queued_len, row_height, |ui, index| {
+            queue_row(app, ui, queued_len + index, compact);
         });
     }
+}
+
+fn queue_is_empty(app: &App) -> bool {
+    app.queue
+        .get()
+        .is_none_or(|queue| queue.queue.is_empty())
 }
 
 fn recents_contents(app: &mut App, ui: &mut egui::Ui) {
@@ -340,20 +350,22 @@ fn recents_contents(app: &mut App, ui: &mut egui::Ui) {
 
 /// One row of the queue, numbered and indexed by its place in the whole
 /// queue, whichever section it sits in.
-fn queue_row(
-    app: &mut App,
-    ui: &mut egui::Ui,
-    items: &[PlayableItem],
-    index: usize,
-    compact: bool,
-) {
+fn queue_row(app: &mut App, ui: &mut egui::Ui, index: usize, compact: bool) {
+    let Some(item) = app
+        .queue
+        .get()
+        .and_then(|queue| queue.queue.get(index))
+        .cloned()
+    else {
+        return;
+    };
     widgets::track_row(
         ui,
         app,
         TrackRow {
             index,
             number: Some(index + 1),
-            item: &items[index],
+            item: &item,
             context: &RowContext::Queue,
             show_cover: true,
             show_album: !compact,

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -241,9 +241,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
 }
 
 fn queue_is_empty(app: &App) -> bool {
-    app.queue
-        .get()
-        .is_none_or(|queue| queue.queue.is_empty())
+    app.queue.get().is_none_or(|queue| queue.queue.is_empty())
 }
 
 fn recents_contents(app: &mut App, ui: &mut egui::Ui) {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -226,8 +226,11 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
             });
         });
         ui.add_space(4.0);
-        widgets::virtual_rows(ui, queued_len, row_height, |ui, index| {
+        let gap = ui.spacing().item_spacing.y;
+        widgets::virtual_rows(ui, queued_len, row_height + gap, |ui, index| {
+            let width = ui.available_width();
             queue_row(app, ui, index, compact);
+            ui.allocate_space(egui::vec2(width, gap));
         });
         ui.add_space(14.0);
     }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,5 +1,7 @@
 //! The Search page.
 
+use std::sync::Arc;
+
 use egui::{Align, CornerRadius, Layout, Rect, Sense, Vec2, pos2, vec2};
 
 use crate::api::models::{Artist, PlayableItem, SearchResults, pick_image};
@@ -315,8 +317,13 @@ fn songs(app: &mut App, ui: &mut egui::Ui, results: &SearchResults, limit: usize
     }
     theme::section_title(ui, &palette, "Songs");
     ui.add_space(4.0);
-    let uris: Vec<String> = page.items.iter().map(|track| track.uri.clone()).collect();
-    let context = RowContext::Uris(uris);
+    let uris: Arc<[String]> = page
+        .items
+        .iter()
+        .map(|track| track.uri.clone())
+        .collect::<Vec<_>>()
+        .into();
+    let context = RowContext::Uris(Arc::clone(&uris));
     let items: Vec<PlayableItem> = page
         .items
         .iter()

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -238,6 +238,7 @@ fn top_result(
             image_rect,
             if round { 48.0 } else { 6.0 },
             if round { Icon::User } else { Icon::Music },
+            Some(app.backend.art()),
         );
         let text_clip = Rect::from_min_max(
             pos2(rect.left() + 20.0, image_rect.bottom() + 12.0),

--- a/src/ui/show.rs
+++ b/src/ui/show.rs
@@ -1,5 +1,7 @@
 //! Podcast pages and episode rows.
 
+use std::sync::Arc;
+
 use egui::{CornerRadius, Layout, Rect, Sense, UiBuilder, Vec2, pos2, vec2};
 
 use crate::api::models::{Episode, PlayableItem, pick_image};
@@ -332,5 +334,5 @@ pub fn episode_row(
             index: 0,
         });
     }
-    let _ = RowContext::Uris(Vec::new());
+    let _ = RowContext::Uris(Arc::from([]));
 }

--- a/src/ui/show.rs
+++ b/src/ui/show.rs
@@ -173,7 +173,7 @@ pub fn episode_row(
     let inner = rect.shrink2(vec2(12.0, 12.0));
     let cover_rect = Rect::from_min_size(inner.min, Vec2::splat(96.0));
     let image = pick_image(&episode.images, 64).or(fallback_image);
-    widgets::paint_cover(ui, &palette, image, cover_rect, 6.0, Icon::Mic);
+    widgets::paint_cover(ui, &palette, image, cover_rect, 6.0, Icon::Mic, None);
     let text_left = cover_rect.right() + 16.0;
     let text_rect = Rect::from_min_max(
         pos2(text_left, inner.top()),

--- a/src/ui/show.rs
+++ b/src/ui/show.rs
@@ -173,7 +173,15 @@ pub fn episode_row(
     let inner = rect.shrink2(vec2(12.0, 12.0));
     let cover_rect = Rect::from_min_size(inner.min, Vec2::splat(96.0));
     let image = pick_image(&episode.images, 64).or(fallback_image);
-    widgets::paint_cover(ui, &palette, image, cover_rect, 6.0, Icon::Mic, None);
+    widgets::paint_cover(
+        ui,
+        &palette,
+        image,
+        cover_rect,
+        6.0,
+        Icon::Mic,
+        Some(app.backend.art()),
+    );
     let text_left = cover_rect.right() + 16.0;
     let text_rect = Rect::from_min_max(
         pos2(text_left, inner.top()),

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -78,6 +78,7 @@ fn art_panel(app: &mut App, ui: &mut egui::Ui) {
         return;
     };
     let palette = app.palette;
+    let art = app.backend.art();
     let side = ui
         .available_width()
         .min(ui.available_height() * 0.45)
@@ -92,7 +93,15 @@ fn art_panel(app: &mut App, ui: &mut egui::Ui) {
                 ui.max_rect().left_top(),
                 Vec2::splat(side.min(ui.available_width())),
             );
-            super::widgets::paint_cover(ui, &palette, Some(&url), rect, 8.0, Icon::Music, None);
+            super::widgets::paint_cover(
+                ui,
+                &palette,
+                Some(&url),
+                rect,
+                8.0,
+                Icon::Music,
+                Some(art),
+            );
             let art = ui
                 .interact(rect, egui::Id::new("sidebar-art"), Sense::click())
                 .on_hover_cursor(egui::CursorIcon::PointingHand);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -92,7 +92,7 @@ fn art_panel(app: &mut App, ui: &mut egui::Ui) {
                 ui.max_rect().left_top(),
                 Vec2::splat(side.min(ui.available_width())),
             );
-            super::widgets::paint_cover(ui, &palette, Some(&url), rect, 8.0, Icon::Music);
+            super::widgets::paint_cover(ui, &palette, Some(&url), rect, 8.0, Icon::Music, None);
             let art = ui
                 .interact(rect, egui::Id::new("sidebar-art"), Sense::click())
                 .on_hover_cursor(egui::CursorIcon::PointingHand);
@@ -883,6 +883,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                                 cover_rect,
                                 if entry.round { 22.0 } else { 6.0 },
                                 if entry.round { Icon::User } else { Icon::Music },
+                                Some(app.backend.art()),
                             );
                         }
                         let text_left = cover_rect.right() + 12.0;

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -171,6 +171,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                             inner,
                             14.0,
                             Icon::User,
+                            Some(app.backend.art()),
                         ),
                         None => {
                             let initial = name

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -24,7 +24,7 @@ pub fn cover(
     fallback: Icon,
 ) -> Rect {
     let (rect, _) = ui.allocate_exact_size(Vec2::splat(size), Sense::hover());
-    paint_cover(ui, palette, url, rect, radius, fallback);
+    paint_cover(ui, palette, url, rect, radius, fallback, None);
     rect
 }
 
@@ -35,9 +35,13 @@ pub fn paint_cover(
     rect: Rect,
     radius: f32,
     fallback: Icon,
+    art: Option<&crate::images::ArtLoader>,
 ) {
     if !ui.is_rect_visible(rect) {
         return;
+    }
+    if let (Some(url), Some(art)) = (url, art) {
+        art.touch(url);
     }
     let corner = CornerRadius::same(radius.min(127.0) as u8);
     let painter = ui.painter();
@@ -48,6 +52,9 @@ pub fn paint_cover(
         else {
             return false;
         };
+        if let Some(art) = art {
+            art.release_bytes(url);
+        }
 
         let image_aspect = texture.size.x / texture.size.y;
         let rect_aspect = rect.width() / rect.height();
@@ -789,6 +796,7 @@ fn track_row_contents(ui: &mut Ui, app: &mut App, row: TrackRow<'_>) -> Option<R
             } else {
                 Icon::Mic
             },
+            Some(app.backend.art()),
         );
         // Without a number column the cover carries the play control:
         // hover shows it, a click uses it, and what plays shows there.
@@ -1600,6 +1608,7 @@ pub fn card(
             image_rect,
             radius,
             if round { Icon::User } else { Icon::Music },
+            Some(app.backend.art()),
         );
         let text_left = rect.left() + PAD;
         let title_galley = ellipsized(ui, title, title_font, palette.text, text_width, 1);

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -154,6 +154,34 @@ pub fn virtual_rows(
     ui.spacing_mut().item_spacing = previous_spacing;
 }
 
+/// A wrapping grid of cards, laid out row by row so only visible cards are
+/// measured and painted.
+pub fn virtual_wrapped_cards(
+    ui: &mut Ui,
+    count: usize,
+    card_height: f32,
+    mut card: impl FnMut(&mut Ui, usize),
+) {
+    if count == 0 {
+        return;
+    }
+    let spacing = CARD_GAP / 2.0;
+    let row_width = ui.available_width().max(CARD_WIDTH);
+    let cards_per_row =
+        ((row_width + spacing) / (CARD_WIDTH + spacing)).floor().max(1.0) as usize;
+    let row_count = count.div_ceil(cards_per_row);
+    virtual_rows(ui, row_count, card_height + CARD_GAP, |ui, row| {
+        ui.horizontal_wrapped(|ui| {
+            ui.spacing_mut().item_spacing = vec2(spacing, CARD_GAP);
+            let start = row * cards_per_row;
+            let end = (start + cards_per_row).min(count);
+            for index in start..end {
+                card(ui, index);
+            }
+        });
+    });
+}
+
 /// Asks for the next page when the user scrolls near the end of a list.
 pub fn load_more_when_near_end(ui: &Ui, app: &mut App, page: Page, can_load: bool) {
     if !can_load {
@@ -1550,6 +1578,24 @@ pub fn ellipsized(
 pub struct CardResponse {
     pub clicked: bool,
     pub play: bool,
+}
+
+/// Fixed height of a [`card`] row for virtualised grids.
+pub fn card_row_height(ui: &mut Ui) -> f32 {
+    const PAD: f32 = 12.0;
+    const TITLE_GAP: f32 = 10.0;
+    const SUBTITLE_GAP: f32 = 2.0;
+    const BOTTOM_PAD: f32 = 8.0;
+    let image_size = CARD_WIDTH - 2.0 * PAD;
+    let title_font = theme::semibold(14.0);
+    let subtitle_font = theme::regular(12.5);
+    let (title_row, subtitle_row) = ui.fonts_mut(|fonts| {
+        (
+            fonts.row_height(&title_font),
+            fonts.row_height(&subtitle_font),
+        )
+    });
+    PAD + image_size + TITLE_GAP + title_row + SUBTITLE_GAP + 2.0 * subtitle_row + BOTTOM_PAD
 }
 
 /// A cover-and-title card for grids and shelves.

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -167,8 +167,9 @@ pub fn virtual_wrapped_cards(
     }
     let spacing = CARD_GAP / 2.0;
     let row_width = ui.available_width().max(CARD_WIDTH);
-    let cards_per_row =
-        ((row_width + spacing) / (CARD_WIDTH + spacing)).floor().max(1.0) as usize;
+    let cards_per_row = ((row_width + spacing) / (CARD_WIDTH + spacing))
+        .floor()
+        .max(1.0) as usize;
     let row_count = count.div_ceil(cards_per_row);
     virtual_rows(ui, row_count, card_height + CARD_GAP, |ui, row| {
         ui.horizontal_wrapped(|ui| {

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -54,6 +54,11 @@ pub fn paint_cover(
         };
         if let Some(art) = art {
             art.release_bytes(url);
+            art.note_decoded(
+                url,
+                texture.size.x.round() as usize,
+                texture.size.y.round() as usize,
+            );
         }
 
         let image_aspect = texture.size.x / texture.size.y;

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -171,17 +171,24 @@ pub fn virtual_wrapped_cards(
         .floor()
         .max(1.0) as usize;
     let row_count = count.div_ceil(cards_per_row);
+    // CARD_GAP is already in the row height. Do not also inherit item_spacing.y.
+    let previous_spacing = ui.spacing().item_spacing;
+    ui.spacing_mut().item_spacing.y = 0.0;
+    let grid_id = ui.unique_id().with("virtual-card");
     virtual_rows(ui, row_count, card_height + CARD_GAP, |ui, row| {
         ui.horizontal_wrapped(|ui| {
             ui.spacing_mut().item_spacing = vec2(spacing, CARD_GAP);
             let start = row * cards_per_row;
             let end = (start + cards_per_row).min(count);
             for index in start..end {
-                card(ui, index);
+                ui.scope_builder(UiBuilder::new().id(grid_id.with(index)), |ui| {
+                    card(ui, index);
+                });
             }
         });
         ui.allocate_space(vec2(row_width, CARD_GAP));
     });
+    ui.spacing_mut().item_spacing = previous_spacing;
 }
 
 /// Asks for the next page when the user scrolls near the end of a list.
@@ -1639,6 +1646,9 @@ pub fn card(
             format!("{title}, {subtitle}"),
         )
     });
+    if response.gained_focus() {
+        response.scroll_to_me(None);
+    }
     let mut play = false;
     if ui.is_rect_visible(rect) {
         let hovered = ui.rect_contains_pointer(rect);
@@ -2316,6 +2326,81 @@ mod tests {
                 .any(|action| matches!(action, Action::LoadMore(Page::Albums))),
             "scrolling near the end must page: {:?}",
             app.actions
+        );
+    }
+
+    #[test]
+    fn virtual_rows_keep_the_gap_a_for_loop_would() {
+        let size = vec2(400.0, 800.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        let mut loop_span = 0.0;
+        let mut virt_span = 0.0;
+        run(size, clip, Vec::new(), |ui| {
+            let start = ui.cursor().top();
+            for _ in 0..8 {
+                ui.allocate_exact_size(vec2(ui.available_width(), 40.0), Sense::hover());
+            }
+            loop_span = ui.cursor().top() - start;
+        });
+        run(size, clip, Vec::new(), |ui| {
+            let start = ui.cursor().top();
+            let gap = ui.spacing().item_spacing.y;
+            virtual_rows(ui, 8, 40.0 + gap, |ui, _| {
+                let width = ui.available_width();
+                ui.allocate_exact_size(vec2(width, 40.0), Sense::hover());
+                ui.allocate_space(vec2(width, gap));
+            });
+            virt_span = ui.cursor().top() - start;
+        });
+        assert!(
+            loop_span > 8.0 * 40.0,
+            "a for-loop keeps item spacing: {loop_span}"
+        );
+        assert!(
+            (loop_span - virt_span).abs() < 1.0,
+            "playing-next style virtual rows must keep that spacing: loop={loop_span} virtual={virt_span}"
+        );
+    }
+
+    #[test]
+    fn virtual_wrapped_cards_keep_widget_ids_when_the_first_row_changes() {
+        use std::collections::HashMap;
+        let ctx = egui::Context::default();
+        let size = vec2(400.0, 800.0);
+        let mut top_ids = HashMap::new();
+        run_on(
+            &ctx,
+            size,
+            Rect::from_min_size(pos2(0.0, 0.0), vec2(400.0, 220.0)),
+            Vec::new(),
+            |ui| {
+                virtual_wrapped_cards(ui, 40, 180.0, |ui, index| {
+                    let response = ui.button(format!("Card {index}"));
+                    top_ids.insert(index, response.id);
+                });
+            },
+        );
+        let mut scrolled_ids = HashMap::new();
+        run_on(
+            &ctx,
+            size,
+            Rect::from_min_max(pos2(0.0, 400.0), pos2(400.0, 620.0)),
+            Vec::new(),
+            |ui| {
+                virtual_wrapped_cards(ui, 40, 180.0, |ui, index| {
+                    let response = ui.button(format!("Card {index}"));
+                    scrolled_ids.insert(index, response.id);
+                });
+            },
+        );
+        let shared = top_ids
+            .keys()
+            .find(|index| scrolled_ids.contains_key(index))
+            .copied()
+            .expect("a card must remain built after the first visible row changes");
+        assert_eq!(
+            top_ids[&shared], scrolled_ids[&shared],
+            "card {shared} must keep its widget id when earlier rows leave the clip"
         );
     }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -2116,3 +2116,223 @@ pub fn setting_row(
     });
     ui.add_space(10.0);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, AppOptions};
+    use crate::model::{Action, Page};
+    use crate::paths::AppDirs;
+    use crate::settings::Settings;
+
+    fn test_app() -> App {
+        let root = std::env::temp_dir().join(format!(
+            "fastpotify-virtual-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        App::new(
+            &crate::backend::Waker::default(),
+            AppDirs {
+                config: root.join("config"),
+                state: root.join("state"),
+                cache: root.join("cache"),
+            },
+            Settings::default(),
+            AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        )
+    }
+
+    fn run_on(
+        ctx: &egui::Context,
+        size: Vec2,
+        clip: Rect,
+        events: Vec<egui::Event>,
+        mut f: impl FnMut(&mut Ui),
+    ) {
+        let input = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(pos2(0.0, 0.0), size)),
+            events,
+            ..Default::default()
+        };
+        let mut output = ctx.run_ui(input, |ui| {
+            ui.set_clip_rect(clip);
+            f(ui);
+        });
+        output.textures_delta.clear();
+    }
+
+    fn run(size: Vec2, clip: Rect, events: Vec<egui::Event>, f: impl FnMut(&mut Ui)) {
+        run_on(&egui::Context::default(), size, clip, events, f);
+    }
+
+    #[test]
+    fn virtual_rows_only_build_visible_indices() {
+        let mut painted = Vec::new();
+        let size = vec2(400.0, 240.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        run(size, clip, Vec::new(), |ui| {
+            virtual_rows(ui, 10_000, 40.0, |_, index| painted.push(index));
+        });
+        assert!(
+            painted.len() < 20,
+            "a long list must not build every row: {} painted",
+            painted.len()
+        );
+        assert!(!painted.is_empty());
+        assert_eq!(painted[0], 0);
+        assert!(
+            painted.windows(2).all(|pair| pair[1] == pair[0] + 1),
+            "visible indices must be consecutive"
+        );
+    }
+
+    #[test]
+    fn virtual_rows_keep_full_height_when_scrolled() {
+        let mut painted = Vec::new();
+        let mut span = 0.0;
+        let size = vec2(400.0, 800.0);
+        let clip = Rect::from_min_max(pos2(0.0, 400.0), pos2(400.0, 600.0));
+        run(size, clip, Vec::new(), |ui| {
+            let start = ui.cursor().top();
+            virtual_rows(ui, 10_000, 40.0, |ui, index| {
+                painted.push(index);
+                ui.allocate_exact_size(vec2(ui.available_width(), 40.0), Sense::hover());
+            });
+            span = ui.cursor().top() - start;
+        });
+        assert!(
+            (span - 10_000.0 * 40.0).abs() < 1.0,
+            "scroll height must match the full list, got {span}"
+        );
+        assert!(
+            painted.first().copied().unwrap_or(0) >= 8,
+            "rows above the clip must be skipped: {painted:?}"
+        );
+        assert!(
+            painted.last().copied().unwrap_or(0) < 20,
+            "rows below the clip must be skipped: {painted:?}"
+        );
+        assert!(painted.len() < 20);
+    }
+
+    #[test]
+    fn a_click_on_a_visible_virtual_row_still_fires() {
+        let ctx = egui::Context::default();
+        let size = vec2(400.0, 240.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        let mut row0 = Rect::NOTHING;
+        run_on(&ctx, size, clip, Vec::new(), |ui| {
+            virtual_rows(ui, 500, 40.0, |ui, index| {
+                let (rect, _) =
+                    ui.allocate_exact_size(vec2(ui.available_width(), 40.0), Sense::click());
+                if index == 0 {
+                    row0 = rect;
+                }
+            });
+        });
+        let pos = row0.center();
+        let mut clicked = None;
+        let events = vec![
+            egui::Event::PointerMoved(pos),
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::NONE,
+            },
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            },
+        ];
+        run_on(&ctx, size, clip, events, |ui| {
+            virtual_rows(ui, 500, 40.0, |ui, index| {
+                let (_, response) =
+                    ui.allocate_exact_size(vec2(ui.available_width(), 40.0), Sense::click());
+                if response.clicked() {
+                    clicked = Some(index);
+                }
+            });
+        });
+        assert_eq!(clicked, Some(0));
+    }
+
+    #[test]
+    fn load_more_asks_when_the_list_end_is_near() {
+        let mut app = test_app();
+        let size = vec2(400.0, 800.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        run(size, clip, Vec::new(), |ui| {
+            virtual_rows(ui, 5, 40.0, |ui, _| {
+                ui.allocate_exact_size(vec2(ui.available_width(), 40.0), Sense::hover());
+            });
+            load_more_when_near_end(ui, &mut app, Page::Albums, true);
+        });
+        assert!(
+            app.actions
+                .iter()
+                .any(|action| matches!(action, Action::LoadMore(Page::Albums))),
+            "a short list must request the next page: {:?}",
+            app.actions
+        );
+    }
+
+    #[test]
+    fn load_more_waits_until_a_long_list_is_near_the_end() {
+        let mut app = test_app();
+        let size = vec2(400.0, 200.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        run(size, clip, Vec::new(), |ui| {
+            virtual_rows(ui, 10_000, 40.0, |_, _| {});
+            load_more_when_near_end(ui, &mut app, Page::Albums, true);
+        });
+        assert!(
+            app.actions.is_empty(),
+            "the top of a long list must not page: {:?}",
+            app.actions
+        );
+
+        run(
+            size,
+            Rect::from_min_max(pos2(0.0, 399_200.0), pos2(400.0, 400_000.0)),
+            Vec::new(),
+            |ui| {
+                virtual_rows(ui, 10_000, 40.0, |_, _| {});
+                load_more_when_near_end(ui, &mut app, Page::Albums, true);
+            },
+        );
+        assert!(
+            app.actions
+                .iter()
+                .any(|action| matches!(action, Action::LoadMore(Page::Albums))),
+            "scrolling near the end must page: {:?}",
+            app.actions
+        );
+    }
+
+    #[test]
+    fn virtual_wrapped_cards_only_build_visible_rows() {
+        let mut painted = Vec::new();
+        let size = vec2(400.0, 220.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        run(size, clip, Vec::new(), |ui| {
+            virtual_wrapped_cards(ui, 200, 180.0, |_, index| painted.push(index));
+        });
+        assert!(
+            painted.len() < 40,
+            "a long grid must not build every card: {} painted",
+            painted.len()
+        );
+        assert!(!painted.is_empty());
+        assert_eq!(painted[0], 0);
+    }
+}

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -180,6 +180,7 @@ pub fn virtual_wrapped_cards(
                 card(ui, index);
             }
         });
+        ui.allocate_space(vec2(row_width, CARD_GAP));
     });
 }
 


### PR DESCRIPTION
**Merge order:** after #319 and #321. This branch is rebased onto #321 so the diff is virtualization-only.

## Why

The queue Playing next section and library card grids build every row or card each frame, even when most are off screen.

## What changed

- Virtualize Playing next (Next up was already virtual). Those rows keep the same gap a for-loop would, so Next up does not move up.
- Virtualize library card grids. Cards keep a stable widget id keyed by index so Tab works as the first visible row changes.
- `--demo-size WIDTHxHEIGHT` for sized review shots. `--demo-show playing-next` fills a few manual queue rows.

User-visible UI: none if spacing matches main. Captures to check that are in the latest comment (1240 queue before/after, then albums at 760 vs 1240).