### PR TITLE
feat: follow the Linux desktop palette in system theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ everyday use, and connection details.
   starts.
 - **Album-art colour.** Pages and the player bar take a tint from the cover
   of what you are looking at or listening to. Turn it off in Settings.
-- **Light and dark**, or follow the system.
+- **Light and dark**, or follow the system. On Linux, follow system also
+  uses the active Omarchy desktop palette when
+  `~/.config/omarchy/current/theme/colors.toml` is present.
 - **Winamp mini player.** `Ctrl+M` opens a small player for classic `.wsz`
   skins, drawn at 1x to 4x scale. It includes a spectrum analyser, playlist,
   and equalizer. Drop a skin from the

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -72,7 +72,7 @@ main fields are:
 | `gapless` | `true` | Gapless playback |
 | `audio_backend` | platform | `pulseaudio` or `rodio` on Linux |
 | `audio_cache_mb` | `1024` | On-disk audio cache budget |
-| `theme` | `dark` | `dark`, `light`, or `system` |
+| `theme` | `dark` | `dark`, `light`, or `system`. `system` follows the OS light/dark setting. On Linux it also reads Omarchy's `~/.config/omarchy/current/theme/colors.toml` when that file exists. |
 | `accent_from_art` | `true` | Tint pages with album art |
 | `sidebar_compact` | `false` | Names only in the library sidebar, no covers |
 | `tracklist_compact` | `false` | One-line track rows without covers |

