### PR TITLE
Cut a featuring where it starts, not where the lower-cased copy says

### DIFF
--- a/src/lyrics.rs
+++ b/src/lyrics.rs
@@ -401,7 +401,25 @@ pub fn clean_title(title: &str) -> String {
 
 /// Everything from a standalone "feat", "ft", or "featuring" on.
 fn strip_featuring(text: &str) -> String {
-    let lower = text.to_lowercase();
+    // The marker is looked for in a lower-cased copy and the cut is made in
+    // `text`, and lower casing does not preserve length: Turkish 'İ' becomes
+    // two characters and one byte longer, capital sharp s one byte shorter.
+    // An offset measured in the copy therefore means somewhere else in the
+    // title -- letters kept that should have gone, or, when it lands inside a
+    // character, a panic. `starts` carries every offset in the copy back to
+    // the same place in `text`, so no offset is ever used in the string it
+    // was not measured in.
+    let mut lower = String::with_capacity(text.len());
+    let mut starts: Vec<usize> = Vec::with_capacity(text.len() + 1);
+    for (at, character) in text.char_indices() {
+        for lowered in character.to_lowercase() {
+            for _ in 0..lowered.len_utf8() {
+                starts.push(at);
+            }
+            lower.push(lowered);
+        }
+    }
+    starts.push(text.len());
     let mut cut = None;
     for marker in ["featuring", "feat", "ft"] {
         let mut from = 0;
@@ -423,7 +441,7 @@ fn strip_featuring(text: &str) -> String {
         }
     }
     match cut {
-        Some(at) => text[..at].trim().to_string(),
+        Some(at) => text[..starts[at]].trim().to_string(),
         None => text.trim().to_string(),
     }
 }
@@ -591,6 +609,31 @@ fn write_cache(path: &Path, found: &Option<Lyrics>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_featuring_is_cut_where_it_starts_whatever_the_case_costs() {
+        // The cut is found in a lower-cased copy and applied to the original,
+        // and lower casing is not always the same number of bytes. Turkish
+        // 'İ' grows by one byte, so every offset past it points one byte too
+        // far into the title, and the letters between are kept.
+        assert_eq!(
+            clean_title("\u{130}\u{130} feat. Someone"),
+            "\u{130}\u{130}"
+        );
+        assert_eq!(clean_artist("\u{130}zel feat. Someone"), "\u{130}zel");
+
+        // Capital sharp s shrinks by one, so the offset points one byte SHORT
+        // -- and one byte short of the end of a character is a panic.
+        assert_eq!(
+            clean_title("\u{1e9e} caf\u{e9} feat. Someone"),
+            "\u{1e9e} caf\u{e9}"
+        );
+
+        // The ASCII case, which already worked, still does.
+        assert_eq!(clean_title("Song feat. Someone"), "Song");
+        assert_eq!(clean_title("Song ft. Someone"), "Song");
+        assert_eq!(clean_artist("Artist featuring Other"), "Artist");
+    }
 
     #[test]
     fn titles_lose_what_a_database_leaves_out() {


### PR DESCRIPTION
## Why

The featuring cut is looked for in a lower-cased copy of the title and then made in the title
itself:

```rust
let lower = text.to_lowercase();
...
let before = lower[..start].trim_end_matches(['-', '(']).trim_end();
let at = before.len();          // an offset into `lower`
...
Some(at) => text[..at].trim().to_string(),   // used as an offset into `text`
```

Lower casing is not length-preserving. Turkish `İ` (U+0130) lower cases to two characters and one
byte more; capital sharp s `ẞ` (U+1E9E) loses one. Past either of them the two strings no longer
agree about where anything is, so the offset means somewhere else in the title.

Too far, and letters that should have gone are kept:

```
clean_title("İİ feat. Someone")
  left:  "İİ f"
  right: "İİ"
```

Too short, and it lands inside a character, which is not a wrong answer but a panic:

```
clean_title("ẞ café feat. Someone")
thread panicked at src/lyrics.rs:426:25:
end byte index 8 is not a char boundary; it is inside 'é' (bytes 7..9 of string)
```

Both are reached by playing a track and opening the lyrics: `clean_title` and `clean_artist` are
what the LRCLIB lookup is built from, and both run `strip_featuring`. `İ` is an ordinary letter in
Turkish and Azerbaijani, and a title of the form `Şarkı feat. Biri` is the normal way a
collaboration is written there.

## What changed

`strip_featuring` builds the lower-cased copy itself, keeping a table beside it that carries every
byte offset in the copy back to the same place in `text`. The search is unchanged and still runs in
the copy; only the final cut is translated:

```rust
Some(at) => text[..starts[at]].trim().to_string(),
```

`starts` is built by walking `text.char_indices()` and pushing the source character's offset once
per byte the lowered form occupies, so a character that lowers to two still resolves to the place it
came from. `starts.push(text.len())` covers a cut at the very end.

For a title where lower casing is length-preserving -- which is every ASCII title and the
overwhelming majority of the rest -- `starts[at] == at`, so nothing about the existing behaviour
moves.

## Tests

`a_featuring_is_cut_where_it_starts_whatever_the_case_costs`:

- `İİ feat. Someone` cuts to `İİ`, and `İzel feat. Someone` (a real Turkish singer) to `İzel`
- `ẞ café feat. Someone` cuts to `ẞ café` instead of panicking
- `Song feat. Someone`, `Song ft. Someone` and `Artist featuring Other` are unchanged, which is the
  check that the ASCII path did not move

On `main` the first assertion fails with `left: "İİ f"` and the third panics.

## How I tested

Windows 11, toolchain 1.98.0 from `rust-toolchain.toml`. `cargo fmt --all --check`,
`cargo test --locked --all-targets` (347 passed, up from 346 by the new test) and
`cargo clippy --locked --all-targets`, all with `--no-default-features` because this machine has no
vcpkg for MilkDrop; nothing here touches that feature.

No user-visible setting, file or network access changes, so no documentation change.
