### PR TITLE
Name what the queue is playing from

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ everyday use, and connection details.
   song, album, artist, playlist, or podcast shared from another app opens
   in it, whether it is running or not. `open.spotify.com` addresses go
   through the browser, which hands them to the same handler.
-- **Queue** as a side panel or a page; add anything to it from a row menu.
+- **Queue** as a side panel or a page; it names what is playing from, and
+  anything can be added to it from a row menu.
 - **Resumes the last session.** On startup, the last song is paused where it
   stopped. Play resumes it, and the other playback controls work before it
   starts.

--- a/docs/_reference/queue.md
+++ b/docs/_reference/queue.md
@@ -9,6 +9,12 @@ under **Playing next**, are the songs you queued yourself. Below them,
 under **Next up**, are the songs that come next in whatever playlist or
 album is playing. Your songs always play first.
 
+Above both, **Playing from** names where the playing song came from: the
+playlist, album, artist, or podcast, which opens when clicked, Liked
+Songs, or a song radio named after its song. A radio has no page of its
+own, so its name is plain text. The line shows only while a song is
+playing from somewhere Spotify reports.
+
 These are the rules the app follows. The queue tests in `src/app.rs`
 check every one of them.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1637,6 +1637,107 @@ impl App {
         }
     }
 
+    /// Where the playing songs come from, for the queue's header: the
+    /// playlist, album, artist, or podcast with its page, Liked Songs, or
+    /// a song radio as plain text because a station has no page. A context
+    /// whose name has not loaded is still named by kind so it can open.
+    pub fn playing_from(&self) -> Option<PlayingFrom> {
+        let context = self.playing_context_uri()?;
+        if context.ends_with(":collection") {
+            return Some(PlayingFrom {
+                name: "Liked Songs".into(),
+                page: Some(Page::LikedSongs),
+            });
+        }
+        if context.starts_with("spotify:station:") {
+            return Some(PlayingFrom {
+                name: self
+                    .station_name(&context)
+                    .unwrap_or_else(|| "Radio".into()),
+                page: None,
+            });
+        }
+        let kind = util::uri_kind(&context)?;
+        let id = util::uri_id(&context)?.to_string();
+        let (name, page) = match kind {
+            "playlist" => {
+                let name = self
+                    .library
+                    .playlists
+                    .get()
+                    .and_then(|list| list.iter().find(|playlist| playlist.id == id))
+                    .map(|playlist| playlist.name.clone())
+                    .or_else(|| {
+                        self.playlist_pages
+                            .get(&id)
+                            .and_then(|page| page.playlist.get())
+                            .map(|playlist| playlist.name.clone())
+                    });
+                (
+                    name.unwrap_or_else(|| "Playlist".into()),
+                    Page::Playlist(id),
+                )
+            }
+            "album" => {
+                let name = self
+                    .album_pages
+                    .get(&id)
+                    .and_then(|page| page.album.get())
+                    .map(|album| album.name.clone())
+                    .or_else(|| {
+                        self.now_playing()
+                            .filter(|now| now.album_id.as_deref() == Some(id.as_str()))
+                            .map(|now| now.album_name)
+                    });
+                (name.unwrap_or_else(|| "Album".into()), Page::Album(id))
+            }
+            "artist" => {
+                let name = self
+                    .artist_pages
+                    .get(&id)
+                    .and_then(|page| page.artist.get())
+                    .map(|artist| artist.name.clone())
+                    .or_else(|| {
+                        self.now_playing().and_then(|now| {
+                            now.artists
+                                .into_iter()
+                                .find(|artist| artist.id.as_deref() == Some(id.as_str()))
+                                .map(|artist| artist.name)
+                        })
+                    });
+                (name.unwrap_or_else(|| "Artist".into()), Page::Artist(id))
+            }
+            "show" => {
+                let name = self
+                    .show_pages
+                    .get(&id)
+                    .and_then(|page| page.show.get())
+                    .map(|show| show.name.clone())
+                    .or_else(|| {
+                        self.library
+                            .shows
+                            .items
+                            .iter()
+                            .find(|saved| saved.show.id == id)
+                            .map(|saved| saved.show.name.clone())
+                    });
+                (name.unwrap_or_else(|| "Podcast".into()), Page::Show(id))
+            }
+            _ => return None,
+        };
+        Some(PlayingFrom {
+            name,
+            page: Some(page),
+        })
+    }
+
+    /// "<Song> Radio" for a song station whose song is cached.
+    fn station_name(&self, context: &str) -> Option<String> {
+        let id = context.strip_prefix("spotify:station:track:")?;
+        let track = self.track_cache.get(id)?;
+        Some(format!("{} Radio", track.name))
+    }
+
     /// Encodes a context as a value accepted by `Page::decode`.
     fn context_page(context_uri: &str) -> String {
         if context_uri.ends_with(":collection") {
@@ -3067,10 +3168,9 @@ impl App {
     /// Name for a playlist created from the queue.
     pub fn queue_playlist_name(&self) -> String {
         if let Some(context) = self.playing_context_uri()
-            && let Some(id) = context.strip_prefix("spotify:station:track:")
-            && let Some(track) = self.track_cache.get(id)
+            && let Some(name) = self.station_name(&context)
         {
-            return format!("{} Radio", track.name);
+            return name;
         }
         let today = jiff::Zoned::now().strftime("%Y-%m-%d").to_string();
         format!("Queue {today}")
@@ -8120,6 +8220,78 @@ mod tests {
         assert_eq!(app.queue_playlist_name(), "Wish You Were Here Radio");
         app.assumed_context = None;
         assert!(app.queue_playlist_name().starts_with("Queue "));
+    }
+
+    /// The queue names where the playing song comes from and opens it.
+    /// A radio has no page; a context whose name has not loaded is still
+    /// named by kind so it can open.
+    #[test]
+    fn playing_from_names_the_context_and_its_page() {
+        let mut app = headless_app();
+        assert_eq!(app.playing_from(), None, "no context, no line");
+        let assume = |app: &mut App, uri: &str| {
+            app.assumed_context = Some(AssumedContext {
+                uri: uri.into(),
+                shuffle: None,
+                at: Instant::now(),
+            });
+        };
+        let named = |app: &App| {
+            let from = app.playing_from().expect("a context is playing");
+            (from.name, from.page)
+        };
+
+        app.library.playlists = Loadable::Loaded(vec![crate::api::models::Playlist {
+            id: "pl9".into(),
+            uri: "spotify:playlist:pl9".into(),
+            name: "Long Way Home".into(),
+            ..Default::default()
+        }]);
+        assume(&mut app, "spotify:playlist:pl9");
+        assert_eq!(
+            named(&app),
+            ("Long Way Home".into(), Some(Page::Playlist("pl9".into())))
+        );
+        assume(&mut app, "spotify:playlist:unloaded");
+        assert_eq!(
+            named(&app),
+            ("Playlist".into(), Some(Page::Playlist("unloaded".into())))
+        );
+
+        app.album_pages.insert(
+            "alb1".into(),
+            AlbumPage {
+                album: Loadable::Loaded(crate::api::models::Album {
+                    id: "alb1".into(),
+                    uri: "spotify:album:alb1".into(),
+                    name: "Black Sands".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        assume(&mut app, "spotify:album:alb1");
+        assert_eq!(
+            named(&app),
+            ("Black Sands".into(), Some(Page::Album("alb1".into())))
+        );
+
+        assume(&mut app, "spotify:user:me:collection");
+        assert_eq!(named(&app), ("Liked Songs".into(), Some(Page::LikedSongs)));
+
+        app.track_cache.insert(
+            "xyz".into(),
+            crate::api::models::Track {
+                id: Some("xyz".into()),
+                uri: "spotify:track:xyz".into(),
+                name: "Wish You Were Here".into(),
+                ..Default::default()
+            },
+        );
+        assume(&mut app, "spotify:station:track:xyz");
+        assert_eq!(named(&app), ("Wish You Were Here Radio".into(), None));
+        assume(&mut app, "spotify:station:track:uncached");
+        assert_eq!(named(&app), ("Radio".into(), None));
     }
 
     /// Song radio opens the queue panel.

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1733,6 +1733,113 @@ mod tests {
         app.backend.shutdown();
     }
 
+    /// The queue names where the playing song comes from, on one row
+    /// with its label: the playlist, or the song a radio is seeded by.
+    /// With nothing reported, the row is not drawn.
+    #[test]
+    fn the_queue_names_where_the_song_plays_from() {
+        let root = std::env::temp_dir().join(format!(
+            "fastpotify-playing-from-test-{}",
+            std::process::id()
+        ));
+        let dirs = AppDirs {
+            config: root.join("config"),
+            state: root.join("state"),
+            cache: root.join("cache"),
+        };
+        let ctx = egui::Context::default();
+        let waker = crate::backend::Waker::default();
+        waker.attach(&ctx);
+        let mut app = App::new(
+            &waker,
+            dirs,
+            Settings::default(),
+            AppOptions {
+                media_controls: false,
+                tray: false,
+            },
+        );
+        app.attach(&ctx);
+        populate(&mut app);
+        app.show_queue_panel = true;
+
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1280.0, 800.0),
+            )),
+            ..Default::default()
+        };
+        let drawn = |app: &mut App| {
+            let mut placed = Vec::new();
+            // A panel applies its requested width after the first frame.
+            for _ in 0..2 {
+                placed.clear();
+                let mut output = ctx.run_ui(input.clone(), |ui| app.frame_ui(ui));
+                output.textures_delta.clear();
+                fn walk(shape: &egui::epaint::Shape, placed: &mut Vec<(String, egui::Rect)>) {
+                    match shape {
+                        egui::epaint::Shape::Text(text) => {
+                            placed.push((text.galley.job.text.clone(), text.visual_bounding_rect()))
+                        }
+                        egui::epaint::Shape::Vec(shapes) => {
+                            shapes.iter().for_each(|shape| walk(shape, placed))
+                        }
+                        _ => {}
+                    }
+                }
+                for clipped in &output.shapes {
+                    walk(&clipped.shape, &mut placed);
+                }
+            }
+            placed
+        };
+        let find = |placed: &[(String, egui::Rect)], label: &str| {
+            placed
+                .iter()
+                .find(|(text, _)| text == label)
+                .map(|(_, rect)| *rect)
+                .unwrap_or_else(|| panic!("{label} was never drawn: {placed:?}"))
+        };
+
+        // The name sits to the right of its label on one row. The sidebar
+        // draws the same playlist name elsewhere, so look beside the label.
+        let beside = |placed: &[(String, egui::Rect)], text: &str| {
+            let label = find(placed, "Playing from");
+            placed
+                .iter()
+                .find(|(drawn, rect)| {
+                    drawn == text
+                        && (rect.center().y - label.center().y).abs() < 10.0
+                        && rect.left() >= label.right()
+                })
+                .unwrap_or_else(|| panic!("{text} was not drawn beside its label: {placed:?}"));
+        };
+
+        // The demo plays the second playlist.
+        beside(&drawn(&mut app), "Late night focus");
+
+        // A song radio is named after its song.
+        if let Some(remote) = app.remote.as_mut() {
+            remote.state.context = Some(Context {
+                uri: "spotify:station:track:trk0".into(),
+                kind: "station".into(),
+            });
+        }
+        beside(&drawn(&mut app), "Rosewood Radio");
+
+        // Nothing reported, nothing named.
+        if let Some(remote) = app.remote.as_mut() {
+            remote.state.context = None;
+        }
+        let placed = drawn(&mut app);
+        assert!(
+            !placed.iter().any(|(text, _)| text == "Playing from"),
+            "the row hides without a context"
+        );
+        app.backend.shutdown();
+    }
+
     /// Every page, panel, and dialog lays out without panicking.
     #[test]
     fn every_surface_renders_headless() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -639,6 +639,14 @@ pub struct DragTrack {
     pub from: Option<(String, u32)>,
 }
 
+/// Where the playing songs come from, as the queue's header names it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlayingFrom {
+    pub name: String,
+    /// The page that opens on click. A song radio has none.
+    pub page: Option<Page>,
+}
+
 /// Sidebar entry held during a drag.
 #[derive(Clone, Debug)]
 pub struct DragEntry {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -170,6 +170,24 @@ fn contents(app: &mut App, ui: &mut egui::Ui, compact: bool) {
             .get()
             .and_then(|queue| queue.currently_playing.clone()),
     };
+    // Where the songs come from, above the song itself. A radio has no
+    // page, so its name is plain text.
+    if let Some(from) = app.playing_from().filter(|_| current.is_some()) {
+        ui.horizontal(|ui| {
+            theme::text(ui, "Playing from", theme::regular(13.0), palette.secondary);
+            match from.page {
+                Some(page) => {
+                    if theme::link(ui, from.name, theme::semibold(13.0), palette.text).clicked() {
+                        app.actions.push(Action::Open(page));
+                    }
+                }
+                None => {
+                    theme::text(ui, from.name, theme::semibold(13.0), palette.text);
+                }
+            }
+        });
+        ui.add_space(10.0);
+    }
     if let Some(current) = current.as_ref() {
         theme::text(ui, "Now playing", theme::semibold(14.0), palette.text);
         ui.add_space(4.0);


### PR DESCRIPTION
Fixes #173.

## Why

The queue showed the playing song and what comes next, but never where they come from. A song radio or a playlist started from another device had no name anywhere in the app, so there was no way to tell what was playing or where the recommendations came from.

## What changed

A **Playing from** line above *Now playing*, in the Queue page and the side panel, as approved in #173:

- playlist, album, artist, or podcast → its name, opens the page on click
- `:collection` → **Liked Songs**, opens the collection
- song radio → `<Song> Radio` as plain text, since a station has no page
- a context whose name has not loaded yet → named by kind ("Playlist", "Album", …) so it still opens
- no reported context → nothing drawn

Implementation reuses what exists: `playing_context_uri()` supplies the context, `Action::Open(Page::…)` the navigation. The radio naming moved into one `station_name()` shared with the save-as-playlist name. The player bar's artwork click is unchanged.

Names come from the loaded library and page caches, so no new requests.

## Tests

- `app::tests::playing_from_names_the_context_and_its_page`: playlist, unloaded playlist, album, Liked Songs, cached radio, uncached radio, and no context.
- `demo::tests::the_queue_names_where_the_song_plays_from`: the line renders beside its label in the queue panel, switches to the radio name, and disappears without a context.

## Docs

`docs/_reference/queue.md` describes the line; the README's queue bullet mentions it.

## Screenshots

Demo mode, `--demo-page playlist:pl1 --demo-show queue` (dark) and `queue,light`.

| | Before | After |
|---|---|---|
| Dark | <img width="2758" height="1922" alt="image" src="https://github.com/user-attachments/assets/68b2bc71-4338-45f0-ac61-1639ce5ea44a" /> | <img width="2758" height="1922" alt="image" src="https://github.com/user-attachments/assets/8bf944f9-f41c-4d54-a627-cfc0ca19997e" /> |
| Light | <img width="2758" height="1922" alt="image" src="https://github.com/user-attachments/assets/411f2885-14b6-40f7-b831-4874e43b8239" />| <img width="2758" height="1922" alt="image" src="https://github.com/user-attachments/assets/da4443d3-171c-4faa-95d8-fd6a64897de9" />|

## Checks

Run on macOS (Apple Silicon), toolchain 1.98.0 from `rust-toolchain.toml`:

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets` (360 passed)
- `cargo test --locked --all-targets --all-features` (360 passed)
- `cargo test --locked --all-features --doc`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- `(cd docs && bundle exec jekyll build)`

Linux and Windows were not tested locally; the change has no platform-specific code.
