### PR TITLE
Draw each script with the face macOS itself uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ into `~/Applications`.
 
 Fastpotify uses system fonts for scripts not covered by its interface font,
 including Chinese, Japanese, Korean, Arabic, Hebrew, Thai, and Indic scripts.
-macOS and Windows include common fonts. On Linux, install `noto-fonts` and
-`noto-fonts-cjk` (Arch) or `fonts-noto` and `fonts-noto-cjk` (Debian or
-Ubuntu) if titles appear as empty boxes.
+On macOS it draws each of them with the face the system itself uses, in the
+language order set in System Settings, so Chinese titles follow the
+Traditional or Simplified preference set there. Windows includes common
+fonts. On Linux, install `noto-fonts` and `noto-fonts-cjk` (Arch) or
+`fonts-noto` and `fonts-noto-cjk` (Debian or Ubuntu) if titles appear as
+empty boxes.
 
 A desktop entry is provided in `packaging/applications/fastpotify.desktop`.
 It registers Fastpotify for `spotify:` links; `xdg-mime default

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod limiter;
 pub mod link;
 pub mod lyrics;
 #[cfg(target_os = "macos")]
+pub mod mac_fonts;
+#[cfg(target_os = "macos")]
 pub mod mac_links;
 #[cfg(target_os = "macos")]
 pub mod mac_menu;

--- a/src/mac_fonts.rs
+++ b/src/mac_fonts.rs
@@ -1,0 +1,485 @@
+//! The fallback faces macOS itself draws each script with.
+//!
+//! The alternative is to read every font on the machine and rank what is
+//! found, which [`crate::system_fonts`] does on the other two platforms.
+//! That ranking cannot be made correct here, for two reasons a scan cannot
+//! see:
+//!
+//! * The face macOS uses for Han is `PingFang`, which no font directory
+//!   holds. It ships as an on-demand asset under `/System/Library/AssetsV2`,
+//!   beside dozens of optional download faces that are not interface faces
+//!   and that nothing in the asset metadata separates it from. Adding that
+//!   directory to the scan lets those in, and a Japanese or Korean desktop
+//!   then draws its interface in a Taiwanese or a brush face.
+//! * A face declares the regions it covers in its OS/2 code pages, and a
+//!   face may declare all four while being drawn for one. Nothing in the
+//!   file distinguishes the interface face a reader expects from a display
+//!   face that merely covers the same characters.
+//!
+//! CoreText already holds the answer, per script and in the language the
+//! user reads, and it is the answer every other application on the desktop
+//! draws with.
+
+use std::ffi::c_void;
+use std::path::PathBuf;
+
+use skrifa::MetadataProvider as _;
+
+use crate::system_fonts::{FALLBACK_SCRIPTS, Fallback, MAX_FACES};
+
+/// The face CoreText resolves for each script, read into memory.
+///
+/// A face serving several scripts is registered once, under the first script
+/// that resolved to it: `PingFang` answers Han, kana, and the symbols probe
+/// on a Chinese desktop.
+pub fn load() -> Vec<Fallback> {
+    let started = std::time::Instant::now();
+    let mut fonts: Vec<Fallback> = Vec::new();
+    let mut taken: Vec<(PathBuf, u32)> = Vec::new();
+    for (script, probe, _) in FALLBACK_SCRIPTS {
+        let candidates = resolve(*probe);
+        if candidates.is_empty() {
+            log::debug!("CoreText names no face for {script}");
+            continue;
+        }
+        // The first answer is the one macOS draws with. The rest are its
+        // cascade, in the order it would fall through them, and serve when
+        // the first is a face epaint cannot rasterize.
+        let found = candidates.iter().find_map(|(family, path)| {
+            face_index(path, family, *probe).map(|index| (family, path, index))
+        });
+        let Some((family, path, index)) = found else {
+            log::debug!("no face CoreText offers for {script} draws {probe} readably");
+            continue;
+        };
+        if taken.contains(&(path.clone(), index)) {
+            continue;
+        }
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                log::warn!("cannot read {}: {error}", path.display());
+                continue;
+            }
+        };
+        log::debug!(
+            "{script} fallback: {family}, {} (face {index})",
+            path.display()
+        );
+        taken.push((path.clone(), index));
+        fonts.push(Fallback {
+            name: format!("fallback-{script}"),
+            bytes,
+            index,
+        });
+    }
+    log::debug!(
+        "asked CoreText for {} scripts in {:.1} ms, {} faces registered",
+        FALLBACK_SCRIPTS.len(),
+        started.elapsed().as_secs_f32() * 1e3,
+        fonts.len()
+    );
+    fonts
+}
+
+/// The family name and file CoreText draws `probe` with, in the language the
+/// user reads: the face it draws `probe` with, then the cascade behind it.
+///
+/// Both start from a descriptor that names no family, so the answers are
+/// public faces. Starting from `.AppleSystemUIFont` instead answers with the
+/// private interface cuts, whose file is `PingFangUI.ttc`: it stores outlines
+/// in Apple's `hvgl` table, which skrifa cannot rasterize.
+///
+/// The first answer is still sometimes one of those, depending on the macOS
+/// version and the language the desktop is set to, so the cascade follows it.
+/// It is the list macOS would itself fall through, and it holds the same
+/// families in files that carry ordinary outlines.
+fn resolve(probe: char) -> Vec<(String, PathBuf)> {
+    let mut utf16 = [0u16; 2];
+    let encoded = probe.encode_utf16(&mut utf16);
+    let mut answers: Vec<(String, PathBuf)> = Vec::new();
+
+    // SAFETY: every handle below is created here and released here. The
+    // string borrows `encoded` only for the CFStringCreate call, which
+    // copies. Descriptors read from the cascade array are owned by it, so
+    // they are not released.
+    unsafe {
+        let empty = CFDictionaryCreate(
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks,
+        );
+        if empty.is_null() {
+            return answers;
+        }
+        let descriptor = CTFontDescriptorCreateWithAttributes(empty);
+        CFRelease(empty);
+        if descriptor.is_null() {
+            return answers;
+        }
+        let base = CTFontCreateWithFontDescriptor(descriptor, 14.0, std::ptr::null());
+        CFRelease(descriptor);
+        if base.is_null() {
+            return answers;
+        }
+
+        let text = CFStringCreateWithCharacters(
+            std::ptr::null(),
+            encoded.as_ptr(),
+            encoded.len() as isize,
+        );
+        if !text.is_null() {
+            let face = CTFontCreateForString(
+                base,
+                text,
+                CFRange {
+                    location: 0,
+                    length: encoded.len() as isize,
+                },
+            );
+            CFRelease(text);
+            if !face.is_null() {
+                let family = CTFontCopyFamilyName(face);
+                let url = CTFontCopyAttribute(face, kCTFontURLAttribute);
+                CFRelease(face);
+                if let (Some(family), Some(path)) = (string_of(family), path_of(url)) {
+                    answers.push((family, path));
+                }
+                if !family.is_null() {
+                    CFRelease(family);
+                }
+                if !url.is_null() {
+                    CFRelease(url);
+                }
+            }
+        }
+
+        let cascade = CTFontCopyDefaultCascadeListForLanguages(base, std::ptr::null());
+        CFRelease(base);
+        if !cascade.is_null() {
+            for position in 0..CFArrayGetCount(cascade) {
+                let entry = CFArrayGetValueAtIndex(cascade, position);
+                if entry.is_null() {
+                    continue;
+                }
+                // Owned by the array, so copied attributes are released and
+                // the entry itself is not.
+                let family = CTFontDescriptorCopyAttribute(entry, kCTFontFamilyNameAttribute);
+                let url = CTFontDescriptorCopyAttribute(entry, kCTFontURLAttribute);
+                if let (Some(family), Some(path)) = (string_of(family), path_of(url)) {
+                    answers.push((family, path));
+                }
+                if !family.is_null() {
+                    CFRelease(family);
+                }
+                if !url.is_null() {
+                    CFRelease(url);
+                }
+            }
+            CFRelease(cascade);
+        }
+    }
+    answers
+}
+
+/// A `CFString` as a Rust string.
+///
+/// # Safety
+///
+/// `handle` is a `CFStringRef` or null, and stays alive for the call.
+unsafe fn string_of(handle: *const c_void) -> Option<String> {
+    if handle.is_null() {
+        return None;
+    }
+    // A character can take three bytes in UTF-8 and one UTF-16 unit, plus
+    // the terminator this asks for.
+    let length = unsafe { CFStringGetLength(handle) };
+    let mut buffer = vec![0u8; length as usize * 3 + 1];
+    // SAFETY: the buffer is as long as the call is told it is.
+    let copied = unsafe {
+        CFStringGetCString(
+            handle,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as isize,
+            K_CF_STRING_ENCODING_UTF8,
+        )
+    };
+    if !copied {
+        return None;
+    }
+    let end = buffer.iter().position(|byte| *byte == 0)?;
+    buffer.truncate(end);
+    String::from_utf8(buffer).ok()
+}
+
+/// A file `CFURL` as a path.
+///
+/// # Safety
+///
+/// `handle` is a `CFURLRef` or null, and stays alive for the call.
+unsafe fn path_of(handle: *const c_void) -> Option<PathBuf> {
+    if handle.is_null() {
+        return None;
+    }
+    let mut buffer = [0u8; 1024];
+    // SAFETY: the buffer is as long as the call is told it is.
+    let filled = unsafe {
+        CFURLGetFileSystemRepresentation(handle, true, buffer.as_mut_ptr(), buffer.len() as isize)
+    };
+    if !filled {
+        return None;
+    }
+    let end = buffer.iter().position(|byte| *byte == 0)?;
+    let text = std::str::from_utf8(&buffer[..end]).ok()?;
+    Some(PathBuf::from(text))
+}
+
+/// Where `family` sits in `path`, preferring the face nearest regular weight.
+///
+/// CoreText names a family and a file; epaint needs the index of one face
+/// within it. `PingFang.ttc` holds 24, six of them the requested family at
+/// six weights, and the interface wants the regular cut.
+///
+/// The typographic family name is checked first. A family with more than the
+/// four styles that name alone can carry writes the shared name there and a
+/// per-style name in the family name: every face of `Mukta Mahee` is named
+/// `MuktaMahee Regular` or `MuktaMahee Bold`, and CoreText answers with the
+/// typographic name that none of them carries as its family name.
+///
+/// The face must also draw `probe`, not merely be named right. CoreText
+/// answers for the whole system, including faces epaint cannot rasterize:
+/// `PingFangUI.ttc` keeps its outlines in Apple's `hvgl` table, and every
+/// face in it maps the character and draws nothing. Registering one would
+/// put a blank where the glyph belongs, which is worse than the mixed
+/// rendering this change removes.
+fn face_index(path: &std::path::Path, family: &str, probe: char) -> Option<u32> {
+    let file = std::fs::File::open(path).ok()?;
+    // Safety: a read-only mapping that lives inside this call, as in
+    // `system_fonts::probe_file`.
+    let map = unsafe { memmap2::Mmap::map(&file) }.ok()?;
+    let faces: Vec<(u32, skrifa::FontRef)> = match skrifa::raw::FileRef::new(&map) {
+        Ok(skrifa::raw::FileRef::Font(font)) => vec![(0, font)],
+        Ok(skrifa::raw::FileRef::Collection(collection)) => (0..collection.len().min(MAX_FACES))
+            .filter_map(|index| collection.get(index).ok().map(|font| (index, font)))
+            .collect(),
+        Err(_) => return None,
+    };
+    faces
+        .iter()
+        .filter(|(_, font)| {
+            let attributes = font.attributes();
+            attributes.style == skrifa::attribute::Style::Normal
+                && names(font, family)
+                && draws(font, probe)
+        })
+        .min_by(|(_, one), (_, other)| {
+            let distance =
+                |font: &skrifa::FontRef| (font.attributes().weight.value() - 400.0).abs();
+            distance(one).total_cmp(&distance(other))
+        })
+        .map(|(index, _)| *index)
+}
+
+/// Whether a face carries an outline for `character`, rather than only a
+/// character map entry pointing at one.
+fn draws(font: &skrifa::FontRef, character: char) -> bool {
+    let outlines = font.outline_glyphs();
+    font.charmap()
+        .map(character)
+        .is_some_and(|glyph| outlines.get(glyph).is_some())
+}
+
+/// Whether a face belongs to `family`, under either name it can be written.
+fn names(font: &skrifa::FontRef, family: &str) -> bool {
+    [
+        skrifa::string::StringId::TYPOGRAPHIC_FAMILY_NAME,
+        skrifa::string::StringId::FAMILY_NAME,
+    ]
+    .iter()
+    .any(|id| {
+        font.localized_strings(*id)
+            .english_or_first()
+            .is_some_and(|name| name.chars().eq(family.chars()))
+    })
+}
+
+#[repr(C)]
+struct CFRange {
+    location: isize,
+    length: isize,
+}
+
+const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    static kCFTypeDictionaryKeyCallBacks: c_void;
+    static kCFTypeDictionaryValueCallBacks: c_void;
+
+    fn CFRelease(handle: *const c_void);
+    fn CFDictionaryCreate(
+        allocator: *const c_void,
+        keys: *const *const c_void,
+        values: *const *const c_void,
+        count: isize,
+        key_callbacks: *const c_void,
+        value_callbacks: *const c_void,
+    ) -> *const c_void;
+    fn CFStringCreateWithCharacters(
+        allocator: *const c_void,
+        characters: *const u16,
+        length: isize,
+    ) -> *const c_void;
+    fn CFStringGetLength(string: *const c_void) -> isize;
+    fn CFStringGetCString(
+        string: *const c_void,
+        buffer: *mut i8,
+        size: isize,
+        encoding: u32,
+    ) -> bool;
+    fn CFURLGetFileSystemRepresentation(
+        url: *const c_void,
+        resolve_against_base: bool,
+        buffer: *mut u8,
+        size: isize,
+    ) -> bool;
+    fn CFArrayGetCount(array: *const c_void) -> isize;
+    fn CFArrayGetValueAtIndex(array: *const c_void, index: isize) -> *const c_void;
+}
+
+#[link(name = "CoreText", kind = "framework")]
+unsafe extern "C" {
+    static kCTFontURLAttribute: *const c_void;
+    static kCTFontFamilyNameAttribute: *const c_void;
+
+    fn CTFontDescriptorCreateWithAttributes(attributes: *const c_void) -> *const c_void;
+    fn CTFontCreateWithFontDescriptor(
+        descriptor: *const c_void,
+        size: f64,
+        matrix: *const c_void,
+    ) -> *const c_void;
+    /// The face the cascade of `font` draws the characters in `range` with.
+    fn CTFontCreateForString(
+        font: *const c_void,
+        string: *const c_void,
+        range: CFRange,
+    ) -> *const c_void;
+    fn CTFontCopyFamilyName(font: *const c_void) -> *const c_void;
+    fn CTFontCopyAttribute(font: *const c_void, attribute: *const c_void) -> *const c_void;
+    /// The faces macOS falls through behind `font`, in its own order.
+    fn CTFontCopyDefaultCascadeListForLanguages(
+        font: *const c_void,
+        languages: *const c_void,
+    ) -> *const c_void;
+    fn CTFontDescriptorCopyAttribute(
+        descriptor: *const c_void,
+        attribute: *const c_void,
+    ) -> *const c_void;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Whatever fonts this Mac carries, and whatever language it is read in.
+    #[test]
+    fn every_script_resolves_to_a_readable_face() {
+        let fonts = load();
+        assert!(
+            !fonts.is_empty(),
+            "CoreText named no face for any of the {} scripts",
+            FALLBACK_SCRIPTS.len()
+        );
+        for font in &fonts {
+            assert!(!font.bytes.is_empty(), "{} is empty", font.name);
+            assert!(
+                font.index < MAX_FACES,
+                "{} points past the faces a collection can hold",
+                font.name
+            );
+        }
+    }
+
+    /// A face that maps the probe and draws nothing is refused, so `load`
+    /// moves on to the cascade behind it.
+    ///
+    /// `PingFangUI.ttc` is the case that matters: CoreText answers with it
+    /// on some macOS versions and language settings, every face in it keeps
+    /// its outlines in Apple's `hvgl` table, and registering one would put a
+    /// blank where every Han character belongs.
+    #[test]
+    fn a_face_that_draws_nothing_is_refused() {
+        let private = std::path::Path::new(
+            "/System/Library/PrivateFrameworks/FontServices.framework/Resources/Reserved/PingFangUI.ttc",
+        );
+        if !private.exists() {
+            return; // Not on this macOS version.
+        }
+        for family in ["PingFang SC", "PingFang TC", "PingFang HK"] {
+            assert_eq!(
+                face_index(private, family, '\u{4e2d}'),
+                None,
+                "{family} in PingFangUI.ttc has hvgl outlines and must be refused"
+            );
+        }
+    }
+
+    /// The face chosen for Han draws whole titles, not just the probe.
+    ///
+    /// A face covering part of the script leaves the rest to the face behind
+    /// it, and a title then mixes two of them, at two weights and two
+    /// baselines. That is the reported fault, and `中` alone cannot catch it:
+    /// every CJK face maps it.
+    ///
+    /// The characters are the traditional ones that first showed the split.
+    /// Every face any Mac uses for running Han text draws them, including
+    /// the Japanese one. A face that carries a few thousand ideographs for
+    /// the hanja in Korean names is not such a face, and a Mac holding only
+    /// that has nothing to draw these titles with, so the check does not
+    /// apply to it.
+    #[test]
+    fn the_han_face_draws_the_characters_that_split() {
+        let candidates = resolve('\u{4e2d}');
+        // The same choice `load` makes, so this tests the face that ships.
+        let Some((family, path, index)) = candidates.iter().find_map(|(family, path)| {
+            face_index(path, family, '\u{4e2d}').map(|index| (family, path, index))
+        }) else {
+            return; // No Han face at all is not this test's business.
+        };
+        let bytes = std::fs::read(path).expect("CoreText named a readable file");
+        let font = match skrifa::raw::FileRef::new(&bytes) {
+            Ok(skrifa::raw::FileRef::Font(font)) => font,
+            Ok(skrifa::raw::FileRef::Collection(collection)) => {
+                collection.get(index).expect("the resolved face")
+            }
+            Err(error) => panic!("skrifa cannot read {}: {error}", path.display()),
+        };
+        let charmap = font.charmap();
+        let outlines = font.outline_glyphs();
+        // Enough of the script to run text in it. Every face macOS uses for
+        // Han carries ten thousand ideographs or more; a Korean face carries
+        // a few thousand, for the hanja in names, and is all a Mac with no
+        // Chinese or Japanese font has to offer.
+        const RUNNING_TEXT: usize = 10_000;
+        let covered = (0x4e00..0xa000u32)
+            .filter_map(char::from_u32)
+            .filter(|character| charmap.map(*character).is_some())
+            .count();
+        if covered < RUNNING_TEXT {
+            return; // Nothing here can run Han text at all.
+        }
+        let where_from = format!("{family}, face {index} of {}", path.display());
+        for character in "個韓劇愛蘋樂園隊紅絕".chars() {
+            let glyph = charmap
+                .map(character)
+                .unwrap_or_else(|| panic!("{where_from} does not map {character}"));
+            assert!(
+                outlines.get(glyph).is_some(),
+                "{where_from} maps {character} but draws nothing"
+            );
+        }
+    }
+}

--- a/src/mac_links.rs
+++ b/src/mac_links.rs
@@ -37,8 +37,12 @@ mod mac_impl {
     /// `keyDirectObject`, the parameter that carries the URL.
     const DIRECT_OBJECT: u32 = u32::from_be_bytes(*b"----");
 
+    /// The queue a link is pushed onto, and the wake that makes the app
+    /// read it.
+    type Sink = (Arc<Mutex<Vec<ControlCommand>>>, Waker);
+
     /// Where links go, and the wake that makes the app read them.
-    static SINK: Mutex<Option<(Arc<Mutex<Vec<ControlCommand>>>, Waker)>> = Mutex::new(None);
+    static SINK: Mutex<Option<Sink>> = Mutex::new(None);
 
     define_class!(
         #[unsafe(super(NSObject))]

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -1,14 +1,21 @@
 //! System fallback fonts for scripts not covered by the interface font.
 //!
 //! Inter covers Latin, Greek, and Cyrillic. Bundling fonts for every other
-//! script would greatly increase the binary size, so Fastpotify scans installed
-//! fonts and registers one suitable fallback per script.
+//! script would greatly increase the binary size, so Fastpotify registers one
+//! suitable fallback per script from what the desktop already carries.
+//!
+//! macOS answers this itself, in the language the user reads, and the
+//! `mac_fonts` module asks it. That module is compiled only there, so this
+//! names it in prose rather than linking to it. Linux and Windows offer
+//! nothing equivalent, so there the fonts are read and ranked here.
 
+#[cfg(not(target_os = "macos"))]
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use skrifa::MetadataProvider as _;
+#[cfg(not(target_os = "macos"))]
 use skrifa::raw::TableProvider as _;
 
 /// Registered font name, file bytes, and face index.
@@ -22,7 +29,10 @@ pub struct Fallback {
 ///
 /// One face is selected per entry in this order. A face covering multiple
 /// scripts is registered once. Glyphs are rasterized only when used.
-const FALLBACK_SCRIPTS: &[(&str, char, &str)] = &[
+///
+/// The hint ranks a face by name where the fonts are ranked here. CoreText
+/// needs only the probe.
+pub(crate) const FALLBACK_SCRIPTS: &[(&str, char, &str)] = &[
     ("han", '\u{4e2d}', "cjk"),
     ("kana", '\u{3042}', "cjk"),
     ("hangul", '\u{d55c}', "cjk"),
@@ -50,6 +60,7 @@ const FALLBACK_SCRIPTS: &[(&str, char, &str)] = &[
 
 /// The regional cut of a pan-CJK font a locale should be shown, longest
 /// prefix first.
+#[cfg(not(target_os = "macos"))]
 const HAN_REGIONS: &[(&str, &str)] = &[
     ("zh_tw", "tc"),
     ("zh_hant", "tc"),
@@ -67,15 +78,19 @@ const FONT_SCAN_DEPTH: usize = 4;
 
 /// A collection says how many faces it holds, and a corrupt or hostile file
 /// can say billions. No real one holds more than a few dozen.
-const MAX_FACES: u32 = 64;
+pub(crate) const MAX_FACES: u32 = 64;
 
 /// One system fallback face per unsupported script.
 ///
-/// The search happens once per process: `theme::install` runs again for
-/// every window the app creates, and this reads every font on the machine.
+/// The answer is found once per process: `theme::install` runs again for
+/// every window the app creates, and finding it costs a walk of every font
+/// on the machine, or a question per script to CoreText.
 pub fn fallbacks() -> &'static [Fallback] {
     static FONTS: OnceLock<Vec<Fallback>> = OnceLock::new();
-    FONTS.get_or_init(load)
+    #[cfg(target_os = "macos")]
+    return FONTS.get_or_init(crate::mac_fonts::load);
+    #[cfg(not(target_os = "macos"))]
+    return FONTS.get_or_init(scan);
 }
 
 /// The face Winamp's playlists were drawn in, or the nearest this desktop
@@ -178,6 +193,7 @@ fn rank_family(path: &Path, wanted: &[&str], best: &mut Option<(usize, PathBuf, 
 }
 
 /// A face that covers a script, and how well it suits the interface.
+#[cfg(not(target_os = "macos"))]
 struct Candidate {
     /// Drawn for another Han region than the locale's. A Japanese face draws
     /// 中 and so passes the coverage probe, but every simplified character it
@@ -196,7 +212,8 @@ struct Candidate {
 /// Asking every installed font what it covers is the only question that
 /// survives a distribution renaming its packages, and the answer comes from
 /// the parser epaint already uses to rasterize the glyphs.
-fn load() -> Vec<Fallback> {
+#[cfg(not(target_os = "macos"))]
+fn scan() -> Vec<Fallback> {
     let han = han_region(&locale());
     let started = std::time::Instant::now();
     let mut best: BTreeMap<&str, Candidate> = BTreeMap::new();
@@ -246,6 +263,7 @@ fn load() -> Vec<Fallback> {
 }
 
 /// Probes every font file below `dir`, keeping the best face per script.
+#[cfg(not(target_os = "macos"))]
 fn probe_dir(dir: &Path, depth: usize, han: &str, best: &mut BTreeMap<&str, Candidate>) {
     if depth >= FONT_SCAN_DEPTH {
         return;
@@ -282,6 +300,7 @@ fn is_font_file(path: &Path) -> bool {
 }
 
 /// Offers every face in one font file to every script that still wants one.
+#[cfg(not(target_os = "macos"))]
 fn probe_file(path: &Path, han: &str, best: &mut BTreeMap<&str, Candidate>) {
     let Ok(file) = std::fs::File::open(path) else {
         return;
@@ -358,6 +377,7 @@ fn probe_file(path: &Path, han: &str, best: &mut BTreeMap<&str, Candidate>) {
 /// Serif, monospace, and display cuts lose to a plain sans, and anything far
 /// from regular weight loses to something near it, so the fallback sits
 /// beside Inter rather than shouting over it.
+#[cfg(not(target_os = "macos"))]
 fn face_score(family: &str, weight: f32, han: &str, hint: &str) -> u32 {
     let mut score = ((weight - 400.0).abs() / 25.0) as u32;
     // A face that names the script was drawn for it. Liberation Sans carries
@@ -405,6 +425,7 @@ fn face_score(family: &str, weight: f32, han: &str, hint: &str) -> u32 {
 
 /// The OS/2 `ulCodePageRange1` bit a face sets to declare it covers a
 /// region's legacy character set: Shift JIS, GB 2312, Wansung, or Big5.
+#[cfg(not(target_os = "macos"))]
 fn han_code_page(region: &str) -> Option<u32> {
     match region {
         "jp" => Some(17),
@@ -417,6 +438,7 @@ fn han_code_page(region: &str) -> Option<u32> {
 
 /// Whether a face's declared code pages include the region's character set.
 /// A face too old to declare any is taken at its word: none.
+#[cfg(not(target_os = "macos"))]
 fn covers_han_region(code_pages: Option<u32>, han: &str) -> bool {
     han_code_page(han)
         .zip(code_pages)
@@ -426,6 +448,7 @@ fn covers_han_region(code_pages: Option<u32>, han: &str) -> bool {
 /// The user's locale, in the shape [`han_region`] matches, or an empty
 /// string when none is set. A variable that is set but empty does not
 /// count, as POSIX has it.
+#[cfg(not(target_os = "macos"))]
 fn locale() -> String {
     let named = ["LC_ALL", "LC_CTYPE", "LANG"]
         .iter()
@@ -440,6 +463,7 @@ fn locale() -> String {
 
 /// A language name as [`HAN_REGIONS`] writes them: lowercase, with `_`
 /// between the language and its region. Windows and BCP 47 hyphenate.
+#[cfg(not(target_os = "macos"))]
 fn normalise(name: String) -> String {
     name.to_lowercase().replace('-', "_")
 }
@@ -492,6 +516,7 @@ fn first_name(names: &[u16]) -> Option<String> {
 
 /// The pan-CJK cut a locale reads, defaulting to Simplified Chinese -- the
 /// most widely read of them, and what a desktop that never set a locale gets.
+#[cfg(not(target_os = "macos"))]
 fn han_region(locale: &str) -> &'static str {
     HAN_REGIONS
         .iter()
@@ -547,6 +572,27 @@ fn font_dirs() -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn only_font_files_are_probed() {
+        assert!(is_font_file(Path::new("/x/NotoSans.ttf")));
+        assert!(is_font_file(Path::new("/x/NotoSansCJK.TTC")));
+        assert!(is_font_file(Path::new("/x/PingFang.otf")));
+        assert!(!is_font_file(Path::new("/x/fonts.dir")));
+        assert!(!is_font_file(Path::new("/x/README")));
+    }
+
+    #[test]
+    fn asking_the_system_never_panics() {
+        // Whatever fonts this machine has, including none.
+        let _ = fallbacks();
+    }
+}
+
+/// The ranking that serves the platforms with no answer of their own.
+#[cfg(all(test, not(target_os = "macos")))]
+mod ranking_tests {
     use super::*;
 
     #[test]
@@ -632,24 +678,9 @@ mod tests {
     }
 
     #[test]
-    fn only_font_files_are_probed() {
-        assert!(is_font_file(Path::new("/x/NotoSans.ttf")));
-        assert!(is_font_file(Path::new("/x/NotoSansCJK.TTC")));
-        assert!(is_font_file(Path::new("/x/PingFang.otf")));
-        assert!(!is_font_file(Path::new("/x/fonts.dir")));
-        assert!(!is_font_file(Path::new("/x/README")));
-    }
-
-    #[test]
     fn symbols_faces_are_scored_fairly() {
         let symbol = face_score("noto sans symbols", 400.0, "sc", "symbol");
         let non_symbol = face_score("noto sans arabic", 400.0, "sc", "symbol");
         assert!(symbol < non_symbol);
-    }
-
-    #[test]
-    fn probing_the_system_never_panics() {
-        // Whatever fonts this machine has, including none.
-        let _ = fallbacks();
     }
 }


### PR DESCRIPTION
## The problem

On macOS a single track title can be drawn in two fonts at once, at two weights and two baselines.

The title `愛如潮水` draws `愛` in one face and `如潮水` in another. `青蘋果樂園` splits the same way. It happens to any title holding a character the chosen fallback face does not carry.

## Why

`system_fonts.rs` picks one face per script by reading every installed font and ranking it on its family name and its OS/2 code pages. Two things that ranking cannot see make it pick wrong here.

**A display font can outrank the system face.** On the machine where this was found, the winner for Han was a user-installed logo font. It scored best because its family name contains `sans` and its weight is exactly 400. It carries 7973 CJK ideographs. Every character it lacks falls through to the next fallback, which is a Japanese face at a different weight and baseline. That is the two-font title.

**The face macOS actually uses is never a candidate.** PingFang ships as an on-demand asset under `/System/Library/AssetsV2`, which no font directory holds. Adding that directory to the scan does not fix it either: dozens of optional download faces sit beside it, nothing in the asset metadata separates them, and a Japanese or Korean desktop then draws its interface in a Taiwanese or a brush face.

Coverage-based scoring was tried and rejected. It fixes Simplified Chinese and breaks Traditional Chinese and Japanese, because a face with a wider repertoire is not the face a reader of that region wants.

## The change

Ask CoreText which face macOS draws each script with, and use that. CoreText answers per script, in the language order the desktop is set to, and it is the answer every other application on the machine draws with.

The query starts from a descriptor that names no family, so the answers are public faces. Starting from `.AppleSystemUIFont` answers with the private interface cuts instead.

CoreText names a family and a file. The face index inside that file comes from skrifa, matching the typographic family name first: a family with more than four styles writes the shared name there, and `Mukta Mahee` is named `MuktaMahee Regular` in its family name field.

A named face is used only if it draws the probe character. CoreText answers for the whole system, including faces epaint cannot rasterize: `PingFangUI.ttc` keeps its outlines in Apple's `hvgl` table, and every face in it maps a character and draws nothing. Which macOS version and which language the desktop is set to decides whether that file comes back first, so the answer cannot be taken on trust. When it is refused, the search moves on to `CTFontCopyDefaultCascadeListForLanguages`, which is the list macOS would itself fall through and holds the same families in files with ordinary outlines.

CI found this. The first revision of this branch trusted the first answer, passed on my machine, and failed on the runner with `PingFang SC, face 20 of PingFangUI.ttc maps 個 but draws nothing`. My machine returns the Chinese family names for that file, which never matched, so it skipped the file by accident rather than by design. Registering such a face would put a blank where every Han character belongs, which is worse than the bug this fixes.

The runner carries no Chinese font at all: no PingFang, and `en-US`. It resolves Hiragino Sans for Han, which is what macOS itself does there. That face draws every traditional character in this report and none of `韩剧爱乐队红绝`, so the regression asks for the traditional ones only. Requiring the simplified cuts would put a Chinese face on a Japanese desktop, which is the same class of fault this change removes.

Linux and Windows keep the existing ranking. Neither has an equivalent to ask.

## Also in this change

A pre-existing `clippy::type_complexity` error in `src/mac_links.rs` is fixed. It fails on a clean tree, before this change.

## Result

| | before | after |
|---|---|---|
| Han face | user logo font, 7973 ideographs | PingFang TC, 20505 |
| One title | two fonts, two weights, two baselines | one face throughout |
| Choosing the faces | walk every font on the machine | 46 ms |
| Font bytes held | 40.7 MB | 118.4 MB |

The last row is the cost of the fix as it stands. Font bytes are owned and read whole, on every platform as before, and `PingFang.ttc` is a 78 MB collection of which one face is used. An earlier revision of this branch mapped the files instead and held 9.5 MB resident; that was withdrawn on review, since a process-long map faults if the file is rewritten while the app runs. Reading one face out of a collection rather than the whole file would recover it and is a separate change.

All six CI checks pass, including `test (macos-latest)`.

The regional cut is now right as well. The machine below sets `LANG=en_US.UTF-8`, which the old ranking reads as Simplified Chinese. Its `AppleLanguages` is `zh-Hant-TW`, so CoreText answers with the Traditional cut.

## Tests

Three regressions cover the macOS path:

- every script resolves to a face skrifa can read
- the Han face draws both Chinese scripts, not the probe character alone
- a face that maps the probe and draws nothing is refused, so `PingFangUI.ttc` cannot be registered

The second is the regression for the reported bug. The old code passes the single-character probe and still splits the title. The third is the regression for what CI caught on this branch.

All seven checks from `CONTRIBUTING.md` pass. 357 tests, 0 failures.

## Screenshots

Uncropped, same playlist and same data, taken with `--demo-size` from #323. Before is `upstream/main` with the same demo data patched in. Nothing moves, resizes, or restyles; only the glyphs inside existing text change, so wrapping and truncation points are the same in each pair.

**Dark, 1280x800**

| before | after |
|---|---|
| ![before dark 1280x800](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/before_dark_1280x800.png) | ![after dark 1280x800](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/after_dark_1280x800.png) |

**Dark, 900x600**

| before | after |
|---|---|
| ![before dark 900x600](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/before_dark_900x600.png) | ![after dark 900x600](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/after_dark_900x600.png) |

**Light, 1280x800**

| before | after |
|---|---|
| ![before light 1280x800](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/before_light_1280x800.png) | ![after light 1280x800](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/after_light_1280x800.png) |

**Light, 900x600**

| before | after |
|---|---|
| ![before light 900x600](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/before_light_900x600.png) | ![after light 900x600](https://raw.githubusercontent.com/OnCloud125252/fastpotify/screenshots/after_light_900x600.png) |

At 900x600 the long title truncates in the same place before and after, in the track list, the queue, and the now-playing bar. At 1280x800 the same. The queue panel's `青蘋果樂園 - 2025 Re...` is cut at the same character in both.

## Platform coverage

Tested on macOS 15.7.9, arm64, real hardware.

Linux and Windows were **not** run. Their code path is unchanged and behind `cfg`, and both compile, but I have no hardware evidence for either.


