### PR TITLE
Fix playback authorization scopes and username forwarding

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -38,14 +38,7 @@ pub const WEB_REDIRECT_PORT: u16 = 8989;
 pub const REDIRECT_PATH: &str = "/login";
 
 /// Playback: what librespot needs to stream and join Spotify Connect.
-pub const PLAYBACK_SCOPES: &[&str] = &[
-    "app-remote-control",
-    "streaming",
-    "user-modify-playback-state",
-    "user-read-currently-playing",
-    "user-read-playback-state",
-    "user-read-private",
-];
+pub const PLAYBACK_SCOPES: &[&str] = &["streaming"];
 
 /// Web API: what visible features use, plus `user-read-private` for the
 /// plan (Free or Premium), which decides whether local playback is offered
@@ -133,8 +126,13 @@ pub fn begin(grant: Grant) -> Flow {
     let verifier = random_token(48);
     let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
     let state = random_token(18);
+    let show_dialog = if grant.client_id == PLAYBACK_CLIENT_ID {
+        "&show_dialog=true"
+    } else {
+        ""
+    };
     let url = format!(
-        "{AUTHORIZE_URL}?client_id={}&response_type=code&redirect_uri={}&code_challenge_method=S256&code_challenge={challenge}&state={state}&scope={}",
+        "{AUTHORIZE_URL}?client_id={}&response_type=code&redirect_uri={}&code_challenge_method=S256&code_challenge={challenge}&state={state}&scope={}{show_dialog}",
         grant.client_id,
         urlencoding::encode(&grant.redirect_uri()),
         urlencoding::encode(&grant.scopes.join(" "))
@@ -484,6 +482,7 @@ mod tests {
                 .contains(&format!("client_id={DEFAULT_WEB_CLIENT_ID}"))
         );
         assert!(flow.url.contains("8989"));
+        assert!(!flow.url.contains("show_dialog=true"));
         let playback = begin(Grant::playback());
         assert!(
             playback
@@ -491,6 +490,17 @@ mod tests {
                 .contains(&format!("client_id={PLAYBACK_CLIENT_ID}"))
         );
         assert!(playback.url.contains("8898"));
+        assert!(playback.url.contains("show_dialog=true"));
+    }
+
+    #[test]
+    fn playback_scopes_conform_to_spotify_streaming_contract() {
+        assert_eq!(PLAYBACK_SCOPES, &["streaming"]);
+        let playback = Grant::playback();
+        assert_eq!(playback.scopes, vec!["streaming".to_string()]);
+        let personal = Grant::personal_web_api("test-id").unwrap();
+        let flow = begin(personal);
+        assert!(!flow.url.contains("show_dialog=true"));
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -882,7 +882,13 @@ impl Worker {
                     user,
                 } => self.on_web_verified(source, *token, *user),
                 Command::PlaybackAuthorized { access_token } => {
-                    self.connect_engine(Credentials::with_access_token(access_token))
+                    let username = self.api.account().map(|a| a.as_str().to_string());
+                    let credentials = Credentials {
+                        username,
+                        auth_type: librespot_protocol::authentication::AuthenticationType::AUTHENTICATION_SPOTIFY_TOKEN,
+                        auth_data: access_token.into_bytes(),
+                    };
+                    self.connect_engine(credentials)
                 }
                 Command::EngineConnected { engine, error } => {
                     self.on_engine_connected(*engine, error)
@@ -1068,6 +1074,15 @@ impl Worker {
                 self.emit(Event::WebApp {
                     client_id: Some(token.client_id),
                 });
+                if !self.signed_in {
+                    self.signed_in = true;
+                    self.emit(Event::Auth(AuthStatus::Connected {
+                        username: user.name().to_string(),
+                    }));
+                    self.emit(Event::Api(Box::new(ApiResponse::Me(Ok(user.clone())))));
+                    let premium = user.product.as_deref().map(|product| product == "premium");
+                    self.on_account_checked(premium);
+                }
             }
         }
         self.finish_authorization(source);


### PR DESCRIPTION
### Summary

When authorizing Spotify playback using the desktop client ID, Spotify Access Point rejects authentication unless scopes are strictly limited to streaming. This PR restricts `PLAYBACK_SCOPES` to `["streaming"]` and appends `show_dialog=true` to authorization requests.

Additionally, it forwards the account username when initializing session credentials in `Command::PlaybackAuthorized`. If the shared Web API client experiences rate limiting during startup, `self.api.account()` is empty; passing the configured or authenticated account prevents sending an empty username to Spotify AP. It also updates personal source verification to track sign-in state and check premium status.

### Changes

- Restrict `PLAYBACK_SCOPES` in `src/auth.rs` to `["streaming"]`.
- Include `show_dialog=true` for playback authorization requests in `src/auth.rs`.
- Forward account username in `Command::PlaybackAuthorized` in `src/backend.rs`.
- Update personal source verification in `src/backend.rs` to set sign-in state and check premium status.
- Add regression tests in `src/auth.rs` covering playback scopes and dialog flags.

Fixes #123. References librespot-org/librespot#1737.
