### PR TITLE
Read an album's year the way format_date reads the same field

### DIFF
--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -201,9 +201,13 @@ pub struct Copyright {
 
 impl Album {
     pub fn year(&self) -> Option<&str> {
+        // `get` rather than a slice, the way `util::format_date` reads the
+        // same field: `min` clamps the length and says nothing about
+        // character boundaries, so a date whose fourth byte is inside a
+        // character is a panic rather than a date that does not parse.
         self.release_date
             .as_deref()
-            .map(|date| &date[..date.len().min(4)])
+            .map(|date| date.get(..4).unwrap_or(date))
     }
 
     pub fn kind_label(&self) -> &'static str {
@@ -752,6 +756,33 @@ pub struct ApiErrorDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_albums_year_reads_a_date_the_way_format_date_does() {
+        let dated = |date: &str| {
+            let json = format!(
+                r#"{{"id":"a","name":"A","uri":"spotify:album:a","release_date":"{date}"}}"#
+            );
+            serde_json::from_str::<Album>(&json).unwrap()
+        };
+        // The dates Spotify documents, at all three precisions.
+        assert_eq!(dated("2024-03-15").year(), Some("2024"));
+        assert_eq!(dated("2024-03").year(), Some("2024"));
+        assert_eq!(dated("2024").year(), Some("2024"));
+        // Shorter than a year, which `min` was there to hold.
+        assert_eq!(dated("20").year(), Some("20"));
+        // A date whose fourth byte is inside a character. `min` clamps the
+        // length and says nothing about boundaries, so this used to panic;
+        // `util::format_date` reads the same field with `get` and does not.
+        assert_eq!(dated("\u{c791}\u{b144}").year(), Some("\u{c791}\u{b144}"));
+        assert_eq!(
+            crate::util::format_date("\u{c791}\u{b144}"),
+            "\u{c791}\u{b144}"
+        );
+        // No date at all is still no year.
+        let json = r#"{"id":"a","name":"A","uri":"spotify:album:a"}"#;
+        assert_eq!(serde_json::from_str::<Album>(json).unwrap().year(), None);
+    }
 
     #[test]
     fn playlist_items_accept_both_item_and_track_keys() {


### PR DESCRIPTION
## Why

`release_date` has two readers in the crate, and only one of them can survive what the other is
written to survive.

```rust
// util::format_date
let date = iso.get(..10).unwrap_or(iso);

// Album::year
.map(|date| &date[..date.len().min(4)])
```

`min` clamps the length and says nothing about character boundaries, so `year()` panics on any date
whose fourth byte falls inside a character:

```
thread panicked at src/api/models.rs:210:30:
byte index 4 is not a char boundary; it is inside '년' (bytes 3..6 of string)
```

`format_date` reads the same field, from the same responses, and answers the same input by handing
the string back. That `get` is not there by accident — it is what says this field is not trusted to
be ASCII — and `year()` is the one place that trusts it.

I should be straight about reachability: Spotify documents `release_date` as ISO-8601, and I could
not get the live API to return anything else, so I am not claiming a user can reach this today.
`year()` is called from the artist page, the collection grid and search results, so if it ever is
reached it is a crash rather than a bad label. This is a one-line change that makes the two readers
of one field agree, and it costs nothing if the field is always well formed.

## What changed

`year()` reads with `get`, the way its neighbour does. Every documented shape is unaffected:

| `release_date` | before | after |
| --- | --- | --- |
| `2024-03-15` | `2024` | `2024` |
| `2024-03` | `2024` | `2024` |
| `2024` | `2024` | `2024` |
| `20` | `20` | `20` |
| `작년` | panic | `작년` |

The last row is the only behaviour that moves, and it moves from a panic to the same answer
`format_date` already gives: the string as it came.

## Tests

`an_albums_year_reads_a_date_the_way_format_date_does` covers all three documented precisions, a
date shorter than a year (which is what `min` was there for), the boundary case, and an album with
no date at all. It also asserts `format_date` on the same input, so the two readers are pinned as
agreeing rather than merely both being called.

Against `main` it panics at `models.rs:210`.

## How I tested

Windows 11, toolchain 1.98.0 from `rust-toolchain.toml`. `cargo fmt --all --check`,
`cargo test --locked --all-targets` (348 passed, up from 347 by the new test) and
`cargo clippy --locked --all-targets`, all with `--no-default-features` because this machine has no
vcpkg for MilkDrop; nothing here touches that feature.

No user-visible setting, file or network access changes, so no documentation change.
