### PR TITLE
Distinguish EP releases from singles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ everyday use, and connection details.
   available. Follow Spotify’s playlist order or keep a separate local arrangement.
   Move Liked Songs among your pins or unpin it and choose its local position;
   the placement survives restarts.
+  With local playback enabled, releases that the Web API groups as singles
+  are labelled EP when librespot confirms that type.
   Liked Songs reopens from an account-specific metadata cache. Older rows
   refresh in the background while Like and Unlike take effect immediately.
   Right-click album, artist, and podcast cards for their actions (on `main`,

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -134,6 +134,10 @@ uses the Web API for subsequent control requests.
 Playback runs on a separate runtime. Librespot maintains the Spotify Connect
 session, exposes this computer as a device, receives transfers, and reports
 playback state. If the session drops, it reconnects with the stored credential.
+The same session checks releases that the Web API calls `single`, so confirmed
+EPs can carry their precise label. Fastpotify deduplicates these checks while
+the app session is active. If the engine reconnects, an interrupted check may
+be tried again; if metadata is unavailable, its label stays `Single`.
 
 The engine discovers access points through `apresolve.spotify.com` and
 connects over TCP in the resolver's preference order: port 4070 first,

--- a/docs/_reference/what-spotify-allows.md
+++ b/docs/_reference/what-spotify-allows.md
@@ -52,6 +52,7 @@ clients. Fastpotify uses its session for:
   these playlists. Fastpotify cannot manage collaborators.
 - **Lyrics** when Spotify has them.
 - **Display names** for the user IDs attached to songs in a playlist.
+- **Precise EP types** for releases that the Web API groups with singles.
 - **Song radio and autoplay** through Spotify's context resolver.
 
 ## librespot playback

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -219,6 +219,10 @@ impl Album {
             _ => "Album",
         }
     }
