### PR TITLE
Fold full-width punctuation onto the skin font's own cells

### DIFF
--- a/src/skin/font.rs
+++ b/src/skin/font.rs
@@ -34,7 +34,9 @@ pub fn cell(character: char) -> (u32, u32) {
 /// Whether the font has a real cell for the character, rather than the
 /// question mark it falls back to.
 pub fn covered(character: char) -> bool {
-    character == '?' || cell(character) != cell('?')
+    // Asked after folding, so a character that folds onto the question mark
+    // is covered by it: the full-width one is the same question mark.
+    fold(character) == '?' || cell(character) != cell('?')
 }
 
 /// The sprite for a character.
@@ -120,6 +122,10 @@ mod tests {
         assert_eq!(cell('\u{3000}'), cell(' '));
         // The full-width tilde takes the dash the ASCII one already took.
         assert_eq!(cell('\u{ff5e}'), cell('-'));
+        // The full-width question mark is the question mark, so it is a cell
+        // the font has rather than the fallback for one it does not.
+        assert_eq!(cell('\u{ff1f}'), cell('?'));
+        assert!(covered('\u{ff1f}'));
     }
 
     #[test]

--- a/src/skin/font.rs
+++ b/src/skin/font.rs
@@ -45,6 +45,17 @@ pub fn glyph(character: char) -> Sprite {
 
 /// Reduces a character to one the font has a cell for.
 fn fold(character: char) -> char {
+    // Full-width forms are the ASCII punctuation, digits and letters again,
+    // shifted up by 0xFEE0, and a Japanese or Korean release writes a title
+    // with them: a star is U+FF0A, a tilde U+FF5E, the brackets U+FF08 and
+    // U+FF09. Folding them is the same move as dropping an accent, and it
+    // matters more, because one uncovered character sends the whole line to
+    // a borrowed face instead of the skin's own font.
+    let character = match character {
+        '\u{ff01}'..='\u{ff5e}' => ((character as u32 - 0xfee0) as u8) as char,
+        '\u{3000}' => ' ',
+        other => other,
+    };
     match character {
         'a'..='z' => character.to_ascii_uppercase(),
         ' ' | '\t' | '\u{a0}' => ' ',
@@ -96,6 +107,32 @@ mod tests {
         assert_eq!(cell('('), (1, 13));
         assert_eq!(cell('-'), (1, 15));
         assert_eq!(cell('#'), (1, 30));
+    }
+
+    #[test]
+    fn full_width_forms_fold_to_the_shapes_they_are() {
+        assert_eq!(cell('\u{ff0a}'), cell('*'));
+        assert_eq!(cell('\u{ff08}'), cell('('));
+        assert_eq!(cell('\u{ff09}'), cell(')'));
+        assert_eq!(cell('\u{ff21}'), cell('A'));
+        assert_eq!(cell('\u{ff41}'), cell('A'));
+        assert_eq!(cell('\u{ff10}'), cell('0'));
+        assert_eq!(cell('\u{3000}'), cell(' '));
+        // The full-width tilde takes the dash the ASCII one already took.
+        assert_eq!(cell('\u{ff5e}'), cell('-'));
+    }
+
+    #[test]
+    fn a_title_punctuated_full_width_keeps_the_skin_font() {
+        // One uncovered character sends the whole line to a borrowed face,
+        // so a title written this way used to lose the skin's font outright.
+        assert!(
+            "\u{ff08}2026\u{ff09}\u{3000}REMIX\u{ff5e}"
+                .chars()
+                .all(covered)
+        );
+        // Kana is still not in the font, and still falls back.
+        assert!(!"\u{3042}".chars().all(covered));
     }
 
     #[test]


### PR DESCRIPTION
## Why

A title punctuated with full-width characters loses the skin's font entirely, not just those
characters.

`covered` decides per character whether `text.bmp` has a real cell for it, and both callers ask the
question of the whole string:

```rust
if text.chars().all(font::covered) { …skin font… } else { …borrowed face… }
```

`fold` already reduces a character to one the font has: lower case takes the capital, an accent is
dropped, a curly quote takes the straight one, `~` takes the dash. Full-width forms are missing from
it, so `＊`, `～`, `（`, `）` and the rest all reach `cell` unchanged, land on the question mark, and
`covered` says no. One of them anywhere in a title sends the entire line to a borrowed face.

They are not rare in the titles this affects. A Japanese or Korean release writes `（2026）`,
`ＲＥＭＩＸ`, `～`; the full-width forms are the normal punctuation there.

The font's own note says accented Latin letters "lose their accents rather than turning into
question marks". A full-width star is a star and a full-width tilde is a tilde, so the same rule
covers them, and here it decides a whole line rather than one glyph.

## What changed

`fold` maps U+FF01 to U+FF5E onto the ASCII range they mirror, which is a fixed offset of 0xFEE0,
and the ideographic space U+3000 onto a space. The existing arms then apply as they already do, so a
full-width lower-case letter still takes its capital and the full-width tilde still takes the dash
the ASCII one takes.

`covered` asks its question after folding. It used to compare the raw character against the question
mark, so `？` folded onto a cell the font really has and was still reported as uncovered. Now
anything that folds onto the question mark counts as covered by it, which is what the fold means.

Nothing else moves: a character outside those ranges reaches the same match it did before, and kana,
Han and hangul are still uncovered and still fall back, which is correct — the font has no cell for
them.

## Before and after

The mini player, built-in skin, playing a title whose only non-ASCII is full-width punctuation
(`--demo --demo-show winamp`, with the demo track renamed to `Rosewood（2026）～REMIX` for the shot):

Before — one full-width character sends the line to the borrowed face:

![before](https://raw.githubusercontent.com/kevin9327/fastpotify/assets-332/before.png)

After — the same title in the skin's own cells:

![after](https://raw.githubusercontent.com/kevin9327/fastpotify/assets-332/after.png)

## Tests

- `full_width_forms_fold_to_the_shapes_they_are` — `＊` is the star cell, `（` and `）` the bracket
  cells, `Ａ` and `ａ` the capital, `０` the digit, U+3000 the blank, `～` the dash, `？` the question
  mark and `covered('？')` is true. Before this change the star assertion fails with `left: (2, 3)`,
  the question mark, against `right: (2, 4)`, the star; before the `covered` change the last
  assertion fails on its own.
- `a_title_punctuated_full_width_keeps_the_skin_font` — the whole-string question both callers ask
  now answers yes for `（2026）　REMIX～`, and still answers no for kana, so the fallback is not
  weakened.

## How I tested

Windows 11, toolchain 1.98.0 from `rust-toolchain.toml`. `cargo fmt --all --check`,
`cargo test --locked --all-targets` (326 passed, up from 324 by the two new tests) and
`cargo clippy --locked --all-targets`, all with `--no-default-features` because this machine has no
vcpkg for MilkDrop; nothing here touches that feature. The captures above are from a
`--features demo` build. No platform-specific code.

## On #104

I overstated the connection in the first description, and have corrected it above. #104's follow-up
is about font fallback in the main window, which this change does not touch. What I took from that
thread is only the example: `＊〜アスタリスク` is the kind of title people were reporting, and it
still falls back here because of the kana. This change is about the neighbouring case — a title
whose only non-ASCII is full-width punctuation, which had no reason to lose the skin font and did.

No user-visible setting, file or network access changes, so no documentation change.
