### PR TITLE
Upload playlist covers from Edit details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -1753,6 +1755,7 @@ dependencies = [
  "rand 0.9.5",
  "raw-window-handle",
  "reqwest",
+ "rfd",
  "rodio",
  "serde",
  "serde_json",
@@ -3629,6 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -4258,6 +4262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "polycool"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,6 +4779,33 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
+]
+
+[[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"
 sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"
+# Native asynchronous file selection on macOS, Windows and Linux desktop portals.
+rfd = "0.17.2"
 rand = "0.9"
 open = "5"
 percent-encoding = "2"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ everyday use, and connection details.
   artists. **Album**, **playlist**, and **podcast** pages support playback
   from any row.
 - **Edit your playlists.** Create, rename, describe, reorder, and delete them.
+  Upload a JPEG or PNG cover from **Edit details → Change cover**.
   Add songs from a row menu, or drag a row or the currently playing song to a
   playlist in the sidebar. A playlist a friend shared with you takes songs too,
   as Spotify's own apps allow.

--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -43,3 +43,14 @@ Storage shows its location and has a **Clear history** button.
 On Windows, the main window's minimize, maximize, and close buttons share the
 top bar with Fastpotify's controls. Drag an empty part of that bar to move or
 snap the window, and drag a window edge or corner to resize it.
+
+## Playlist covers
+
+Open a playlist you own and choose **Edit details → Change cover**. Select a
+JPEG or PNG, check the preview, then choose **Upload cover**. Cancelling the
+picker leaves your previous selection intact. An upload error keeps the
+preview so you can try again. Uploading the cover is separate from **Save**,
+which saves the playlist name, description, and visibility.
+
+If Spotify refuses permission, sign in again and approve image uploads. If you
+use a personal Spotify app, reconnect it in Settings as well.

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -68,6 +68,28 @@ successful write advances the cached playlist to Spotify's returned snapshot
 instead of downloading the playlist again. If Spotify cannot answer the scan,
 Fastpotify preserves the requested edit and lets the write report its result.
 
+## Playlist cover uploads
+
+**Edit details → Change cover** opens the native file picker. Fastpotify reads
+only the selected JPEG or PNG, preserves its aspect ratio, flattens transparent
+pixels onto white, and encodes a JPEG preview. Files must be smaller than 20 MB
+and no larger than 8192 pixels per side. Encoding reduces the image to fit
+Spotify's 256 KB Base64 request limit. **Upload cover** sends that preview to
+Spotify; **Save** separately saves the name, description, and visibility.
+
+Uploads use the same shared or personal app routing as playlist edits. Requests
+are not retried through another app. The uploaded image stays visible for the
+session while Spotify propagates its artwork. The selected source file is not
+copied to the cache or settings.
+
+Image uploads require renewed Web API consent. If Fastpotify asks you to sign
+in again after updating, approve the image upload permission. Reconnect your
+personal app in Settings too, if you use one. Local playback authorization is
+unchanged. Spotify can refuse changes to playlists you do not own.
+
+On Linux the file picker uses a desktop portal, with Zenity as a fallback.
+Install your desktop's file chooser portal or Zenity if no picker opens.
+
 ## Receivers on the local network
 
 Spotify's device list only shows signed-in receivers. A new librespot or

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -78,9 +78,10 @@ Spotify's 256 KB Base64 request limit. **Upload cover** sends that preview to
 Spotify; **Save** separately saves the name, description, and visibility.
 
 Uploads use the same shared or personal app routing as playlist edits. Requests
-are not retried through another app. The uploaded image stays visible for the
-session while Spotify propagates its artwork. The selected source file is not
-copied to the cache or settings.
+are not retried through another app. The uploaded image stays visible while
+Spotify propagates its artwork. Once Spotify returns changed artwork URLs, they
+replace the temporary preview so later cover changes from other clients can
+appear. The selected source file is not copied to the cache or settings.
 
 Image uploads require renewed Web API consent. If Fastpotify asks you to sign
 in again after updating, approve the image upload permission. Reconnect your

--- a/docs/_reference/what-spotify-allows.md
+++ b/docs/_reference/what-spotify-allows.md
@@ -23,8 +23,7 @@ Fastpotify uses the Web API for:
   also save and remove items.
 - **Playlists:** reading, creating, renaming, changing the description and
   visibility, adding and removing songs, reordering songs, and following and
-  unfollowing. The API also supports cover uploads, but Fastpotify does not yet
-  use them.
+  unfollowing, and uploading custom playlist covers.
 - **Catalogue:** albums, artists, tracks, shows, episodes, search, and
   recommendations. Artist pages include top tracks, releases, and related
   artists.

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
                 pname = "fastpotify";
                 version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
                 src = self;
-                hash = "sha256-Cp6mdDC67P2yUOUkNVAeOLEOfTmUxhryCAMrkz8Y22g=";
+                hash = "sha256-+VkXL4GZQZKIbKCNSVkLv9YysmZKG9CK2vkN7f+gPEM=";
               };
 
               nativeBuildInputs =

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
                 pname = "fastpotify";
                 version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
                 src = self;
-                hash = "sha256-+VkXL4GZQZKIbKCNSVkLv9YysmZKG9CK2vkN7f+gPEM=";
+                hash = "sha256-zDdDKUcybY+ZwhejO03pTnZeURkJ2lzpqZL5HVkmHX4=";
               };
 
               nativeBuildInputs =

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -262,6 +262,8 @@ impl Drop for ActivityGuard<'_> {
 }
 
 pub struct ApiClient {
+    #[cfg(test)]
+    base_url: Option<String>,
     http: reqwest::Client,
     tokens: Mutex<Option<TokenProvider>>,
     limiter: Semaphore,
@@ -281,6 +283,8 @@ impl ApiClient {
         source: ApiSource,
     ) -> Self {
         Self {
+            #[cfg(test)]
+            base_url: None,
             http,
             tokens: Mutex::new(None),
             limiter: Semaphore::new(MAX_IN_FLIGHT),
@@ -328,10 +332,25 @@ impl ApiClient {
         query: &[(&str, String)],
         body: Option<&Value>,
     ) -> Result<String> {
+        self.send_body(method, path, query, body, None).await
+    }
+
+    async fn send_body(
+        &self,
+        method: Method,
+        path: &str,
+        query: &[(&str, String)],
+        body: Option<&Value>,
+        jpeg: Option<&str>,
+    ) -> Result<String> {
         let url = if path.starts_with("http") {
             path.to_string()
         } else {
-            format!("{BASE_URL}{path}")
+            #[cfg(test)]
+            let base = self.base_url.as_deref().unwrap_or(BASE_URL);
+            #[cfg(not(test))]
+            let base = BASE_URL;
+            format!("{base}{path}")
         };
         let provider = self.provider()?;
         let started = Instant::now();
@@ -356,7 +375,11 @@ impl ApiClient {
                 .request(method.clone(), &url)
                 .bearer_auth(&token)
                 .query(query);
-            if let Some(body) = body {
+            if let Some(jpeg) = jpeg {
+                request = request
+                    .header(reqwest::header::CONTENT_TYPE, "image/jpeg")
+                    .body(jpeg.to_owned());
+            } else if let Some(body) = body {
                 request = request.json(body);
             } else if matches!(method, Method::PUT | Method::POST | Method::DELETE) {
                 request = request.header(reqwest::header::CONTENT_LENGTH, "0");
@@ -700,6 +723,24 @@ impl ApiClient {
         serde_json::from_value(value).map_err(|error| ApiError::Decode(error.to_string()))
     }
 
+    pub async fn upload_playlist_cover(&self, id: &str, encoded: &str) -> Result<()> {
+        if encoded.is_empty() || encoded.len() > crate::playlist_cover::MAX_PAYLOAD {
+            return Err(ApiError::Status {
+                status: 413,
+                message: "Choose a smaller image.".into(),
+            });
+        }
+        self.send_body(
+            Method::PUT,
+            &format!("/playlists/{id}/images"),
+            &[],
+            None,
+            Some(encoded),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub async fn update_playlist(
         &self,
         id: &str,
@@ -1023,6 +1064,92 @@ impl ApiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cover_upload_sends_raw_base64_jpeg_and_reports_spotify_errors() {
+        use std::io::{Read, Write};
+        for status in [202, 403, 413] {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = std::thread::spawn(move || {
+                let (mut socket, _) = listener.accept().unwrap();
+                socket
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut received = Vec::new();
+                let mut buffer = [0; 1024];
+                loop {
+                    let count = socket.read(&mut buffer).unwrap();
+                    assert!(count > 0);
+                    received.extend_from_slice(&buffer[..count]);
+                    if let Some(end) = received.windows(4).position(|part| part == b"\r\n\r\n") {
+                        let headers = String::from_utf8_lossy(&received[..end]).to_lowercase();
+                        let length: usize = headers
+                            .lines()
+                            .find_map(|line| line.strip_prefix("content-length: "))
+                            .unwrap()
+                            .parse()
+                            .unwrap();
+                        if received.len() >= end + 4 + length {
+                            break;
+                        }
+                    }
+                }
+                write!(
+                    socket,
+                    "HTTP/1.1 {status} Test\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                )
+                .unwrap();
+                received
+            });
+            let http = reqwest::Client::new();
+            let mut client = ApiClient::new(
+                http.clone(),
+                Arc::new(NetActivity::default()),
+                20,
+                50,
+                ApiSource::Shared,
+            );
+            client.base_url = Some(format!("http://{address}"));
+            client.set_token_provider(Some(TokenProvider::Web(WebTokens::new(
+                http,
+                crate::auth::StoredToken {
+                    access_token: "test-only".into(),
+                    expires_at: u64::MAX,
+                    ..Default::default()
+                },
+                std::env::temp_dir().join("unused-cover-token"),
+                ApiSource::Shared,
+            ))));
+            let result = client
+                .upload_playlist_cover("test-playlist", "/9j/test")
+                .await;
+            if status == 202 {
+                assert!(result.is_ok());
+            } else {
+                assert_eq!(result.unwrap_err().status(), Some(status));
+            }
+            let received = String::from_utf8(server.join().unwrap()).unwrap();
+            assert!(received.starts_with("PUT /playlists/test-playlist/images HTTP/1.1"));
+            assert!(received.to_lowercase().contains("content-type: image/jpeg"));
+            assert_eq!(received.split("\r\n\r\n").nth(1), Some("/9j/test"));
+        }
+    }
+
+    #[tokio::test]
+    async fn oversized_cover_is_rejected_before_authentication_or_network() {
+        let client = ApiClient::new(
+            reqwest::Client::new(),
+            Arc::new(NetActivity::default()),
+            20,
+            50,
+            ApiSource::Shared,
+        );
+        let result = client
+            .upload_playlist_cover("test", &"x".repeat(crate::playlist_cover::MAX_PAYLOAD + 1))
+            .await;
+        assert_eq!(result.unwrap_err().status(), Some(413));
+    }
 
     #[test]
     fn play_request_body_shapes() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -278,6 +278,9 @@ pub struct App {
     accent_pending: HashSet<String>,
 
     pub dialog: Option<Dialog>,
+    cover_request: u64,
+    /// Successful uploads stay visible while Spotify propagates the new image.
+    uploaded_covers: std::collections::HashMap<String, crate::playlist_cover::Cover>,
     pub show_queue_panel: bool,
     pub show_lyrics_panel: bool,
     /// The track the lyrics below are for.
@@ -573,6 +576,8 @@ impl App {
             accents: HashMap::new(),
             accent_pending: HashSet::new(),
             dialog: None,
+            cover_request: 0,
+            uploaded_covers: Default::default(),
             show_queue_panel: session.queue_open.unwrap_or(false),
             show_lyrics_panel: false,
             lyrics_uri: None,
@@ -1239,6 +1244,13 @@ impl App {
                 continue;
             }
             match event {
+                Event::PlaylistCoverChosen {
+                    id,
+                    request,
+                    result,
+                } => {
+                    self.cover_chosen(&id, request, result);
+                }
                 Event::Auth(status) => self.handle_auth(status),
                 Event::Playback(status) => self.handle_playback(status),
                 Event::Receivers(receivers) => self.receivers = receivers,
@@ -1355,6 +1367,7 @@ impl App {
             }
             AuthStatus::WaitingForBrowser { url } => self.sign_in_url = Some(url.clone()),
             AuthStatus::SignedOut => {
+                self.uploaded_covers.clear();
                 self.sign_in_url = None;
                 self.web_app = None;
                 self.user = None;
@@ -3127,7 +3140,65 @@ impl App {
 
     // ---- api responses -------------------------------------------------------
 
-    fn handle_api(&mut self, response: ApiResponse) {
+    fn cover_chosen(
+        &mut self,
+        id: &str,
+        request: u64,
+        result: Result<Option<crate::playlist_cover::Cover>, String>,
+    ) {
+        if let Some(Dialog::EditPlaylist {
+            id: current, cover, ..
+        }) = &mut self.dialog
+            && current == id
+            && cover.request == Some(request)
+        {
+            cover.request = None;
+            match result {
+                Ok(Some(selected)) => {
+                    cover.selection = Some(selected);
+                    cover.error = None;
+                }
+                Ok(None) => {}
+                Err(error) => cover.error = Some(error),
+            }
+        }
+    }
+
+    fn set_playlist_cover(&mut self, id: &str, cover: &crate::playlist_cover::Cover) {
+        if let Some(page) = self.playlist_pages.get_mut(id)
+            && let Some(playlist) = page.playlist.get_mut()
+        {
+            playlist.images = cover_images(cover);
+        }
+        if let Some(playlists) = self.library.playlists.get_mut() {
+            for playlist in playlists.iter_mut().filter(|playlist| playlist.id == id) {
+                playlist.images = cover_images(cover);
+            }
+        }
+    }
+
+    fn handle_api(&mut self, mut response: ApiResponse) {
+        match &mut response {
+            ApiResponse::Playlist {
+                id,
+                result: Ok(playlist),
+                ..
+            } => {
+                if let Some(cover) = self.uploaded_covers.get(id) {
+                    playlist.images = cover_images(cover);
+                }
+            }
+            ApiResponse::MyPlaylists {
+                result: Ok(page), ..
+            } => {
+                for playlist in &mut page.items {
+                    if let Some(cover) = self.uploaded_covers.get(&playlist.id) {
+                        playlist.images = cover_images(cover);
+                    }
+                }
+            }
+            _ => {}
+        }
         match response {
             ApiResponse::Me(result) => match result {
                 Ok(user) => {
@@ -3672,6 +3743,29 @@ impl App {
                     Err(error) => {
                         self.toast_error(format!("Couldn't create the playlist: {error}"))
                     }
+                }
+            }
+            ApiResponse::PlaylistCoverUploaded { id, cover, result } => {
+                if let Some(Dialog::EditPlaylist {
+                    id: current,
+                    cover: draft,
+                    ..
+                }) = &mut self.dialog
+                    && *current == id
+                {
+                    draft.uploading = false;
+                    draft.error = result.as_ref().err().map(cover_error);
+                    if result.is_ok() {
+                        draft.selection = None;
+                    }
+                }
+                match result {
+                    Ok(()) => {
+                        self.set_playlist_cover(&id, &cover);
+                        self.uploaded_covers.insert(id, cover);
+                        self.toast("Playlist cover updated");
+                    }
+                    Err(error) => self.toast_error(cover_error(&error)),
                 }
             }
             ApiResponse::PlaylistUpdated { id, result } => {
@@ -5196,6 +5290,9 @@ impl App {
     // ---- actions -----------------------------------------------------------------
 
     fn apply_actions(&mut self, ctx: &egui::Context) {
+        for cover in self.uploaded_covers.values() {
+            ctx.include_bytes(cover.uri.clone(), cover.jpeg.clone());
+        }
         let mut actions = std::mem::take(&mut self.actions);
         while !actions.is_empty() {
             for action in actions.drain(..) {
@@ -5508,6 +5605,37 @@ impl App {
                     insert_before: to,
                     snapshot_id,
                 });
+            }
+            Action::ChoosePlaylistCover(id) => {
+                if let Some(Dialog::EditPlaylist {
+                    id: current, cover, ..
+                }) = &mut self.dialog
+                    && *current == id
+                    && cover.request.is_none()
+                    && !cover.uploading
+                {
+                    self.cover_request = self.cover_request.wrapping_add(1);
+                    cover.request = Some(self.cover_request);
+                    cover.error = None;
+                    self.backend.choose_playlist_cover(id, self.cover_request);
+                }
+            }
+            Action::UploadPlaylistCover(id) => {
+                if let Some(Dialog::EditPlaylist {
+                    id: current, cover, ..
+                }) = &mut self.dialog
+                    && *current == id
+                    && !cover.uploading
+                    && cover.request.is_none()
+                    && let Some(selected) = cover.selection.clone()
+                {
+                    cover.uploading = true;
+                    cover.error = None;
+                    self.backend.api(ApiRequest::UploadPlaylistCover {
+                        id,
+                        cover: selected,
+                    });
+                }
             }
             Action::ShowDialog(dialog) => self.dialog = Some(dialog),
             Action::CloseDialog => self.dialog = None,
@@ -6570,6 +6698,23 @@ fn cap_uris(uris: Vec<String>, index: u32) -> (Vec<String>, u32) {
     (uris[start..end].to_vec(), 0)
 }
 
+fn cover_images(cover: &crate::playlist_cover::Cover) -> Vec<crate::api::models::Image> {
+    vec![crate::api::models::Image {
+        url: cover.uri.clone(),
+        width: None,
+        height: None,
+    }]
+}
+
+fn cover_error(error: &crate::api::client::ApiError) -> String {
+    match error.status() {
+        Some(401) => "Spotify sign-in expired. Sign in again, then retry the cover upload.".into(),
+        Some(403) => "Spotify refused this cover. Check that you own the playlist, then sign in again to grant image upload permission. If using a personal app, reconnect it in Settings too.".into(),
+        Some(413) => "Spotify rejected the image size. Choose a smaller image.".into(),
+        _ => format!("Couldn't upload the cover: {error}. Try again."),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -7585,6 +7730,110 @@ mod tests {
         app.pick_row(&album, "v", 2, RowPick::Only, 10);
         assert_eq!(picked(&app, &album), vec![2]);
         assert!(picked(&app, &liked).is_empty());
+    }
+
+    fn cover_dialog(request: Option<u64>) -> Dialog {
+        Dialog::EditPlaylist {
+            id: "pl1".into(),
+            name: "Test".into(),
+            description: String::new(),
+            public: false,
+            cover: crate::playlist_cover::Draft {
+                request,
+                ..Default::default()
+            },
+        }
+    }
+
+    fn test_cover() -> crate::playlist_cover::Cover {
+        let pixels = image::RgbImage::from_pixel(16, 16, image::Rgb([220, 20, 40]));
+        let mut bytes = std::io::Cursor::new(Vec::new());
+        pixels
+            .write_to(&mut bytes, image::ImageFormat::Png)
+            .unwrap();
+        crate::playlist_cover::prepare(bytes.get_ref()).unwrap()
+    }
+
+    #[test]
+    fn cover_picker_cancellation_and_stale_completion_preserve_the_dialog() {
+        let mut app = test_app("cover-picker");
+        app.dialog = Some(cover_dialog(Some(2)));
+        app.cover_chosen("pl1", 1, Ok(Some(test_cover())));
+        let Some(Dialog::EditPlaylist { cover, .. }) = &app.dialog else {
+            panic!()
+        };
+        assert!(cover.selection.is_none());
+        assert_eq!(cover.request, Some(2));
+        app.cover_chosen("pl1", 2, Ok(None));
+        let Some(Dialog::EditPlaylist { cover, .. }) = &app.dialog else {
+            panic!()
+        };
+        assert!(cover.request.is_none());
+        assert!(cover.error.is_none());
+        app.dialog = None;
+        app.cover_chosen("pl1", 2, Ok(Some(test_cover())));
+        assert!(app.dialog.is_none());
+        app.backend.shutdown();
+    }
+
+    #[test]
+    fn failed_cover_upload_preserves_preview_and_success_refreshes_library_art() {
+        let mut app = test_app("cover-upload");
+        app.dialog = Some(cover_dialog(None));
+        let cover = test_cover();
+        if let Some(Dialog::EditPlaylist { cover: draft, .. }) = &mut app.dialog {
+            draft.selection = Some(cover.clone());
+            draft.uploading = true;
+        }
+        app.handle_api(ApiResponse::PlaylistCoverUploaded {
+            id: "pl1".into(),
+            cover: cover.clone(),
+            result: Err(crate::api::ApiError::Status {
+                status: 403,
+                message: "Forbidden".into(),
+            }),
+        });
+        let Some(Dialog::EditPlaylist { cover: draft, .. }) = &app.dialog else {
+            panic!()
+        };
+        assert!(!draft.uploading);
+        assert!(draft.selection.is_some());
+        assert!(draft.error.as_ref().unwrap().contains("sign in again"));
+        app.library.playlists = Loadable::Loaded(vec![Playlist {
+            id: "pl1".into(),
+            ..Default::default()
+        }]);
+        app.handle_api(ApiResponse::PlaylistCoverUploaded {
+            id: "pl1".into(),
+            cover: cover.clone(),
+            result: Ok(()),
+        });
+        assert_eq!(
+            app.library.playlists.get().unwrap()[0].images[0].url,
+            cover.uri
+        );
+        assert!(app.uploaded_covers.contains_key("pl1"));
+        app.handle_api(ApiResponse::MyPlaylists {
+            offset: 0,
+            result: Ok(crate::api::models::Page {
+                items: vec![Playlist {
+                    id: "pl1".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+        });
+        assert_eq!(
+            app.library.playlists.get().unwrap()[0].images[0].url,
+            cover.uri,
+            "lagging metadata must not undo the uploaded artwork"
+        );
+        let Some(Dialog::EditPlaylist { cover: draft, .. }) = &app.dialog else {
+            panic!()
+        };
+        assert!(draft.selection.is_none());
+        assert!(draft.error.is_none());
+        app.backend.shutdown();
     }
 
     fn test_app(name: &str) -> App {

--- a/src/app.rs
+++ b/src/app.rs
@@ -280,7 +280,7 @@ pub struct App {
     pub dialog: Option<Dialog>,
     cover_request: u64,
     /// Successful uploads stay visible while Spotify propagates the new image.
-    uploaded_covers: std::collections::HashMap<String, crate::playlist_cover::Cover>,
+    uploaded_covers: std::collections::HashMap<String, crate::playlist_cover::PendingCover>,
     pub show_queue_panel: bool,
     pub show_lyrics_panel: bool,
     /// The track the lyrics below are for.
@@ -3177,24 +3177,51 @@ impl App {
         }
     }
 
+    fn reconcile_playlist_cover(&mut self, id: &str, images: &mut Vec<crate::api::models::Image>) {
+        let Some(pending) = self.uploaded_covers.get(id) else {
+            return;
+        };
+        if !images.is_empty()
+            && images
+                .iter()
+                .all(|image| !pending.previous_urls.contains(&image.url))
+        {
+            self.uploaded_covers.remove(id);
+            if let Some(page) = self.playlist_pages.get_mut(id)
+                && let Some(playlist) = page.playlist.get_mut()
+            {
+                playlist.images = images.clone();
+            }
+            if let Some(playlists) = self.library.playlists.get_mut() {
+                for playlist in playlists.iter_mut().filter(|playlist| playlist.id == id) {
+                    playlist.images = images.clone();
+                }
+            }
+        } else {
+            *images = cover_images(&pending.cover);
+        }
+    }
+
     fn handle_api(&mut self, mut response: ApiResponse) {
         match &mut response {
             ApiResponse::Playlist {
                 id,
                 result: Ok(playlist),
-                ..
+                generation,
             } => {
-                if let Some(cover) = self.uploaded_covers.get(id) {
-                    playlist.images = cover_images(cover);
+                if self
+                    .playlist_pages
+                    .get(id)
+                    .is_some_and(|page| page.generation == *generation)
+                {
+                    self.reconcile_playlist_cover(id, &mut playlist.images);
                 }
             }
             ApiResponse::MyPlaylists {
                 result: Ok(page), ..
             } => {
                 for playlist in &mut page.items {
-                    if let Some(cover) = self.uploaded_covers.get(&playlist.id) {
-                        playlist.images = cover_images(cover);
-                    }
+                    self.reconcile_playlist_cover(&playlist.id, &mut playlist.images);
                 }
             }
             _ => {}
@@ -3745,15 +3772,22 @@ impl App {
                     }
                 }
             }
-            ApiResponse::PlaylistCoverUploaded { id, cover, result } => {
+            ApiResponse::PlaylistCoverUploaded {
+                id,
+                request,
+                previous_urls,
+                cover,
+                result,
+            } => {
                 if let Some(Dialog::EditPlaylist {
                     id: current,
                     cover: draft,
                     ..
                 }) = &mut self.dialog
                     && *current == id
+                    && draft.uploading == Some(request)
                 {
-                    draft.uploading = false;
+                    draft.uploading = None;
                     draft.error = result.as_ref().err().map(cover_error);
                     if result.is_ok() {
                         draft.selection = None;
@@ -3762,7 +3796,19 @@ impl App {
                 match result {
                     Ok(()) => {
                         self.set_playlist_cover(&id, &cover);
-                        self.uploaded_covers.insert(id, cover);
+                        self.uploaded_covers.insert(
+                            id.clone(),
+                            crate::playlist_cover::PendingCover {
+                                cover,
+                                previous_urls,
+                            },
+                        );
+                        if let Some(page) = self.playlist_pages.get(&id) {
+                            self.backend.api(ApiRequest::Playlist {
+                                id,
+                                generation: page.generation,
+                            });
+                        }
                         self.toast("Playlist cover updated");
                     }
                     Err(error) => self.toast_error(cover_error(&error)),
@@ -5291,7 +5337,7 @@ impl App {
 
     fn apply_actions(&mut self, ctx: &egui::Context) {
         for cover in self.uploaded_covers.values() {
-            ctx.include_bytes(cover.uri.clone(), cover.jpeg.clone());
+            ctx.include_bytes(cover.cover.uri.clone(), cover.cover.jpeg.clone());
         }
         let mut actions = std::mem::take(&mut self.actions);
         while !actions.is_empty() {
@@ -5612,7 +5658,7 @@ impl App {
                 }) = &mut self.dialog
                     && *current == id
                     && cover.request.is_none()
-                    && !cover.uploading
+                    && cover.uploading.is_none()
                 {
                     self.cover_request = self.cover_request.wrapping_add(1);
                     cover.request = Some(self.cover_request);
@@ -5621,18 +5667,43 @@ impl App {
                 }
             }
             Action::UploadPlaylistCover(id) => {
+                let previous_urls = self
+                    .uploaded_covers
+                    .get(&id)
+                    .map(|pending| pending.previous_urls.clone())
+                    .unwrap_or_else(|| {
+                        self.playlist_pages
+                            .get(&id)
+                            .and_then(|page| page.playlist.get())
+                            .into_iter()
+                            .chain(
+                                self.library
+                                    .playlists
+                                    .get()
+                                    .into_iter()
+                                    .flatten()
+                                    .filter(|playlist| playlist.id == id),
+                            )
+                            .flat_map(|playlist| {
+                                playlist.images.iter().map(|image| image.url.clone())
+                            })
+                            .collect()
+                    });
                 if let Some(Dialog::EditPlaylist {
                     id: current, cover, ..
                 }) = &mut self.dialog
                     && *current == id
-                    && !cover.uploading
+                    && cover.uploading.is_none()
                     && cover.request.is_none()
                     && let Some(selected) = cover.selection.clone()
                 {
-                    cover.uploading = true;
+                    self.cover_request = self.cover_request.wrapping_add(1);
+                    cover.uploading = Some(self.cover_request);
                     cover.error = None;
                     self.backend.api(ApiRequest::UploadPlaylistCover {
                         id,
+                        request: self.cover_request,
+                        previous_urls,
                         cover: selected,
                     });
                 }
@@ -7783,10 +7854,12 @@ mod tests {
         let cover = test_cover();
         if let Some(Dialog::EditPlaylist { cover: draft, .. }) = &mut app.dialog {
             draft.selection = Some(cover.clone());
-            draft.uploading = true;
+            draft.uploading = Some(1);
         }
         app.handle_api(ApiResponse::PlaylistCoverUploaded {
             id: "pl1".into(),
+            request: 1,
+            previous_urls: vec![],
             cover: cover.clone(),
             result: Err(crate::api::ApiError::Status {
                 status: 403,
@@ -7796,15 +7869,20 @@ mod tests {
         let Some(Dialog::EditPlaylist { cover: draft, .. }) = &app.dialog else {
             panic!()
         };
-        assert!(!draft.uploading);
+        assert!(draft.uploading.is_none());
         assert!(draft.selection.is_some());
         assert!(draft.error.as_ref().unwrap().contains("sign in again"));
         app.library.playlists = Loadable::Loaded(vec![Playlist {
             id: "pl1".into(),
             ..Default::default()
         }]);
+        if let Some(Dialog::EditPlaylist { cover: draft, .. }) = &mut app.dialog {
+            draft.uploading = Some(2);
+        }
         app.handle_api(ApiResponse::PlaylistCoverUploaded {
             id: "pl1".into(),
+            request: 2,
+            previous_urls: vec![],
             cover: cover.clone(),
             result: Ok(()),
         });
@@ -7834,6 +7912,125 @@ mod tests {
         assert!(draft.selection.is_none());
         assert!(draft.error.is_none());
         app.backend.shutdown();
+    }
+
+    #[test]
+    fn old_upload_completion_does_not_change_a_reopened_dialog() {
+        for succeeds in [false, true] {
+            for newer_upload in [None, Some(2)] {
+                let mut app = test_app("reopened-cover-upload");
+                app.dialog = Some(cover_dialog(None));
+                let selected = test_cover();
+                if let Some(Dialog::EditPlaylist { cover, .. }) = &mut app.dialog {
+                    cover.selection = Some(selected.clone());
+                    cover.uploading = Some(1);
+                }
+                app.dialog = None;
+                app.dialog = Some(cover_dialog(Some(3)));
+                if let Some(Dialog::EditPlaylist { cover, .. }) = &mut app.dialog {
+                    cover.selection = Some(selected.clone());
+                    cover.uploading = newer_upload;
+                    cover.error = Some("Newer selection error".into());
+                }
+                app.handle_api(ApiResponse::PlaylistCoverUploaded {
+                    id: "pl1".into(),
+                    request: 1,
+                    previous_urls: vec![],
+                    cover: selected.clone(),
+                    result: if succeeds {
+                        Ok(())
+                    } else {
+                        Err(crate::api::ApiError::Status {
+                            status: 403,
+                            message: "Forbidden".into(),
+                        })
+                    },
+                });
+                let Some(Dialog::EditPlaylist { cover, .. }) = &app.dialog else {
+                    panic!()
+                };
+                assert_eq!(cover.selection.as_ref().unwrap().uri, selected.uri);
+                assert_eq!(cover.uploading, newer_upload);
+                assert_eq!(cover.request, Some(3));
+                assert_eq!(cover.error.as_deref(), Some("Newer selection error"));
+                app.backend.shutdown();
+            }
+        }
+    }
+
+    #[test]
+    fn confirmed_spotify_art_retires_the_override_and_accepts_later_changes() {
+        for confirm_from_library in [false, true] {
+            let mut app = test_app("confirmed-cover");
+            let remote = |url: &str| {
+                vec![crate::api::models::Image {
+                    url: url.into(),
+                    width: None,
+                    height: None,
+                }]
+            };
+            let playlist = |url: &str| Playlist {
+                id: "pl1".into(),
+                images: remote(url),
+                ..Default::default()
+            };
+            app.library.playlists = Loadable::Loaded(vec![playlist("old")]);
+            let page = app.playlist_pages.entry("pl1".into()).or_default();
+            page.playlist = Loadable::Loaded(playlist("old"));
+            let generation = page.generation;
+            let cover = test_cover();
+            app.handle_api(ApiResponse::PlaylistCoverUploaded {
+                id: "pl1".into(),
+                request: 1,
+                previous_urls: vec!["old".into()],
+                cover: cover.clone(),
+                result: Ok(()),
+            });
+            app.handle_api(ApiResponse::Playlist {
+                id: "pl1".into(),
+                generation: generation + 1,
+                result: Ok(playlist("stale-generation")),
+            });
+            assert!(app.uploaded_covers.contains_key("pl1"));
+            for url in ["old", "confirmed", "changed-elsewhere"] {
+                if confirm_from_library {
+                    app.handle_api(ApiResponse::MyPlaylists {
+                        offset: 0,
+                        result: Ok(crate::api::models::Page {
+                            items: vec![playlist(url)],
+                            ..Default::default()
+                        }),
+                    });
+                } else {
+                    app.handle_api(ApiResponse::Playlist {
+                        id: "pl1".into(),
+                        generation,
+                        result: Ok(playlist(url)),
+                    });
+                }
+                let expected = if url == "old" { &cover.uri } else { url };
+                if confirm_from_library {
+                    assert_eq!(
+                        app.library.playlists.get().unwrap()[0].images[0].url,
+                        expected
+                    );
+                } else {
+                    assert_eq!(
+                        app.playlist_pages["pl1"].playlist.get().unwrap().images[0].url,
+                        expected
+                    );
+                }
+                assert_eq!(app.uploaded_covers.contains_key("pl1"), url == "old");
+                if url == "confirmed" {
+                    assert_eq!(app.library.playlists.get().unwrap()[0].images[0].url, url);
+                    assert_eq!(
+                        app.playlist_pages["pl1"].playlist.get().unwrap().images[0].url,
+                        url
+                    );
+                }
+            }
+            app.backend.shutdown();
+        }
     }
 
     fn test_app(name: &str) -> App {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -51,6 +51,7 @@ pub const PLAYBACK_SCOPES: &[&str] = &[
 /// plan (Free or Premium), which decides whether local playback is offered
 /// at all; no email.
 pub const WEB_SCOPES: &[&str] = &[
+    "ugc-image-upload",
     "playlist-modify-private",
     "playlist-modify-public",
     "playlist-read-collaborative",
@@ -472,6 +473,25 @@ fn failure_page(reason: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn old_web_grants_require_image_upload_consent() {
+        let token = StoredToken {
+            scope: WEB_SCOPES
+                .iter()
+                .filter(|scope| **scope != "ugc-image-upload")
+                .copied()
+                .collect::<Vec<_>>()
+                .join(" "),
+            ..Default::default()
+        };
+        assert!(!token.has_scopes(WEB_SCOPES));
+        let renewed = StoredToken {
+            scope: WEB_SCOPES.join(" "),
+            ..token
+        };
+        assert!(renewed.has_scopes(WEB_SCOPES));
+    }
 
     #[test]
     fn begin_produces_valid_pkce_material() {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -116,6 +116,10 @@ pub enum ApiRequest {
         public: bool,
         description: String,
     },
+    UploadPlaylistCover {
+        id: String,
+        cover: crate::playlist_cover::Cover,
+    },
     UpdatePlaylist {
         id: String,
         name: Option<String>,
@@ -310,6 +314,11 @@ pub enum ApiResponse {
         result: ApiResult<Page<PlaylistItem>>,
     },
     PlaylistCreated(ApiResult<Playlist>),
+    PlaylistCoverUploaded {
+        id: String,
+        cover: crate::playlist_cover::Cover,
+        result: ApiResult<()>,
+    },
     PlaylistUpdated {
         id: String,
         result: ApiResult<()>,
@@ -423,6 +432,12 @@ pub enum ApiResponse {
 }
 
 pub enum Command {
+    ChoosePlaylistCover {
+        id: String,
+        request: u64,
+        selected:
+            std::pin::Pin<Box<dyn std::future::Future<Output = Option<rfd::FileHandle>> + Send>>,
+    },
     /// Start (or restart) the Web API sign-in in the browser.
     SignIn,
     CancelSignIn,
@@ -510,6 +525,11 @@ pub struct LyricsRequest {
 }
 
 pub enum Event {
+    PlaylistCoverChosen {
+        id: String,
+        request: u64,
+        result: Result<Option<crate::playlist_cover::Cover>, String>,
+    },
     Auth(AuthStatus),
     Playback(LocalPlayback),
     /// Receivers seen on the local network that Spotify has not listed.
@@ -694,6 +714,23 @@ impl Backend {
         let _ = self.commands.send(command);
     }
 
+    /// Construct the native dialog on the UI thread, then await and read it
+    /// on the runtime. AppKit requires its window lookup on the main thread.
+    pub fn choose_playlist_cover(&self, id: String, request: u64) {
+        if self.offline {
+            return;
+        }
+        let selected = rfd::AsyncFileDialog::new()
+            .set_title("Choose playlist cover")
+            .add_filter("JPEG or PNG image", &["jpg", "jpeg", "png"])
+            .pick_file();
+        self.send(Command::ChoosePlaylistCover {
+            id,
+            request,
+            selected: Box::pin(selected),
+        });
+    }
+
     pub fn api(&self, request: ApiRequest) {
         #[cfg(test)]
         if let ApiRequest::PlaylistItems {
@@ -837,6 +874,33 @@ impl Worker {
         self.restore_session();
         while let Some(command) = commands.recv().await {
             match command {
+                Command::ChoosePlaylistCover {
+                    id,
+                    request,
+                    selected,
+                } => {
+                    let events = self.events.clone();
+                    let waker = self.waker.clone();
+                    tokio::spawn(async move {
+                        let selected = selected.await;
+                        let result = match selected {
+                            None => Ok(None),
+                            Some(file) => tokio::task::spawn_blocking(move || {
+                                crate::playlist_cover::read(file.path()).map(Some)
+                            })
+                            .await
+                            .unwrap_or_else(|_| {
+                                Err("Couldn't prepare that image. Try another file.".into())
+                            }),
+                        };
+                        let _ = events.send(Event::PlaylistCoverChosen {
+                            id,
+                            request,
+                            result,
+                        });
+                        waker.wake();
+                    });
+                }
                 Command::Shutdown => break,
                 Command::SignIn => self.sign_in(),
                 Command::CancelSignIn => {
@@ -1767,7 +1831,9 @@ fn operation_for(api: &ApiGateway, request: &ApiRequest) -> Operation {
         | ApiRequest::CheckPlaylistDuplicates {
             playlist_id: id, ..
         } => Operation::PlaylistItems(api.playlist_access(id)),
-        ApiRequest::UpdatePlaylist { id, .. } | ApiRequest::FollowPlaylist { id, .. } => {
+        ApiRequest::UploadPlaylistCover { id, .. }
+        | ApiRequest::UpdatePlaylist { id, .. }
+        | ApiRequest::FollowPlaylist { id, .. } => {
             Operation::PlaylistMutation(api.playlist_access(id))
         }
         ApiRequest::AddToPlaylist { playlist_id, .. }
@@ -1948,6 +2014,11 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> (ApiResponse, Option<A
             public,
             description,
         } => ApiResponse::PlaylistCreated(routed!(create_playlist(&name, public, &description))),
+        ApiRequest::UploadPlaylistCover { id, cover } => ApiResponse::PlaylistCoverUploaded {
+            result: routed!(upload_playlist_cover(&id, &cover.encoded)),
+            id,
+            cover,
+        },
         ApiRequest::UpdatePlaylist {
             id,
             name,
@@ -2249,5 +2320,50 @@ mod playlist_cache_tests {
         assert_eq!(stored.snapshot, "second");
         assert!(!path.with_extension("json.tmp").exists());
         let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[cfg(test)]
+mod cover_routing_tests {
+    use super::*;
+    use crate::api::gateway::{AccountId, PlaylistAccess};
+
+    #[test]
+    fn cover_upload_uses_the_existing_playlist_mutation_route() {
+        let api = ApiGateway::new(
+            reqwest::Client::new(),
+            std::sync::Arc::new(NetActivity::default()),
+        );
+        api.install(ApiSource::Shared, AccountId::new("me"))
+            .unwrap();
+        let request = ApiRequest::UploadPlaylistCover {
+            id: "test".into(),
+            cover: crate::playlist_cover::Cover {
+                jpeg: Vec::new().into(),
+                encoded: "".into(),
+                uri: String::new(),
+            },
+        };
+        assert_eq!(
+            operation_for(&api, &request),
+            Operation::PlaylistMutation(PlaylistAccess::Unknown)
+        );
+        let mut playlist = Playlist {
+            id: "test".into(),
+            ..Default::default()
+        };
+        playlist.owner.id = Some("me".into());
+        api.observe_playlist(&playlist);
+        assert_eq!(
+            operation_for(&api, &request),
+            Operation::PlaylistMutation(PlaylistAccess::Owned)
+        );
+        playlist.owner.id = Some("other".into());
+        playlist.collaborative = true;
+        api.observe_playlist(&playlist);
+        assert_eq!(
+            operation_for(&api, &request),
+            Operation::PlaylistMutation(PlaylistAccess::Collaborative)
+        );
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -118,6 +118,8 @@ pub enum ApiRequest {
     },
     UploadPlaylistCover {
         id: String,
+        request: u64,
+        previous_urls: Vec<String>,
         cover: crate::playlist_cover::Cover,
     },
     UpdatePlaylist {
@@ -316,6 +318,8 @@ pub enum ApiResponse {
     PlaylistCreated(ApiResult<Playlist>),
     PlaylistCoverUploaded {
         id: String,
+        request: u64,
+        previous_urls: Vec<String>,
         cover: crate::playlist_cover::Cover,
         result: ApiResult<()>,
     },
@@ -2014,7 +2018,14 @@ async fn handle(api: &ApiGateway, request: ApiRequest) -> (ApiResponse, Option<A
             public,
             description,
         } => ApiResponse::PlaylistCreated(routed!(create_playlist(&name, public, &description))),
-        ApiRequest::UploadPlaylistCover { id, cover } => ApiResponse::PlaylistCoverUploaded {
+        ApiRequest::UploadPlaylistCover {
+            id,
+            request,
+            previous_urls,
+            cover,
+        } => ApiResponse::PlaylistCoverUploaded {
+            request,
+            previous_urls,
             result: routed!(upload_playlist_cover(&id, &cover.encoded)),
             id,
             cover,
@@ -2338,6 +2349,8 @@ mod cover_routing_tests {
             .unwrap();
         let request = ApiRequest::UploadPlaylistCover {
             id: "test".into(),
+            request: 1,
+            previous_urls: vec![],
             cover: crate::playlist_cover::Cover {
                 jpeg: Vec::new().into(),
                 encoded: "".into(),

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -614,6 +614,15 @@ pub fn apply_flags(app: &mut App, page: Option<&str>, show: Option<&str>) {
             "devices" => app.show_devices = true,
             "shortcuts" => app.dialog = Some(Dialog::Shortcuts),
             "premium" => app.dialog = Some(Dialog::PremiumNeeded),
+            "edit" => {
+                app.dialog = Some(Dialog::EditPlaylist {
+                    id: "pl1".into(),
+                    name: "Long Way Home".into(),
+                    description: "Songs for the road".into(),
+                    public: false,
+                    cover: Default::default(),
+                });
+            }
             "create" => {
                 app.dialog = Some(Dialog::CreatePlaylist {
                     name: "Autumn drives".into(),
@@ -826,6 +835,76 @@ mod tests {
         app.attach(&ctx);
         populate(&mut app);
         (ctx, app)
+    }
+
+    #[test]
+    fn change_cover_button_dispatches_the_native_picker_action() {
+        let (ctx, mut app) = accessible_app("cover-button");
+        app.dialog = Some(Dialog::EditPlaylist {
+            id: "pl1".into(),
+            name: "Test".into(),
+            description: String::new(),
+            public: false,
+            cover: Default::default(),
+        });
+        let _ = accessible_frame(&ctx, &mut app, vec![]);
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let button = accessible_node(&tree, "Change cover", egui::accesskit::Role::Button);
+        let _ = accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(
+                button,
+                egui::accesskit::Action::Click,
+                None,
+            )],
+        );
+        let Some(Dialog::EditPlaylist { cover, .. }) = &app.dialog else {
+            panic!()
+        };
+        assert!(cover.request.is_some());
+        app.backend.shutdown();
+    }
+
+    #[test]
+    fn cover_editing_fits_large_and_narrow_windows_in_both_themes() {
+        for (width, height) in [(1240.0, 800.0), (760.0, 520.0)] {
+            for light in [false, true] {
+                let (ctx, mut app) = accessible_app("cover-dialog");
+                app.open(Page::Playlist("pl1".into()));
+                app.dialog = Some(Dialog::EditPlaylist {
+                    id: "pl1".into(),
+                    name: "Test".into(),
+                    description: String::new(),
+                    public: false,
+                    cover: Default::default(),
+                });
+                if light {
+                    app.settings.theme = crate::settings::ThemeChoice::Light;
+                    app.actions.push(Action::SettingsChanged);
+                }
+                if let Some(Dialog::EditPlaylist { cover, .. }) = &mut app.dialog {
+                    cover.error = Some("Spotify refused this cover. Check that you own the playlist, then sign in again to grant image upload permission.".into());
+                }
+                for _ in 0..3 {
+                    let mut output = ctx.run_ui(
+                        egui::RawInput {
+                            screen_rect: Some(egui::Rect::from_min_size(
+                                egui::Pos2::ZERO,
+                                egui::vec2(width, height),
+                            )),
+                            ..Default::default()
+                        },
+                        |ui| app.frame_ui(ui),
+                    );
+                    output.textures_delta.clear();
+                }
+                let rect = app.dialog_rect.unwrap();
+                assert!(rect.left() >= 0.0 && rect.top() >= 0.0, "{rect:?}");
+                assert!(rect.right() <= width && rect.bottom() <= height, "{rect:?}");
+                app.backend.shutdown();
+            }
+        }
     }
 
     fn accessible_frame(
@@ -1736,6 +1815,7 @@ mod tests {
                 add_uris: vec![],
             },
             Dialog::EditPlaylist {
+                cover: Default::default(),
                 id: "pl1".into(),
                 name: "x".into(),
                 description: String::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod model;
 pub mod opener;
 pub mod paths;
 pub mod player;
+pub mod playlist_cover;
 pub mod resample;
 pub mod settings;
 pub mod single_instance;

--- a/src/mac_links.rs
+++ b/src/mac_links.rs
@@ -38,7 +38,8 @@ mod mac_impl {
     const DIRECT_OBJECT: u32 = u32::from_be_bytes(*b"----");
 
     /// Where links go, and the wake that makes the app read them.
-    static SINK: Mutex<Option<(Arc<Mutex<Vec<ControlCommand>>>, Waker)>> = Mutex::new(None);
+    type LinkSink = (Arc<Mutex<Vec<ControlCommand>>>, Waker);
+    static SINK: Mutex<Option<LinkSink>> = Mutex::new(None);
 
     define_class!(
         #[unsafe(super(NSObject))]

--- a/src/model.rs
+++ b/src/model.rs
@@ -568,6 +568,7 @@ pub enum Dialog {
         add_uris: Vec<String>,
     },
     EditPlaylist {
+        cover: crate::playlist_cover::Draft,
         id: String,
         name: String,
         description: String,
@@ -683,6 +684,8 @@ pub enum Action {
         public: bool,
         add_uris: Vec<String>,
     },
+    ChoosePlaylistCover(String),
+    UploadPlaylistCover(String),
     UpdatePlaylist {
         id: String,
         name: String,

--- a/src/playlist_cover.rs
+++ b/src/playlist_cover.rs
@@ -1,0 +1,154 @@
+//! Bounded preparation of user-selected playlist artwork, off the UI thread.
+
+use std::io::{Cursor, Read};
+use std::path::Path;
+use std::sync::Arc;
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use image::{ImageDecoder, ImageFormat, ImageReader};
+
+/// Spotify limits the complete Base64 request body to 256 KB.
+pub const MAX_PAYLOAD: usize = 256_000;
+const MAX_FILE: usize = 20 * 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub struct Cover {
+    pub jpeg: Arc<[u8]>,
+    pub encoded: Arc<str>,
+    pub uri: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Draft {
+    pub selection: Option<Cover>,
+    pub request: Option<u64>,
+    pub uploading: bool,
+    pub error: Option<String>,
+}
+
+pub fn read(path: &Path) -> Result<Cover, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|_| "Couldn't open that image. Check that it is still available.".to_string())?;
+    if !file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return Err("Choose a JPEG or PNG file.".into());
+    }
+    let mut bytes = Vec::new();
+    file.take((MAX_FILE + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "Couldn't read that image. Try another file.".to_string())?;
+    prepare(&bytes)
+}
+
+pub fn prepare(bytes: &[u8]) -> Result<Cover, String> {
+    if bytes.len() > MAX_FILE {
+        return Err("Choose an image smaller than 20 MB.".into());
+    }
+    let format = image::guess_format(bytes).map_err(|_| "Choose a JPEG or PNG image.")?;
+    if !matches!(format, ImageFormat::Jpeg | ImageFormat::Png) {
+        return Err("Choose a JPEG or PNG image.".into());
+    }
+    let mut reader = ImageReader::with_format(Cursor::new(bytes), format);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(8192);
+    limits.max_image_height = Some(8192);
+    limits.max_alloc = Some(128 * 1024 * 1024);
+    reader.limits(limits);
+    let mut decoder = reader.into_decoder().map_err(|_| {
+        "Couldn't decode this image. Choose a valid JPEG or PNG no larger than 8192 pixels per side."
+    })?;
+    let orientation = decoder
+        .orientation()
+        .unwrap_or(image::metadata::Orientation::NoTransforms);
+    let mut image = image::DynamicImage::from_decoder(decoder)
+        .map_err(|_| "Couldn't decode this image. Try another JPEG or PNG.")?;
+    image.apply_orientation(orientation);
+    // Preserve the entire image and its aspect ratio. Flatten transparency
+    // onto white because JPEG has no alpha channel.
+    let mut pixels = image.thumbnail(640, 640).into_rgba8();
+    for pixel in pixels.pixels_mut() {
+        let alpha = u32::from(pixel[3]);
+        for channel in &mut pixel.0[..3] {
+            *channel = ((u32::from(*channel) * alpha + 255 * (255 - alpha) + 127) / 255) as u8;
+        }
+        pixel[3] = 255;
+    }
+    let original = image::DynamicImage::ImageRgba8(pixels);
+    for size in [640, 480, 320] {
+        let rgb = original.thumbnail(size, size).into_rgb8();
+        for quality in [90, 80, 70, 60] {
+            let mut jpeg = Vec::new();
+            image::codecs::jpeg::JpegEncoder::new_with_quality(&mut jpeg, quality)
+                .encode_image(&rgb)
+                .map_err(|_| "Couldn't encode this image. Try another file.")?;
+            let encoded = STANDARD.encode(&jpeg);
+            if encoded.len() <= MAX_PAYLOAD {
+                use sha2::{Digest, Sha256};
+                let uri = format!("bytes://playlist-cover-{:x}.jpg", Sha256::digest(&jpeg));
+                return Ok(Cover {
+                    jpeg: jpeg.into(),
+                    encoded: encoded.into(),
+                    uri,
+                });
+            }
+        }
+    }
+    Err("This image is too detailed for Spotify's upload limit. Choose a smaller image.".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_unsupported_and_oversized_files() {
+        assert!(prepare(b"not an image").is_err());
+        assert!(prepare(b"GIF89a").is_err());
+        assert!(prepare(&vec![0; MAX_FILE + 1]).is_err());
+    }
+
+    #[test]
+    fn jpeg_input_and_missing_file_are_handled() {
+        let image = image::RgbImage::from_pixel(24, 24, image::Rgb([30, 50, 70]));
+        let mut jpeg = Cursor::new(Vec::new());
+        image.write_to(&mut jpeg, ImageFormat::Jpeg).unwrap();
+        assert!(prepare(jpeg.get_ref()).is_ok());
+        let missing = std::env::temp_dir().join(format!(
+            "fastpotify-missing-cover-{}.jpg",
+            std::process::id()
+        ));
+        assert!(read(&missing).unwrap_err().contains("Couldn't open"));
+    }
+
+    #[test]
+    fn png_is_flattened_and_encoded_as_a_bounded_jpeg() {
+        let image = image::RgbaImage::from_pixel(1200, 600, image::Rgba([0, 0, 0, 0]));
+        let mut png = Cursor::new(Vec::new());
+        image.write_to(&mut png, ImageFormat::Png).unwrap();
+        let cover = prepare(png.get_ref()).unwrap();
+        assert!(cover.encoded.len() <= MAX_PAYLOAD);
+        assert_eq!(
+            STANDARD.decode(cover.encoded.as_bytes()).unwrap(),
+            &*cover.jpeg
+        );
+        let decoded = image::load_from_memory(&cover.jpeg).unwrap().into_rgb8();
+        assert_eq!(decoded.dimensions(), (640, 320));
+        assert!(
+            decoded
+                .pixels()
+                .all(|pixel| pixel.0.iter().all(|value| *value >= 250))
+        );
+    }
+
+    #[test]
+    fn detailed_image_still_fits_the_encoded_payload_limit() {
+        let mut state = 17_u32;
+        let image = image::RgbImage::from_fn(800, 800, |_, _| {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            image::Rgb([state as u8, (state >> 8) as u8, (state >> 16) as u8])
+        });
+        let mut png = Cursor::new(Vec::new());
+        image.write_to(&mut png, ImageFormat::Png).unwrap();
+        let cover = prepare(png.get_ref()).unwrap();
+        assert!(cover.encoded.len() <= MAX_PAYLOAD);
+    }
+}

--- a/src/playlist_cover.rs
+++ b/src/playlist_cover.rs
@@ -22,8 +22,15 @@ pub struct Cover {
 pub struct Draft {
     pub selection: Option<Cover>,
     pub request: Option<u64>,
-    pub uploading: bool,
+    pub uploading: Option<u64>,
     pub error: Option<String>,
+}
+
+/// Artwork held only until Spotify returns URLs different from those before upload.
+#[derive(Clone, Debug)]
+pub struct PendingCover {
+    pub cover: Cover,
+    pub previous_urls: Vec<String>,
 }
 
 pub fn read(path: &Path) -> Result<Cover, String> {

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -1187,6 +1187,7 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
 #[allow(dead_code)]
 fn playlist_dialog(app: &mut App, playlist: &Playlist) {
     app.actions.push(Action::ShowDialog(Dialog::EditPlaylist {
+        cover: Default::default(),
         id: playlist.id.clone(),
         name: playlist.name.clone(),
         description: playlist.description.clone().unwrap_or_default(),

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -312,9 +312,20 @@ fn create_playlist(app: &mut App, ui: &mut egui::Ui) {
 }
 
 fn edit_playlist(app: &mut App, ui: &mut egui::Ui) {
+    let existing_image = if let Some(Dialog::EditPlaylist { id, .. }) = &app.dialog {
+        app.library
+            .playlists
+            .get()
+            .and_then(|playlists| playlists.iter().find(|playlist| &playlist.id == id))
+            .and_then(|playlist| crate::api::models::pick_image(&playlist.images, 100))
+            .map(str::to_owned)
+    } else {
+        None
+    };
     let palette = app.palette;
     let busy = app.playlist_busy;
     let Some(Dialog::EditPlaylist {
+        cover,
         id,
         name,
         description,
@@ -325,32 +336,84 @@ fn edit_playlist(app: &mut App, ui: &mut egui::Ui) {
     };
     theme::text(ui, "Edit details", theme::bold(20.0), palette.text);
     ui.add_space(12.0);
-    theme::text(ui, "Name", theme::medium(13.0), palette.secondary);
-    text_field(ui, &palette, "edit-name", name, "Playlist name", true);
-    ui.add_space(10.0);
-    theme::text(ui, "Description", theme::medium(13.0), palette.secondary);
-    Frame::new()
-        .fill(palette.surface)
-        .corner_radius(CornerRadius::same(6))
-        .inner_margin(Margin::symmetric(12, 8))
+    egui::ScrollArea::vertical()
+        .max_height((ui.ctx().content_rect().height() - 210.0).max(100.0))
         .show(ui, |ui| {
-            ui.add(
-                egui::TextEdit::multiline(description)
-                    .id(egui::Id::new("edit-description"))
-                    .hint_text(egui::RichText::new("Optional description").color(palette.dim))
-                    .font(theme::regular(14.0))
-                    .frame(egui::Frame::NONE)
-                    .desired_rows(3)
-                    .desired_width(f32::INFINITY),
-            );
+            ui.horizontal(|ui| {
+                if let Some(selected) = &cover.selection {
+                    ui.ctx()
+                        .include_bytes(selected.uri.clone(), selected.jpeg.clone());
+                    ui.add(
+                        egui::Image::new(selected.uri.clone())
+                            .fit_to_exact_size(egui::vec2(72.0, 72.0))
+                            .alt_text("Selected playlist cover"),
+                    );
+                } else if let Some(url) = &existing_image {
+                    ui.add(
+                        egui::Image::new(url)
+                            .fit_to_exact_size(egui::vec2(72.0, 72.0))
+                            .alt_text("Current playlist cover"),
+                    );
+                }
+                ui.vertical(|ui| {
+                    if cover.request.is_some() || cover.uploading {
+                        theme::spinner(ui, 18.0, palette.accent);
+                        theme::text(
+                            ui,
+                            if cover.uploading {
+                                "Uploading cover…"
+                            } else {
+                                "Choosing cover…"
+                            },
+                            theme::regular(13.0),
+                            palette.secondary,
+                        );
+                    } else {
+                        if theme::pill_button(ui, &palette, "Change cover", false).clicked() {
+                            app.actions.push(Action::ChoosePlaylistCover(id.clone()));
+                        }
+                        if cover.selection.is_some()
+                            && theme::pill_button(ui, &palette, "Upload cover", true).clicked()
+                        {
+                            app.actions.push(Action::UploadPlaylistCover(id.clone()));
+                        }
+                    }
+                });
+            });
+            if let Some(error) = &cover.error {
+                ui.add(egui::Label::new(egui::RichText::new(error).color(palette.text)).wrap());
+            }
+            ui.add_space(10.0);
+            theme::text(ui, "Name", theme::medium(13.0), palette.secondary);
+            text_field(ui, &palette, "edit-name", name, "Playlist name", true);
+            ui.add_space(10.0);
+            theme::text(ui, "Description", theme::medium(13.0), palette.secondary);
+            Frame::new()
+                .fill(palette.surface)
+                .corner_radius(CornerRadius::same(6))
+                .inner_margin(Margin::symmetric(12, 8))
+                .show(ui, |ui| {
+                    ui.add(
+                        egui::TextEdit::multiline(description)
+                            .id(egui::Id::new("edit-description"))
+                            .hint_text(
+                                egui::RichText::new("Optional description").color(palette.dim),
+                            )
+                            .font(theme::regular(14.0))
+                            .frame(egui::Frame::NONE)
+                            .desired_rows(3)
+                            .desired_width(f32::INFINITY),
+                    );
+                });
+            ui.add_space(10.0);
+            ui.horizontal(|ui| {
+                super::widgets::switch(ui, &palette, "Public playlist", public);
+                theme::text(ui, "Public playlist", theme::regular(14.0), palette.text);
+            });
         });
-    ui.add_space(10.0);
-    ui.horizontal(|ui| {
-        super::widgets::switch(ui, &palette, "Public playlist", public);
-        theme::text(ui, "Public playlist", theme::regular(14.0), palette.text);
-    });
     ui.add_space(20.0);
     let id = id.clone();
+    let busy = busy || cover.uploading || cover.request.is_some();
     let name_value = name.trim().to_string();
     let description_value = description.trim().to_string();
     let public_value = *public;

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -356,11 +356,11 @@ fn edit_playlist(app: &mut App, ui: &mut egui::Ui) {
                     );
                 }
                 ui.vertical(|ui| {
-                    if cover.request.is_some() || cover.uploading {
+                    if cover.request.is_some() || cover.uploading.is_some() {
                         theme::spinner(ui, 18.0, palette.accent);
                         theme::text(
                             ui,
-                            if cover.uploading {
+                            if cover.uploading.is_some() {
                                 "Uploading cover…"
                             } else {
                                 "Choosing cover…"
@@ -413,7 +413,7 @@ fn edit_playlist(app: &mut App, ui: &mut egui::Ui) {
         });
     ui.add_space(20.0);
     let id = id.clone();
-    let busy = busy || cover.uploading || cover.request.is_some();
+    let busy = busy || cover.uploading.is_some() || cover.request.is_some();
     let name_value = name.trim().to_string();
     let description_value = description.trim().to_string();
     let public_value = *public;

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -505,6 +505,7 @@ pub fn context_menu_items(
     if let Some(playlist) = owned_playlist {
         if menu_item(ui, &palette, Some(Icon::Pencil), "Edit details") {
             app.actions.push(Action::ShowDialog(Dialog::EditPlaylist {
+                cover: Default::default(),
                 id: playlist.id.clone(),
                 name: playlist.name.clone(),
                 description: playlist


### PR DESCRIPTION
## Why

Playlist details can be edited in Fastpotify, but changing the cover requires another app. This adds cover uploads using Spotify's existing Web API endpoint.

## What changed

Feature, interaction, and renewed-consent scope remain pending a maintainer decision.

**Visible changes:** Edit details gains a cover preview, Change cover and Upload cover controls, busy feedback and retryable errors. The form scrolls when needed, keeping Save and Cancel visible. Upload cover saves artwork independently of Save, which still saves the existing details fields.

- Select a JPEG or PNG with a native async picker. Bound file size and decoding, apply orientation, preserve aspect ratio, flatten transparency onto white, and encode below Spotify's 256 KB Base64 limit.
- Send raw Base64 JPEG through the existing playlist mutation routing. Add `ugc-image-upload` consent and document shared sign-in and personal-app reconnection.
- Protect picker and upload completions with request identities. Preserve the selected preview after errors and hold uploaded artwork until Spotify returns changed artwork URLs; then retire the override so later external edits can appear.
- Add focused encoding, HTTP, routing, consent, cancellation, state and demo UI regression coverage, plus user and network documentation.

`rfd` supplies the cross-platform native picker. The branch incorporates upstream 0.7.0 and updates the Nix vendored-dependency hash.

## Verification

Passed on macOS Apple Silicon, Rust 1.98.0:

```sh
node --test .github/scripts/issue-assessment.test.cjs
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets
cargo test --locked --all-targets --all-features
cargo test --locked --all-features --doc
RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
# in docs:
bundle exec jekyll build
```

Both local test configurations passed 372 library tests and 5 binary tests; the 24 issue-assessment tests also passed. Coverage includes regressions for stale upload completions after reopening the dialog and old, confirmed, and externally changed artwork. Native live testing selected, previewed and uploaded existing artwork on a user-authorized owned playlist through the shared app. Authenticated Spotify image readback confirmed new artwork URLs and changed JPEG bytes. Cancellation state handling passed regression tests; native cancellation was not independently confirmed after the picker adjustment. Personal-app routing has automated coverage only. Linux and Windows were not compiled or run locally; cross-platform results are reported by CI.

[All eight native before/after screenshots and reproducible capture harnesses](https://github.com/dyd4dsh7/fastpotify/tree/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174). Captures use deterministic demo data at 1240 x 800 and 760 x 520 logical pixels, in both themes. Evidence is kept outside the implementation branch.

| Theme and size | Before | After |
| --- | --- | --- |
| dark, large | ![Before](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/before-dark-large.png) | ![After](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/after-dark-large.png) |
| dark, narrow | ![Before](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/before-dark-narrow.png) | ![After](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/after-dark-narrow.png) |
| light, large | ![Before](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/before-light-large.png) | ![After](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/after-light-large.png) |
| light, narrow | ![Before](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/before-light-narrow.png) | ![After](https://raw.githubusercontent.com/dyd4dsh7/fastpotify/3aba8d3fb350a9d0a9228a122af1f8ba1fda8174/screenshots/after-light-narrow.png) |

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.

Prepared and verified with Codex. The final contributor responsibility checkbox is left for human review.

