### PR TITLE
Read a skin whose text files were saved with a byte order mark

### DIFF
--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -171,9 +171,13 @@ impl Skin {
             });
         }
         let text = |file: &str| {
-            files
-                .get(file)
-                .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+            files.get(file).map(|bytes| {
+                // A skin edited on Windows carries a byte order mark, and U+FEFF is not
+                // whitespace, so `trim` leaves it on the first line: `[Text]` stops being a
+                // section header and the first `r,g,b` stops being a colour.
+                let text = String::from_utf8_lossy(bytes);
+                text.strip_prefix('\u{feff}').unwrap_or(&text).to_owned()
+            })
         };
         let playlist = text("pledit.txt")
             .map(|text| PlaylistStyle::parse(&text))
@@ -342,6 +346,26 @@ mod tests {
         assert_eq!(skin.playlist.normal, [0x12, 0x34, 0x56]);
         assert_eq!(skin.vis_colors[0], [9, 8, 7]);
         assert_eq!(skin.vis_colors[1], config::DEFAULT_VIS_COLORS[1]);
+    }
+
+    #[test]
+    fn a_skin_saved_with_a_byte_order_mark_is_still_read() {
+        const BOM: &[u8] = b"\xef\xbb\xbf";
+        let mut pledit = BOM.to_vec();
+        pledit.extend_from_slice(b"[Text]\r\nNormal=#123456\r\n");
+        let mut viscolor = BOM.to_vec();
+        viscolor.extend_from_slice(b"9,8,7\n1,2,3\n");
+
+        let archive = zip::write(&[
+            ("main.bmp", &png(275, 116, [1, 2, 3]), true),
+            ("pledit.txt", &pledit, false),
+            ("viscolor.txt", &viscolor, false),
+        ]);
+        let skin = Skin::from_archive("bom", &archive).unwrap();
+
+        assert_eq!(skin.playlist.normal, [0x12, 0x34, 0x56]);
+        assert_eq!(skin.vis_colors[0], [9, 8, 7]);
+        assert_eq!(skin.vis_colors[1], [1, 2, 3]);
     }
 
     #[test]


### PR DESCRIPTION
## Why

A skin whose text files were saved on Windows loses its colours, silently.

Notepad writes UTF-8 with a byte order mark by default, and a skin's `pledit.txt`, `viscolor.txt`
and `region.txt` are the files an author edits by hand. The mark decodes to U+FEFF, which is not in
Unicode's `White_Space`, so `str::trim` leaves it on the first line and every parser reads that line
as something else:

- `PlaylistStyle::parse` looks for `[` to open a section. The first line is `\u{feff}[Text]`, so the
  section never opens, `in_text` stays false, and every colour after it is skipped. The playlist
  draws in the default green on black however the skin was written.
- `parse_vis_colors` reads `r,g,b` a line at a time and keeps what parses. The first field is
  `\u{feff}15`, whose leading run of digits is empty, so that line yields nothing and is dropped by
  the `filter_map`. The palette then shifts: the background takes the grid's colour, the grid takes
  the first band's, and so on to the end.
- `parse_regions` opens its sections the same way as the playlist, so a skin's window shape is lost
  and the window draws as a rectangle.

Nothing warns. The skin loads, the bitmaps are right, and only the colours are wrong, which reads as
the skin being written that way.

## What changed

The mark is removed once, where the three files are decoded, rather than in each parser. That is the
single seam they share: `from_files` builds one `text` closure and hands its result to all three.

Only a leading mark is removed, and only one, which is what a mark is; a U+FEFF anywhere else in the
file is left alone.

## Tests

`a_skin_saved_with_a_byte_order_mark_is_still_read` builds a `.wsz` through the same
`Skin::from_archive` path the app uses, with a marked `pledit.txt` and a marked `viscolor.txt`, and
asserts the playlist colour and the first two palette entries.

Before this change it fails on the first assertion, with the default green where the skin's colour
should be:

```
assertion `left == right` failed
  left: [0, 255, 0]
 right: [18, 52, 86]
```

The palette assertion is the second half: `vis_colors[1]` is the shift, and it only reads `[1, 2, 3]`
once the first line survives.

## How I tested

Windows 11, toolchain 1.98.0 from `rust-toolchain.toml`. `cargo fmt --all --check`,
`cargo test --locked --all-targets` (325 passed, up from 324 by the new test) and
`cargo clippy --locked --all-targets -- -D warnings`, all with `--no-default-features` because this
machine has no vcpkg for MilkDrop; nothing here touches that feature. No platform-specific code, so
Linux and macOS behave the same; CI covers them.

No user-visible setting, file or network access changes, so no documentation change.