--- a/src/app.rs
+++ b/src/app.rs
@@ -2105,12 +2105,18 @@ impl App {
 
     fn apply_theme(&mut self, ctx: &egui::Context) {
         let dark = ctx.theme() == egui::Theme::Dark;
-        if self.applied_dark != Some(dark) {
-            self.palette = if dark {
-                Palette::dark()
-            } else {
-                Palette::light()
-            };
+        let palette = if self.settings.theme == ThemeChoice::System {
+            // Linux desktop palettes can change while the window is idle.
+            #[cfg(target_os = "linux")]
+            ctx.request_repaint_after(Duration::from_secs(1));
+            Palette::from_system(dark)
+        } else if dark {
+            Palette::dark()
+        } else {
+            Palette::light()
+        };
+        if self.applied_dark != Some(dark) || self.palette != palette {
+            self.palette = palette;
             theme::apply(ctx, &self.palette);
             self.applied_dark = Some(dark);
             self.accents.clear();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -72,6 +72,110 @@ impl Palette {
         }
     }
 
+    /// Follows the OS light/dark setting, and on Linux also the active
+    /// desktop palette when Omarchy publishes one. Missing or unreadable
+    /// palette files use the built-in light or dark colours. A half-written
+    /// file keeps the last complete palette; deleting the file drops back
+    /// to the built-in colours.
+    pub fn from_system(dark: bool) -> Self {
+        #[cfg(not(target_os = "linux"))]
+        {
+            if dark { Self::dark() } else { Self::light() }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Self::from_linux_desktop(dark)
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn from_linux_desktop(dark: bool) -> Self {
+        use std::sync::{Mutex, OnceLock};
+        use std::time::SystemTime;
+
+        struct Cache {
+            mtime: Option<SystemTime>,
+            last_good: Option<Palette>,
+        }
+
+        static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+        let cache = CACHE.get_or_init(|| {
+            Mutex::new(Cache {
+                mtime: None,
+                last_good: None,
+            })
+        });
+        let mut cached = cache.lock().unwrap_or_else(|poison| poison.into_inner());
+        let Some(path) = linux_palette_file() else {
+            cached.mtime = None;
+            cached.last_good = None;
+            return if dark { Self::dark() } else { Self::light() };
+        };
+        let mtime = std::fs::metadata(&path)
+            .ok()
+            .and_then(|meta| meta.modified().ok());
+        if mtime.is_none() {
+            cached.mtime = None;
+            cached.last_good = None;
+            return if dark { Self::dark() } else { Self::light() };
+        }
+        if cached.mtime == mtime
+            && let Some(palette) = cached.last_good
+        {
+            return palette;
+        }
+        cached.mtime = mtime;
+        match std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|colors| Self::from_desktop_colors(&colors))
+        {
+            Some(palette) => {
+                cached.last_good = Some(palette);
+                palette
+            }
+            None => cached
+                .last_good
+                .unwrap_or_else(|| if dark { Self::dark() } else { Self::light() }),
+        }
+    }
+
+    fn from_desktop_colors(colors: &str) -> Option<Self> {
+        let color = |name: &str| color_from_toml(colors, name);
+        let window = color("background")?;
+        let text = color("selection_foreground").or_else(|| color("foreground"))?;
+        let accent = color("accent")?;
+        let dark = luminance(window) < luminance(text);
+        let panel = blend(window, text, 0.035);
+        let surface = blend(window, text, 0.075);
+        Some(Self {
+            dark,
+            window,
+            panel,
+            surface,
+            surface_hover: blend(window, text, 0.13),
+            surface_active: color("selection_background").unwrap_or(blend(window, accent, 0.20)),
+            outline: blend(window, text, 0.18),
+            text,
+            secondary: blend(window, text, 0.80),
+            dim: blend(window, text, 0.68),
+            accent,
+            accent_hover: blend(
+                accent,
+                if dark { Color32::WHITE } else { Color32::BLACK },
+                0.10,
+            ),
+            on_accent: if luminance(accent) > 0.179 {
+                Color32::BLACK
+            } else {
+                Color32::WHITE
+            },
+            danger: color("color1").unwrap_or(accent),
+            warning: color("color3").unwrap_or(accent),
+            overlay: window,
+            shadow: Color32::from_black_alpha(if dark { 140 } else { 50 }),
+        })
+    }
+
     /// A colour derived from album art, softened so it can sit behind text.
     pub fn tint_from_art(&self, rgb: [u8; 3]) -> Color32 {
         let [r, g, b] = rgb.map(|c| c as f32 / 255.0);
@@ -91,6 +195,96 @@ impl Palette {
         };
         Color32::from_rgb((r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
     }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_palette_file() -> Option<std::path::PathBuf> {
+    let config = std::env::var_os("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".config"))
+        })?;
+    Some(config.join("omarchy/current/theme/colors.toml"))
+}
+
+fn color_from_toml(colors: &str, name: &str) -> Option<Color32> {
+    colors.lines().find_map(|line| {
+        let line = toml_without_comment(line).trim();
+        let (key, value) = line.split_once('=')?;
+        (key.trim() == name).then(|| parse_hex_color(toml_string(value)))?
+    })
+}
+
+fn toml_without_comment(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('#') {
+        return "";
+    }
+    let mut in_single = false;
+    let mut in_double = false;
+    for (index, ch) in line.char_indices() {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '#' if !in_single && !in_double => return &line[..index],
+            _ => {}
+        }
+    }
+    line
+}
+
+fn toml_string(value: &str) -> &str {
+    let value = value.trim();
+    value
+        .strip_prefix('"')
+        .and_then(|rest| rest.split('"').next())
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|rest| rest.split('\'').next())
+        })
+        .unwrap_or(value)
+}
+
+fn parse_hex_color(value: &str) -> Option<Color32> {
+    let hex = value.trim().strip_prefix('#')?;
+    if !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let pair = |start: usize| u8::from_str_radix(&hex[start..start + 2], 16).ok();
+    match hex.len() {
+        3 => {
+            let digit = |start: usize| {
+                let value = u8::from_str_radix(&hex[start..start + 1], 16).ok()?;
+                Some(value * 17)
+            };
+            Some(Color32::from_rgb(digit(0)?, digit(1)?, digit(2)?))
+        }
+        6 => Some(Color32::from_rgb(pair(0)?, pair(2)?, pair(4)?)),
+        8 => Some(Color32::from_rgb(pair(0)?, pair(2)?, pair(4)?)),
+        _ => None,
+    }
+}
+
+fn blend(base: Color32, top: Color32, amount: f32) -> Color32 {
+    let mix = |a: u8, b: u8| (a as f32 + (b as f32 - a as f32) * amount).round() as u8;
+    Color32::from_rgb(
+        mix(base.r(), top.r()),
+        mix(base.g(), top.g()),
+        mix(base.b(), top.b()),
+    )
+}
+
+fn luminance(color: Color32) -> f32 {
+    let linear = |v: u8| {
+        let v = v as f32 / 255.0;
+        if v <= 0.04045 {
+            v / 12.92
+        } else {
+            ((v + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    0.2126 * linear(color.r()) + 0.7152 * linear(color.g()) + 0.0722 * linear(color.b())
 }
 
 pub const RADIUS: u8 = 8;
@@ -880,6 +1074,83 @@ pub fn subtle(ui: &mut egui::Ui, palette: &Palette, label: &str) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn omarchy_palette_uses_the_system_theme_colours() {
+        let palette = Palette::from_desktop_colors(
+            r##"
+                background = "#0d0b1a"
+                foreground = "#c4c0e0"
+                selection_foreground = "#e6e2f5"
+                selection_background = "#2a2340"
+                accent = "#a97bf0"
+                color0 = "#1b1730"
+                color1 = "#f7768e"
+                color3 = "#e0c068"
+                color7 = "#b8b2d8"
+                color8 = "#453d63"
+                color13 = "#c49bff"
+            "##,
+        )
+        .expect("valid Omarchy palette");
+
+        assert_eq!(palette.window, Color32::from_rgb(0x0d, 0x0b, 0x1a));
+        assert_eq!(palette.accent, Color32::from_rgb(0xa9, 0x7b, 0xf0));
+        assert_eq!(palette.surface_active, Color32::from_rgb(0x2a, 0x23, 0x40));
+        assert_eq!(palette.danger, Color32::from_rgb(0xf7, 0x76, 0x8e));
+    }
+
+    #[test]
+    fn desktop_palette_accepts_comments_quotes_and_short_hex() {
+        let palette = Palette::from_desktop_colors(
+            r##"
+                # a comment
+                background = '#abc' # trailing
+                foreground = "#e6e2f5"
+                accent = "#A97BF0FF"
+            "##,
+        )
+        .expect("tolerant desktop palette");
+        assert_eq!(palette.window, Color32::from_rgb(0xaa, 0xbb, 0xcc));
+        assert_eq!(palette.accent, Color32::from_rgb(0xa9, 0x7b, 0xf0));
+        assert!(Palette::from_desktop_colors("background = invalid").is_none());
+        assert_eq!(parse_hex_color("#éabcx"), None);
+        assert_eq!(parse_hex_color("#12"), None);
+    }
+
+    #[test]
+    fn system_palette_is_readable_and_rejects_invalid_hex() {
+        let contrast = |a: Color32, b: Color32| {
+            let lum = |c: Color32| {
+                let linear = |v: u8| {
+                    let v = v as f32 / 255.0;
+                    if v <= 0.04045 {
+                        v / 12.92
+                    } else {
+                        ((v + 0.055) / 1.055).powf(2.4)
+                    }
+                };
+                0.2126 * linear(c.r()) + 0.7152 * linear(c.g()) + 0.0722 * linear(c.b())
+            };
+            (lum(a).max(lum(b)) + 0.05) / (lum(a).min(lum(b)) + 0.05)
+        };
+        let p = Palette::from_desktop_colors(
+            "background = \"#0d0b1a\"\nforeground = \"#c4c0e0\"\naccent = \"#a97bf0\"",
+        )
+        .unwrap();
+        assert_eq!(p.on_accent, Color32::BLACK);
+        assert_ne!(p.panel, p.window);
+        assert_ne!(p.surface, p.panel);
+        assert_ne!(p.surface_hover, p.surface);
+        assert!(contrast(p.secondary, p.panel) >= 4.5);
+        assert!(contrast(p.dim, p.panel) >= 4.5);
+        let light = Palette::from_desktop_colors(
+            "background = \"#fafafa\"\nforeground = \"#202020\"\naccent = \"#8050c0\"",
+        )
+        .unwrap();
+        assert!(!light.dark);
+        assert!(contrast(light.on_accent, light.accent) >= 4.5);
+    }
 
     #[test]
     fn fonts_install_and_layout_emojis() {

--- a/tests/system_palette_reload.rs
+++ b/tests/system_palette_reload.rs
@@ -1,0 +1,60 @@
+use fastpotify::theme::Palette;
+use std::{fs, process::Command};
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn follow_system_without_a_linux_palette_file_uses_the_built_in_colours() {
+    assert_eq!(Palette::from_system(true), Palette::dark());
+    assert_eq!(Palette::from_system(false), Palette::light());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn follows_palette_changes_and_falls_back_when_the_file_is_removed() {
+    if std::env::var_os("FASTPOTIFY_PALETTE_TEST_CHILD").is_none() {
+        let dir = std::env::temp_dir().join(format!("fastpotify-palette-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "follows_palette_changes_and_falls_back_when_the_file_is_removed",
+                "--nocapture",
+            ])
+            .env("FASTPOTIFY_PALETTE_TEST_CHILD", "1")
+            .env("XDG_CONFIG_HOME", &dir)
+            .env_remove("HOME")
+            .status()
+            .unwrap();
+        fs::remove_dir_all(dir).unwrap();
+        assert!(status.success());
+        return;
+    }
+    let path = std::path::PathBuf::from(std::env::var_os("XDG_CONFIG_HOME").unwrap())
+        .join("omarchy/current/theme/colors.toml");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let write = |contents: &str| {
+        fs::write(&path, contents).unwrap();
+        // Distinct mtimes so the cache notices each write.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    };
+    write("background = \"#0d0b1a\"\nforeground = \"#e6e2f5\"\naccent = \"#a97bf0\"\n");
+    let dark = Palette::from_system(true);
+    assert_eq!(dark.accent, egui::Color32::from_rgb(169, 123, 240));
+    assert!(dark.dark);
+    write("background = \"#fafafa\"\nforeground = \"#202020\"\naccent = \"#8050c0\"\n");
+    let light = Palette::from_system(true);
+    assert_eq!(light.accent, egui::Color32::from_rgb(128, 80, 192));
+    assert!(!light.dark);
+    write("background = invalid\n");
+    assert_eq!(
+        Palette::from_system(true),
+        light,
+        "keep last good palette during partial writes"
+    );
+    fs::remove_file(&path).unwrap();
+    assert_eq!(
+        Palette::from_system(true),
+        Palette::dark(),
+        "missing file uses the built-in palette"
+    );
+}


### PR DESCRIPTION
## Summary

- On Linux, Appearance, Follow system now uses the active Omarchy desktop palette (`~/.config/omarchy/current/theme/colors.toml`) for window, text, and accent colours.
- Explicit Light and Dark still use Fastpotify's built-in palettes.
- Surfaces are mixed from background and foreground so the UI stays readable instead of using raw terminal ANSI blacks.

## Motivation

Follow system previously only selected light or dark. On Omarchy (and similar Linux setups that publish that colour file), the rest of the desktop already has a full palette. Fastpotify stayed on Spotify green over a generic dark grey.

## Changes

- `Palette::from_system` is Linux-only for the file-based palette. Other platforms still follow OS light/dark.
- The colour file is re-read on the UI thread when its mtime changes. There is no leftover watcher thread after leaving Follow system.
- Incomplete writes keep the last valid palette. Deleting the file falls back to the built-in light or dark colours.
- The parser accepts comments, single or double quotes, 3/6/8-digit hex, and uppercase values.
- README and settings docs describe the Linux palette file.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked --lib` (332 passed)
- [x] `cargo test --locked --test system_palette_reload`
- [x] Live check on Omarchy: Follow system picks up the current violet palette
- [ ] CI on macOS and Windows (compile-only coverage for the `cfg` split)
- [ ] `cargo clippy --locked --all-targets --all-features -- -D warnings` and the remaining CONTRIBUTING checks

## Screenshots / Examples

This is a colour change only: layout, fonts, and controls are unchanged. Live Linux screenshot after the change: system violet accent and deep purple-black surfaces instead of Spotify green.

Demo mode still uses the built-in palettes unless that Omarchy file is present in the test environment.

## Notes for Reviewers

This is not a general GTK or portal theming engine. It only reads Omarchy's published `colors.toml` on Linux. If that path is too specific, it can be narrowed or made a documented Linux extra without changing the Light/Dark behaviour.