+
+    pub(crate) fn is_single_release(&self) -> bool {
+        self.album_group.as_deref().or(self.album_type.as_deref()) == Some("single")
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use egui::Color32;
 
 use crate::api::PlayRequest;
 use crate::api::models::{
-    ArtistRef, Device, PlayableItem, PlaybackState, Playlist, PlaylistItem, Queue, Track,
+    Album, ArtistRef, Device, PlayableItem, PlaybackState, Playlist, PlaylistItem, Queue, Track,
     TrackCount, User, UserRef, pick_image,
 };
 use crate::backend::{
@@ -276,6 +276,10 @@ pub struct App {
     pub show_pages: HashMap<String, ShowPage>,
     pub track_cache: HashMap<String, Track>,
     track_requests: HashSet<String>,
+    /// Album URIs already resolved or attempted through librespot this session.
+    album_types_requested: HashSet<String>,
+    /// Album URIs positively identified as EPs by librespot.
+    confirmed_ep_albums: HashSet<String>,
     /// Built table rows, keyed by page. Capped; dropped on reset and eviction.
     pub table_rows: HashMap<Page, TableRowsCache>,
     page_used: HashMap<Page, Instant>,
@@ -591,6 +595,8 @@ impl App {
             show_pages: HashMap::new(),
             track_cache: HashMap::new(),
             track_requests: HashSet::new(),
+            album_types_requested: HashSet::new(),
+            confirmed_ep_albums: HashSet::new(),
             table_rows: HashMap::new(),
             page_used: HashMap::new(),
             track_used: HashMap::new(),
@@ -802,6 +808,14 @@ impl App {
             Some(true)
         } else {
             exact
+        }
+    }
+
+    pub(crate) fn album_kind_label(&self, album: &Album) -> &'static str {
+        if album.is_single_release() && self.confirmed_ep_albums.contains(&album.uri) {
+            "EP"
+        } else {
+            album.kind_label()
         }
     }
 
@@ -1367,6 +1381,13 @@ impl App {
                 Event::UserName { id, name } => {
                     self.set_user_name(id, name);
                 }
+                Event::AlbumType { uri, result } => match result {
+                    Ok(true) => {
+                        self.confirmed_ep_albums.insert(uri);
+                    }
+                    Ok(false) => {}
+                    Err(error) => log::debug!("album type unavailable for {uri}: {error}"),
+                },
                 Event::WebApp { client_id } => self.web_app = client_id,
                 Event::UpdateChecked { manual, result } => {
                     self.update_checking = false;
@@ -1469,6 +1490,8 @@ impl App {
         self.album_pages.clear();
         self.artist_pages.clear();
         self.show_pages.clear();
+        self.album_types_requested.clear();
+        self.confirmed_ep_albums.clear();
         self.saved.clear();
         self.saved_pending.clear();
         self.track_recordings.clear();
@@ -3406,6 +3429,21 @@ impl App {
         self.backend.send(Command::UserNames(unknown));
     }
 
+    fn request_album_types<'a>(&mut self, albums: impl IntoIterator<Item = &'a Album>) {
+        let mut uris = Vec::new();
+        for album in albums {
+            if album.is_single_release()
+                && !album.uri.is_empty()
+                && self.album_types_requested.insert(album.uri.clone())
+            {
+                uris.push(album.uri.clone());
+            }
+        }
+        if !uris.is_empty() {
+            self.backend.album_types(uris);
+        }
+    }
+
     pub fn request_contains(&mut self, uris: Vec<String>) {
         let mut batch = Vec::new();
         for uri in uris {
@@ -4144,6 +4182,7 @@ impl App {
             }
             ApiResponse::SavedAlbums { offset, result } => match result {
                 Ok(page) => {
+                    self.request_album_types(page.items.iter().map(|item| &item.album));
                     for item in &page.items {
                         self.saved.insert(item.album.uri.clone(), true);
                     }
@@ -4330,6 +4369,9 @@ impl App {
                 offset,
                 result,
             } => {
+                if let Ok(albums) = &result {
+                    self.request_album_types(albums.items.iter());
+                }
                 if let Some(page) = self.artist_pages.get_mut(&id) {
                     let list = page.albums.entry(groups).or_default();
                     match result {
@@ -4345,6 +4387,9 @@ impl App {
             }
             ApiResponse::Album { id, result } => {
                 let mut uris = Vec::new();
+                if let Ok(album) = &result {
+                    self.request_album_types(std::iter::once(album));
+                }
                 if let Ok(album) = &result
                     && let Some(image) = pick_image(&album.images, 300)
                 {
@@ -9736,6 +9781,148 @@ mod tests {
                 ..Track::default()
             },
         );
+    }
+
+    fn web_album(uri: &str, album_type: &str, album_group: Option<&str>) -> Album {
+        Album {
+            id: uri.rsplit(':').next().unwrap_or_default().into(),
+            uri: uri.into(),
+            album_type: Some(album_type.into()),
+            album_group: album_group.map(str::to_string),
+            ..Album::default()
+        }
+    }
+
+    #[test]
+    fn precise_album_types_are_requested_only_for_web_singles_and_once_per_uri() {
+        use crate::api::models::{Page as ApiPage, SavedAlbum};
+
+        let mut app = headless_app();
+        app.backend.set_offline(true);
+        let first = web_album("spotify:album:first", "single", Some("single"));
+        let second = web_album("spotify:album:second", "single", Some("single"));
+        let detail = web_album("spotify:album:detail", "single", None);
+        let album = web_album("spotify:album:album", "album", Some("album"));
+        let compilation = web_album(
+            "spotify:album:compilation",
+            "compilation",
+            Some("compilation"),
+        );
+        let appears_on = web_album("spotify:album:appears", "single", Some("appears_on"));
+
+        app.handle_api(ApiResponse::SavedAlbums {
+            offset: 0,
+            result: Ok(ApiPage {
+                items: vec![
+                    SavedAlbum {
+                        album: first.clone(),
+                        ..SavedAlbum::default()
+                    },
+                    SavedAlbum {
+                        album: compilation,
+                        ..SavedAlbum::default()
+                    },
+                    SavedAlbum {
+                        album,
+                        ..SavedAlbum::default()
+                    },
+                ],
+                ..ApiPage::default()
+            }),
+        });
+        assert_eq!(
+            app.backend.take_album_type_requests(),
+            vec![vec![first.uri.clone()]]
+        );
+
+        app.artist_pages
+            .insert("artist".into(), ArtistPage::default());
+        app.handle_api(ApiResponse::ArtistAlbums {
+            id: "artist".into(),
+            groups: "album,single,compilation,appears_on".into(),
+            offset: 0,
+            result: Ok(ApiPage {
+                items: vec![first, second.clone(), appears_on],
+                ..ApiPage::default()
+            }),
+        });
+        assert_eq!(
+            app.backend.take_album_type_requests(),
+            vec![vec![second.uri.clone()]]
+        );
+
+        app.album_pages
+            .insert(detail.id.clone(), AlbumPage::default());
+        app.handle_api(ApiResponse::Album {
+            id: detail.id.clone(),
+            result: Ok(detail.clone()),
+        });
+        assert_eq!(
+            app.backend.take_album_type_requests(),
+            vec![vec![detail.uri.clone()]]
+        );
+
+        app.handle_api(ApiResponse::Album {
+            id: detail.id.clone(),
+            result: Ok(detail),
+        });
+        assert!(app.backend.take_album_type_requests().is_empty());
+    }
+
+    #[test]
+    fn precise_ep_confirmation_preserves_fallback_and_web_kind_precedence() {
+        let mut app = headless_app();
+        app.backend.set_offline(true);
+        let ep = web_album("spotify:album:ep", "single", Some("single"));
+        let failed = web_album("spotify:album:failed", "single", Some("single"));
+        let timed_out = web_album("spotify:album:timeout", "single", Some("single"));
+        let regular = web_album("spotify:album:regular", "single", Some("single"));
+
+        app.request_album_types([&ep, &failed, &timed_out, &regular]);
+        let _ = app.backend.take_album_type_requests();
+        app.handle_backend_events(vec![
+            Event::AlbumType {
+                uri: ep.uri.clone(),
+                result: Ok(true),
+            },
+            Event::AlbumType {
+                uri: failed.uri.clone(),
+                result: Err("unavailable".into()),
+            },
+            Event::AlbumType {
+                uri: timed_out.uri.clone(),
+                result: Err("album metadata timed out".into()),
+            },
+            Event::AlbumType {
+                uri: regular.uri.clone(),
+                result: Ok(false),
+            },
+        ]);
+
+        assert_eq!(app.album_kind_label(&ep), "EP");
+        assert_eq!(app.album_kind_label(&failed), "Single");
+        assert_eq!(app.album_kind_label(&timed_out), "Single");
+        assert_eq!(app.album_kind_label(&regular), "Single");
+        let appears_on = web_album(&ep.uri, "single", Some("appears_on"));
+        let compilation = web_album(&ep.uri, "single", Some("compilation"));
+        let album = web_album(&ep.uri, "single", Some("album"));
+        assert_eq!(app.album_kind_label(&appears_on), "Appears On");
+        assert_eq!(app.album_kind_label(&compilation), "Compilation");
+        assert_eq!(app.album_kind_label(&album), "Album");
+
+        app.request_album_types([&failed, &timed_out]);
+        assert!(
+            app.backend.take_album_type_requests().is_empty(),
+            "failed lookups are terminal for this session"
+        );
+
+        app.handle_auth(AuthStatus::SignedOut);
+        assert_eq!(app.album_kind_label(&ep), "Single");
+        app.handle_auth(AuthStatus::Connected {
+            username: "next-session".into(),
+        });
+        app.request_album_types([&ep]);
+        assert_eq!(app.backend.take_album_type_requests(), vec![vec![ep.uri]]);
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -6,6 +6,7 @@
 //! the interface with `request_repaint`, so the app stays event-driven and
 //! idle when nothing is happening.
 
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -29,6 +30,7 @@ use crate::player::{Engine, EngineConfig, EngineEvent, LoadSpec, LocalState, Pla
 pub type ApiResult<T> = Result<T, ApiError>;
 
 const PREMIUM_NEEDED: &str = "Local playback needs Spotify Premium.";
+const ALBUM_TYPE_TIMEOUT: Duration = Duration::from_secs(30);
 pub const PLAYLIST_PAGE_SIZE: u32 = 50;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -496,6 +498,7 @@ pub enum Command {
     },
     /// Internal: an engine connection attempt finished.
     EngineConnected {
+        session_generation: u64,
         engine: Box<Option<Engine>>,
         error: Option<String>,
         lease: CredentialLease,
@@ -538,6 +541,15 @@ pub enum Command {
         generation: u64,
     },
     StoreLikedSongsCache(crate::liked::Cache),
+    /// Resolve the precise type of Web API singles through the streaming session.
+    AlbumTypes(Vec<String>),
+    /// Internal: one precise album type lookup finished.
+    AlbumTypeResolved {
+        uri: String,
+        session_generation: u64,
+        engine_generation: u64,
+        result: Result<bool, String>,
+    },
 }
 
 pub struct LyricsRequest {
@@ -588,6 +600,11 @@ pub enum Event {
     UserName {
         id: String,
         name: Option<String>,
+    },
+    /// Whether Spotify's internal metadata positively identifies an album as an EP.
+    AlbumType {
+        uri: String,
+        result: Result<bool, String>,
     },
     /// The verified personal Web API app, or `None` when it is disabled.
     WebApp {
@@ -655,6 +672,8 @@ pub struct Backend {
     playlist_sample_requests: std::sync::Mutex<Vec<(String, u32, u64)>>,
     #[cfg(test)]
     playlist_add_requests: std::sync::Mutex<Vec<ApiRequest>>,
+    #[cfg(test)]
+    album_type_requests: std::sync::Mutex<Vec<Vec<String>>>,
 }
 
 impl Backend {
@@ -722,6 +741,8 @@ impl Backend {
             playlist_sample_requests: std::sync::Mutex::new(Vec::new()),
             #[cfg(test)]
             playlist_add_requests: std::sync::Mutex::new(Vec::new()),
+            #[cfg(test)]
+            album_type_requests: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -816,6 +837,25 @@ impl Backend {
         self.send(Command::Player(command));
     }
 
+    pub(crate) fn album_types(&self, uris: Vec<String>) {
+        #[cfg(test)]
+        self.album_type_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(uris.clone());
+        self.send(Command::AlbumTypes(uris));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_album_type_requests(&self) -> Vec<Vec<String>> {
+        std::mem::take(
+            &mut *self
+                .album_type_requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+    }
+
     pub fn poll(&self) -> Vec<Event> {
         self.events.try_iter().collect()
     }
@@ -829,6 +869,72 @@ impl Backend {
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AlbumTypeRequest {
+    uri: String,
+    session_generation: u64,
+    engine_generation: u64,
+}
+
+#[derive(Default)]
+struct AlbumTypeLookup {
+    session_generation: u64,
+    engine_generation: u64,
+    pending: VecDeque<String>,
+    seen: HashSet<String>,
+    active: Option<AlbumTypeRequest>,
+}
+
+impl AlbumTypeLookup {
+    fn enqueue(&mut self, signed_in: bool, uris: Vec<String>) {
+        if !signed_in {
+            return;
+        }
+        self.pending
+            .extend(uris.into_iter().filter(|uri| self.seen.insert(uri.clone())));
+    }
+
+    fn next(&mut self) -> Option<AlbumTypeRequest> {
+        if self.active.is_some() {
+            return None;
+        }
+        let request = AlbumTypeRequest {
+            uri: self.pending.pop_front()?,
+            session_generation: self.session_generation,
+            engine_generation: self.engine_generation,
+        };
+        self.active = Some(request.clone());
+        Some(request)
+    }
+
+    fn finish(&mut self, request: &AlbumTypeRequest) -> bool {
+        if self.active.as_ref() != Some(request) {
+            return false;
+        }
+        self.active = None;
+        true
+    }
+
+    fn retire_engine(&mut self) {
+        self.engine_generation = self.engine_generation.wrapping_add(1);
+        self.active = None;
+    }
+
+    fn requeue_active_for_new_engine(&mut self) {
+        self.engine_generation = self.engine_generation.wrapping_add(1);
+        if let Some(request) = self.active.take() {
+            self.pending.push_front(request.uri);
+        }
+    }
+
+    fn reset_session(&mut self) {
+        self.session_generation = self.session_generation.wrapping_add(1);
+        self.retire_engine();
+        self.pending.clear();
+        self.seen.clear();
     }
 }
 
@@ -850,6 +956,7 @@ struct Worker {
     commands: mpsc::UnboundedSender<Command>,
     waker: Waker,
     engine: Option<Arc<Engine>>,
+    album_type_lookup: AlbumTypeLookup,
     /// True while a playback grant or engine connection is in flight, so a
     /// second attempt does not pile up.
     engine_busy: bool,
@@ -901,6 +1008,7 @@ impl Worker {
             commands,
             waker,
             engine: None,
+            album_type_lookup: AlbumTypeLookup::default(),
             engine_busy: false,
             signed_in: false,
             premium: None,
@@ -1055,12 +1163,13 @@ impl Worker {
                     }
                 }
                 Command::EngineConnected {
+                    session_generation,
                     engine,
                     error,
                     lease,
                 } => {
                     if lease.current() && self.signed_in {
-                        self.on_engine_connected(*engine, error)
+                        self.on_engine_connected(session_generation, *engine, error)
                     } else if let Some(engine) = *engine {
                         engine.shutdown();
                     }
@@ -1132,6 +1241,20 @@ impl Worker {
                         }
                     }
                 }
+                Command::AlbumTypes(uris) => self.fetch_album_types(uris),
+                Command::AlbumTypeResolved {
+                    uri,
+                    session_generation,
+                    engine_generation,
+                    result,
+                } => self.on_album_type_resolved(
+                    AlbumTypeRequest {
+                        uri,
+                        session_generation,
+                        engine_generation,
+                    },
+                    result,
+                ),
                 Command::ConfigurePersonalWebApp(client_id) => {
                     self.configure_personal_web_app(client_id)
                 }
@@ -1553,6 +1676,7 @@ impl Worker {
         self.premium = None;
         self.resume = None;
         self.resume_verify = None;
+        self.album_type_lookup.reset_session();
         if let Some(engine) = self.engine.take() {
             engine.shutdown();
         }
@@ -1636,6 +1760,7 @@ impl Worker {
             return;
         }
         self.resume_verify = None;
+        self.album_type_lookup.requeue_active_for_new_engine();
         if let Some(engine) = self.engine.take() {
             self.resume = engine.interrupted().map(|interrupted| LoadSpec {
                 uris: vec![interrupted.uri],
@@ -1751,12 +1876,14 @@ impl Worker {
         let events = self.events.clone();
         let commands = self.commands.clone();
         let waker = self.waker.clone();
+        let session_generation = self.album_type_lookup.session_generation;
         tokio::spawn(async move {
             let cache = match config.open_cache() {
                 Ok(cache) => cache,
                 Err(error) => {
                     let _ = commands.send(Command::EngineConnected {
                         lease: lease.clone(),
+                        session_generation,
                         engine: Box::new(None),
                         error: Some(error.to_string()),
                     });
@@ -1771,6 +1898,7 @@ impl Worker {
             let outcome = match attempt {
                 Ok(Ok(engine)) => Command::EngineConnected {
                     lease: lease.clone(),
+                    session_generation,
                     engine: Box::new(Some(engine)),
                     error: None,
                 },
@@ -1778,12 +1906,14 @@ impl Worker {
                     log::error!("engine connect failed: {error:#}");
                     Command::EngineConnected {
                         lease: lease.clone(),
+                        session_generation,
                         engine: Box::new(None),
                         error: Some(friendly_connect_error(&error)),
                     }
                 }
                 Err(_) => Command::EngineConnected {
                     lease: lease.clone(),
+                    session_generation,
                     engine: Box::new(None),
                     error: Some("Connecting to Spotify timed out".into()),
                 },
@@ -1794,7 +1924,18 @@ impl Worker {
         });
     }
 
-    fn on_engine_connected(&mut self, engine: Option<Engine>, error: Option<String>) {
+    fn on_engine_connected(
+        &mut self,
+        session_generation: u64,
+        engine: Option<Engine>,
+        error: Option<String>,
+    ) {
+        if !self.signed_in || session_generation != self.album_type_lookup.session_generation {
+            if let Some(engine) = engine {
+                engine.shutdown();
+            }
+            return;
+        }
         self.engine_busy = false;
         match engine {
             Some(engine) => {
@@ -1826,6 +1967,7 @@ impl Worker {
                 self.engine = Some(engine);
                 self.reconnects.clear();
                 self.emit(Event::Playback(LocalPlayback::Ready { device_id }));
+                self.start_album_type_lookup();
             }
             None => {
                 self.resume = None;
@@ -1841,6 +1983,7 @@ impl Worker {
     fn on_account_checked(&mut self, premium: Option<bool>) {
         self.premium = premium;
         if premium == Some(false) {
+            self.album_type_lookup.retire_engine();
             if let Some(engine) = self.engine.take() {
                 engine.shutdown();
             }
@@ -1977,6 +2120,47 @@ impl Worker {
             let _ = events.send(Event::Rootlist { result });
             waker.wake();
         });
+    }
+
+    fn fetch_album_types(&mut self, uris: Vec<String>) {
+        self.album_type_lookup.enqueue(self.signed_in, uris);
+        self.start_album_type_lookup();
+    }
+
+    fn start_album_type_lookup(&mut self) {
+        let Some(engine) = self.engine.clone() else {
+            return;
+        };
+        let Some(request) = self.album_type_lookup.next() else {
+            return;
+        };
+        let commands = self.commands.clone();
+        tokio::spawn(async move {
+            let result =
+                match tokio::time::timeout(ALBUM_TYPE_TIMEOUT, engine.album_is_ep(&request.uri))
+                    .await
+                {
+                    Ok(result) => result.map_err(|error| format!("{error:#}")),
+                    Err(_) => Err("album metadata timed out".into()),
+                };
+            let _ = commands.send(Command::AlbumTypeResolved {
+                uri: request.uri,
+                session_generation: request.session_generation,
+                engine_generation: request.engine_generation,
+                result,
+            });
+        });
+    }
+
+    fn on_album_type_resolved(&mut self, request: AlbumTypeRequest, result: Result<bool, String>) {
+        if !self.signed_in || !self.album_type_lookup.finish(&request) {
+            return;
+        }
+        self.emit(Event::AlbumType {
+            uri: request.uri,
+            result,
+        });
+        self.start_album_type_lookup();
     }
 
     fn fetch_lyrics(&self, request: LyricsRequest) {
@@ -2638,6 +2822,81 @@ async fn write_cached_playlist(
     let temporary = path.with_extension("json.tmp");
     tokio::fs::write(&temporary, text).await?;
     crate::util::replace_file(&temporary, path)
+}
+
+#[cfg(test)]
+mod album_type_lookup_tests {
+    use super::AlbumTypeLookup;
+
+    #[test]
+    fn signed_out_requests_are_dropped_and_valid_pending_work_is_deduplicated() {
+        let mut lookup = AlbumTypeLookup::default();
+        lookup.enqueue(false, vec!["signed-out".into()]);
+        assert!(lookup.pending.is_empty());
+
+        lookup.enqueue(true, vec!["first".into(), "first".into(), "second".into()]);
+        assert_eq!(lookup.pending.len(), 2);
+
+        let first = lookup.next().expect("first request when an engine appears");
+        assert_eq!(first.uri, "first");
+        assert!(lookup.next().is_none(), "only one lookup may be active");
+        assert!(lookup.finish(&first));
+        assert_eq!(lookup.next().expect("remaining request").uri, "second");
+    }
+
+    #[test]
+    fn results_from_a_signed_out_session_are_rejected_after_a_new_session_starts() {
+        let mut lookup = AlbumTypeLookup::default();
+        lookup.enqueue(true, vec!["old".into()]);
+        let old = lookup.next().expect("old session request");
+
+        lookup.reset_session();
+        assert!(!lookup.finish(&old));
+        lookup.enqueue(false, vec!["after-logout".into()]);
+        assert!(lookup.pending.is_empty());
+
+        lookup.enqueue(true, vec!["new".into()]);
+        let new = lookup.next().expect("new session request");
+        assert_ne!(old.session_generation, new.session_generation);
+        assert!(!lookup.finish(&old));
+        assert!(lookup.finish(&new));
+    }
+
+    #[test]
+    fn reconnect_requeues_active_work_for_the_new_engine() {
+        let mut lookup = AlbumTypeLookup::default();
+        lookup.enqueue(true, vec!["active".into(), "waiting".into()]);
+        let retired = lookup.next().expect("retired engine request");
+
+        lookup.requeue_active_for_new_engine();
+        assert_eq!(lookup.pending.front().map(String::as_str), Some("active"));
+
+        lookup.enqueue(true, vec!["active".into()]);
+        assert_eq!(lookup.pending.len(), 2, "external duplicates stay ignored");
+
+        let replacement = lookup.next().expect("new engine request");
+        assert_eq!(replacement.uri, "active");
+        assert_eq!(retired.session_generation, replacement.session_generation);
+        assert_ne!(retired.engine_generation, replacement.engine_generation);
+        assert!(!lookup.finish(&retired));
+        assert_eq!(lookup.active.as_ref(), Some(&replacement));
+        assert!(lookup.finish(&replacement));
+        assert_eq!(lookup.next().expect("remaining request").uri, "waiting");
+    }
+
+    #[test]
+    fn completed_failures_remain_terminal_for_the_session() {
+        let mut lookup = AlbumTypeLookup::default();
+
+        for uri in ["error", "timeout"] {
+            lookup.enqueue(true, vec![uri.into()]);
+            let request = lookup.next().expect("request before failure");
+            assert!(lookup.finish(&request));
+
+            lookup.enqueue(true, vec![uri.into()]);
+            assert!(lookup.pending.is_empty(), "failed request must not retry");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -889,8 +889,8 @@ struct AlbumTypeLookup {
 }
 
 impl AlbumTypeLookup {
-    fn enqueue(&mut self, signed_in: bool, uris: Vec<String>) {
-        if !signed_in {
+    fn enqueue(&mut self, signed_in: bool, premium: Option<bool>, uris: Vec<String>) {
+        if !signed_in || premium == Some(false) {
             return;
         }
         self.pending
@@ -930,11 +930,15 @@ impl AlbumTypeLookup {
         }
     }
 
-    fn reset_session(&mut self) {
-        self.session_generation = self.session_generation.wrapping_add(1);
+    fn clear_engine_work(&mut self) {
         self.retire_engine();
         self.pending.clear();
         self.seen.clear();
+    }
+
+    fn reset_session(&mut self) {
+        self.session_generation = self.session_generation.wrapping_add(1);
+        self.clear_engine_work();
     }
 }
 
@@ -1983,7 +1987,7 @@ impl Worker {
     fn on_account_checked(&mut self, premium: Option<bool>) {
         self.premium = premium;
         if premium == Some(false) {
-            self.album_type_lookup.retire_engine();
+            self.album_type_lookup.clear_engine_work();
             if let Some(engine) = self.engine.take() {
                 engine.shutdown();
             }
@@ -2123,7 +2127,8 @@ impl Worker {
     }
 
     fn fetch_album_types(&mut self, uris: Vec<String>) {
-        self.album_type_lookup.enqueue(self.signed_in, uris);
+        self.album_type_lookup
+            .enqueue(self.signed_in, self.premium, uris);
         self.start_album_type_lookup();
     }
 
@@ -2831,10 +2836,14 @@ mod album_type_lookup_tests {
     #[test]
     fn signed_out_requests_are_dropped_and_valid_pending_work_is_deduplicated() {
         let mut lookup = AlbumTypeLookup::default();
-        lookup.enqueue(false, vec!["signed-out".into()]);
+        lookup.enqueue(false, None, vec!["signed-out".into()]);
         assert!(lookup.pending.is_empty());
 
-        lookup.enqueue(true, vec!["first".into(), "first".into(), "second".into()]);
+        lookup.enqueue(
+            true,
+            None,
+            vec!["first".into(), "first".into(), "second".into()],
+        );
         assert_eq!(lookup.pending.len(), 2);
 
         let first = lookup.next().expect("first request when an engine appears");
@@ -2847,15 +2856,15 @@ mod album_type_lookup_tests {
     #[test]
     fn results_from_a_signed_out_session_are_rejected_after_a_new_session_starts() {
         let mut lookup = AlbumTypeLookup::default();
-        lookup.enqueue(true, vec!["old".into()]);
+        lookup.enqueue(true, None, vec!["old".into()]);
         let old = lookup.next().expect("old session request");
 
         lookup.reset_session();
         assert!(!lookup.finish(&old));
-        lookup.enqueue(false, vec!["after-logout".into()]);
+        lookup.enqueue(false, None, vec!["after-logout".into()]);
         assert!(lookup.pending.is_empty());
 
-        lookup.enqueue(true, vec!["new".into()]);
+        lookup.enqueue(true, None, vec!["new".into()]);
         let new = lookup.next().expect("new session request");
         assert_ne!(old.session_generation, new.session_generation);
         assert!(!lookup.finish(&old));
@@ -2865,13 +2874,13 @@ mod album_type_lookup_tests {
     #[test]
     fn reconnect_requeues_active_work_for_the_new_engine() {
         let mut lookup = AlbumTypeLookup::default();
-        lookup.enqueue(true, vec!["active".into(), "waiting".into()]);
+        lookup.enqueue(true, None, vec!["active".into(), "waiting".into()]);
         let retired = lookup.next().expect("retired engine request");
 
         lookup.requeue_active_for_new_engine();
         assert_eq!(lookup.pending.front().map(String::as_str), Some("active"));
 
-        lookup.enqueue(true, vec!["active".into()]);
+        lookup.enqueue(true, None, vec!["active".into()]);
         assert_eq!(lookup.pending.len(), 2, "external duplicates stay ignored");
 
         let replacement = lookup.next().expect("new engine request");
@@ -2889,13 +2898,49 @@ mod album_type_lookup_tests {
         let mut lookup = AlbumTypeLookup::default();
 
         for uri in ["error", "timeout"] {
-            lookup.enqueue(true, vec![uri.into()]);
+            lookup.enqueue(true, None, vec![uri.into()]);
             let request = lookup.next().expect("request before failure");
             assert!(lookup.finish(&request));
 
-            lookup.enqueue(true, vec![uri.into()]);
+            lookup.enqueue(true, None, vec![uri.into()]);
             assert!(lookup.pending.is_empty(), "failed request must not retry");
         }
+    }
+
+    #[test]
+    fn non_premium_status_clears_and_invalidates_all_engine_work() {
+        let mut lookup = AlbumTypeLookup::default();
+        lookup.enqueue(true, None, vec!["active".into(), "pending".into()]);
+        let active = lookup.next().expect("request before account check");
+        let session_generation = lookup.session_generation;
+
+        lookup.clear_engine_work();
+
+        assert_eq!(lookup.session_generation, session_generation);
+        assert_ne!(lookup.engine_generation, active.engine_generation);
+        assert!(lookup.active.is_none());
+        assert!(lookup.pending.is_empty());
+        assert!(lookup.seen.is_empty());
+        assert!(!lookup.finish(&active));
+
+        lookup.enqueue(true, Some(false), vec!["after-check".into()]);
+        assert!(lookup.pending.is_empty());
+        assert!(lookup.seen.is_empty());
+    }
+
+    #[test]
+    fn unknown_and_premium_accounts_accept_album_type_work() {
+        let mut lookup = AlbumTypeLookup::default();
+
+        lookup.enqueue(true, None, vec!["unknown".into()]);
+        let unknown = lookup.next().expect("unknown account request");
+        assert_eq!(unknown.uri, "unknown");
+        assert!(lookup.finish(&unknown));
+
+        lookup.enqueue(true, Some(true), vec!["premium".into()]);
+        let premium = lookup.next().expect("premium account request");
+        assert_eq!(premium.uri, "premium");
+        assert!(lookup.finish(&premium));
     }
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -31,6 +31,8 @@ pub type ApiResult<T> = Result<T, ApiError>;
 
 const PREMIUM_NEEDED: &str = "Local playback needs Spotify Premium.";
 const ALBUM_TYPE_TIMEOUT: Duration = Duration::from_secs(30);
+// Keep at most one full Web API album page outstanding for a playback engine.
+const MAX_PENDING_ALBUM_TYPES: usize = 50;
 pub const PLAYLIST_PAGE_SIZE: u32 = 50;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -893,8 +895,14 @@ impl AlbumTypeLookup {
         if !signed_in || premium == Some(false) {
             return;
         }
-        self.pending
-            .extend(uris.into_iter().filter(|uri| self.seen.insert(uri.clone())));
+        for uri in uris {
+            if self.pending.len() + usize::from(self.active.is_some()) >= MAX_PENDING_ALBUM_TYPES {
+                break;
+            }
+            if self.seen.insert(uri.clone()) {
+                self.pending.push_back(uri);
+            }
+        }
     }
 
     fn next(&mut self) -> Option<AlbumTypeRequest> {
@@ -3136,6 +3144,7 @@ mod authorization_tests {
         let shared = worker.credentials.lease(CredentialSlot::Shared);
         let playback = worker.credentials.lease(CredentialSlot::Playback);
         let attempt = worker.authorization_attempt;
+        let album_type_session = worker.album_type_lookup.session_generation;
         let token = crate::auth::StoredToken {
             client_id: crate::auth::DEFAULT_WEB_CLIENT_ID.into(),
             access_token: "dummy-access".into(),
@@ -3187,6 +3196,7 @@ mod authorization_tests {
             .unwrap();
         commands
             .send(Command::EngineConnected {
+                session_generation: album_type_session,
                 engine: Box::new(None),
                 error: Some("late engine error".into()),
                 lease: playback,
@@ -3303,6 +3313,29 @@ mod authorization_tests {
                 .try_iter()
                 .any(|event| matches!(event, Event::Auth(AuthStatus::Connected { .. })))
         );
+    }
+
+    #[test]
+    fn premium_without_local_playback_keeps_album_type_work_bounded() {
+        let (runtime, mut worker, _) = worker("album-types-without-playback");
+        let _entered = runtime.enter();
+        verify(&mut worker, ApiSource::Shared, "alice");
+        assert_eq!(worker.premium, Some(true));
+        assert!(worker.playback_grant.is_none());
+        assert!(worker.engine.is_none());
+
+        worker.fetch_album_types(
+            (0..MAX_PENDING_ALBUM_TYPES + 10)
+                .map(|index| format!("spotify:album:{index}"))
+                .collect(),
+        );
+
+        assert!(worker.album_type_lookup.active.is_none());
+        assert_eq!(
+            worker.album_type_lookup.pending.len(),
+            MAX_PENDING_ALBUM_TYPES
+        );
+        assert_eq!(worker.album_type_lookup.seen.len(), MAX_PENDING_ALBUM_TYPES);
     }
 
     #[test]

--- a/src/player.rs
+++ b/src/player.rs
@@ -17,6 +17,7 @@ use librespot_connect::{
     Spirc,
 };
 use librespot_core::{
+    SpotifyUri,
     authentication::Credentials,
     cache::Cache,
     config::{DeviceType, SessionConfig},
@@ -24,7 +25,11 @@ use librespot_core::{
     session::Session,
     spotify_id::SpotifyId,
 };
-use librespot_metadata::audio::{AudioItem, UniqueFields};
+use librespot_metadata::{
+    Album as MetadataAlbum, Metadata,
+    album::AlbumType,
+    audio::{AudioItem, UniqueFields},
+};
 use librespot_playback::{
     audio_backend::{self, Sink},
     config::{AudioFormat, Bitrate, NormalisationType, PlayerConfig, VolumeCtrl},
@@ -420,6 +425,15 @@ impl Engine {
 
     pub fn device_id(&self) -> &str {
         &self.device_id
+    }
+
+    /// Whether Spotify classifies this album as an EP in its internal metadata.
+    pub(crate) async fn album_is_ep(&self, album_uri: &str) -> Result<bool> {
+        let uri = SpotifyUri::from_uri(album_uri).context("invalid album URI")?;
+        let album = MetadataAlbum::get(&self.session, &uri)
+            .await
+            .context("album metadata")?;
+        Ok(album.album_type == AlbumType::EP)
     }
 
     /// Spotify's own transcription of a track, as the raw JSON its clients

--- a/src/ui/artist.rs
+++ b/src/ui/artist.rs
@@ -189,8 +189,11 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, id: &str) {
                         .collect();
                     widgets::grid(ui, |ui| {
                         for album in &albums {
-                            let subtitle =
-                                format!("{} • {}", album.year().unwrap_or(""), album.kind_label());
+                            let subtitle = format!(
+                                "{} • {}",
+                                album.year().unwrap_or(""),
+                                app.album_kind_label(album)
+                            );
                             let card = widgets::card(
                                 ui,
                                 app,

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -1175,7 +1175,7 @@ fn album_hero(
         Hero {
             image: pick_image(&album.images, 300),
             liked: false,
-            kind: album.kind_label(),
+            kind: app.album_kind_label(album),
             title: &album.name,
             description: None,
             byline,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -731,7 +731,7 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                     name: album.name.clone(),
                     subtitle: format!(
                         "{} • {}",
-                        album.kind_label(),
+                        app.album_kind_label(album),
                         crate::api::models::join_names(
                             album.artists.iter().map(|a| a.name.as_str())
                         )


### PR DESCRIPTION
## Why

Spotify's Web API groups both singles and EPs under the `single` album type, so Fastpotify currently labels EP releases as `Single`.

However, librespot exposes a more precise album type. For example, *My Dear Melancholy,* and *In Tongues* are returned as `single` by the Web API but as `AlbumType::EP` through librespot.

## What changed

* Use the existing librespot session to check releases classified as `single`.
* Show `EP` when librespot identifies the release as an EP.
* Keep `Single` as the fallback if the metadata is unavailable or the release is a regular single.
* Deduplicate lookups and handle them asynchronously.
* Handle engine reconnections and stale results safely.
* Keep the existing behavior for `Album`, `Compilation`, and `Appears On`.

No new dependencies, extra Spotify sessions, or heuristics were added.

## Testing

Tested locally on macOS.

Passed:

* `cargo fmt --all --check`
* `cargo check --locked`
* `cargo clippy --locked --all-targets -- -D warnings`
* `cargo clippy --locked --all-targets --all-features -- -D warnings`
* `cargo test --locked --all-targets`
* `cargo test --locked --all-targets --all-features`
* doc tests
* `cargo doc --locked --all-features --no-deps`
* Node tests

Manual validation:

* `My Dear Melancholy,` — Web API: `single`, librespot: `EP`
* `In Tongues` — Web API: `single`, librespot: `EP`
* `boygenius` — Web API: `single`, librespot: `EP`
* `LLYLM` — Web API: `single`, librespot: `SINGLE`