### PR TITLE
Fix missing context menus on Search and Home cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ everyday use, and connection details.
 - **Library.** Browse playlists, Liked Songs, saved albums, followed artists,
   podcasts, and saved episodes. Filter, pin, and reorder sidebar items.
 - **Search** across songs, artists, albums, playlists, podcasts, and episodes,
-  with a top result and per-type views. Right-click the top result for its actions.
+  with a top result and per-type views. Right-click results and cards for their actions.
 - **Home** with Made for you, Recently played, your top artists and songs, and
-  recommendations.
+  recommendations. Right-click playlist shortcuts and shelf cards for their actions.
 - **Artist pages** with popular songs, a filterable discography, and related
   artists. **Album**, **playlist**, and **podcast** pages support playback
   from any row.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ everyday use, and connection details.
 - **Library.** Browse playlists, Liked Songs, saved albums, followed artists,
   podcasts, and saved episodes. Filter, pin, and reorder sidebar items.
 - **Search** across songs, artists, albums, playlists, podcasts, and episodes,
-  with a top result and per-type views.
+  with a top result and per-type views. Right-click the top result for its actions.
 - **Home** with Made for you, Recently played, your top artists and songs, and
   recommendations.
 - **Artist pages** with popular songs, a filterable discography, and related

--- a/docs/_guide/getting-started.md
+++ b/docs/_guide/getting-started.md
@@ -73,6 +73,8 @@ You can rename it in Settings.
   searches, and `Q` opens the queue. Ctrl+/ shows the full list.
 - **Rows and cards have context menus.** Right-click a song, playlist, album,
   or artist to see actions such as queue, save, add to playlist, and copy link.
+  Search's **Top result** card has the menu for the song, artist, album,
+  playlist, or podcast it shows.
   If the playlist already contains the song, Fastpotify asks before adding
   another copy.
 - **Spotify links open in Fastpotify.** A `spotify:` link shared from another

--- a/docs/_guide/getting-started.md
+++ b/docs/_guide/getting-started.md
@@ -74,7 +74,9 @@ You can rename it in Settings.
 - **Rows and cards have context menus.** Right-click a song, playlist, album,
   or artist to see actions such as queue, save, add to playlist, and copy link.
   Search's **Top result** card has the menu for the song, artist, album,
-  playlist, or podcast it shows.
+  playlist, or podcast it shows. Search shelves and filtered grids, and Home's
+  playlist shortcuts, Made for you, Recently played, and top artist cards offer
+  the same menus. Your own playlists include **Edit details** and **Delete**.
   If the playlist already contains the song, Fastpotify asks before adding
   another copy.
 - **Spotify links open in Fastpotify.** A `spotify:` link shared from another

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1345,16 +1345,25 @@ mod tests {
         app: &mut App,
         events: Vec<egui::Event>,
     ) -> Vec<(String, egui::Rect)> {
+        view_frame(ctx, app, events, crate::ui::search::show)
+    }
+
+    fn view_frame(
+        ctx: &egui::Context,
+        app: &mut App,
+        events: Vec<egui::Event>,
+        view: fn(&mut App, &mut egui::Ui),
+    ) -> Vec<(String, egui::Rect)> {
         let mut output = ctx.run_ui(
             egui::RawInput {
                 screen_rect: Some(egui::Rect::from_min_size(
                     egui::Pos2::ZERO,
-                    egui::vec2(1280.0, 800.0),
+                    egui::vec2(1280.0, 2200.0),
                 )),
                 events,
                 ..Default::default()
             },
-            |ui| crate::ui::search::show(app, ui),
+            |ui| view(app, ui),
         );
         output.textures_delta.clear();
         fn walk(shape: &egui::epaint::Shape, text: &mut Vec<(String, egui::Rect)>) {
@@ -1511,6 +1520,208 @@ mod tests {
             );
             app.backend.shutdown();
         }
+    }
+
+    fn check_card_menu(
+        app: &mut App,
+        ctx: &egui::Context,
+        view: fn(&mut App, &mut egui::Ui),
+        section: &str,
+        title: &str,
+        uri: &str,
+        labels: &[&str],
+    ) {
+        view_frame(ctx, app, vec![], view);
+        let text = view_frame(ctx, app, vec![], view);
+        let below = text
+            .iter()
+            .find(|(text, _)| text == section)
+            .unwrap()
+            .1
+            .bottom();
+        let pos = text
+            .iter()
+            .find(|(text, rect)| text == title && rect.top() >= below)
+            .unwrap_or_else(|| panic!("{title} in {section}"))
+            .1
+            .center();
+        let earlier_card = text
+            .iter()
+            .find(|(_, rect)| (rect.center().y - pos.y).abs() < 1.0 && rect.center().x < pos.x)
+            .map(|(_, rect)| rect.center());
+        app.actions.clear();
+        view_frame(
+            ctx,
+            app,
+            pointer_click(pos, egui::PointerButton::Secondary),
+            view,
+        );
+        // A hovered Play button must not change which item owns the open menu.
+        if let Some(pos) = earlier_card {
+            view_frame(ctx, app, vec![egui::Event::PointerMoved(pos)], view);
+        }
+        let text = view_frame(ctx, app, vec![], view);
+        assert!(
+            app.actions.is_empty(),
+            "right-click must not navigate or play"
+        );
+        for label in labels {
+            assert!(
+                text.iter().any(|(text, _)| text == label),
+                "{section}: missing {label}"
+            );
+        }
+        let copy = text
+            .iter()
+            .find(|(text, _)| text == "Copy link")
+            .unwrap_or_else(|| panic!("{section}: no menu for {title}"));
+        view_frame(
+            ctx,
+            app,
+            pointer_click(copy.1.center(), egui::PointerButton::Primary),
+            view,
+        );
+        assert!(matches!(app.actions.as_slice(), [Action::CopyLink(link)] if link == uri));
+    }
+
+    #[test]
+    fn search_shelves_and_filtered_grids_open_item_menus() {
+        for (filter, title, uri, labels) in [
+            (
+                SearchFilter::Artists,
+                artist(1).name,
+                artist(1).uri,
+                vec!["Follow"],
+            ),
+            (
+                SearchFilter::Albums,
+                album(0).name,
+                album(0).uri,
+                vec!["Play next", "Add to Your Library"],
+            ),
+            (
+                SearchFilter::Playlists,
+                playlist(1).name,
+                playlist(1).uri,
+                vec!["Edit details", "Delete"],
+            ),
+            (
+                SearchFilter::Podcasts,
+                show(0).name,
+                show(0).uri,
+                vec!["Add to Your Library"],
+            ),
+        ] {
+            for selected in [SearchFilter::All, filter] {
+                let (ctx, mut app) =
+                    accessible_app(&format!("search-card-{selected:?}-{filter:?}"));
+                app.saved.clear();
+                app.search.filter = selected;
+                // Keep matching artist subtitles in song rows out of the card lookup.
+                if let Loadable::Loaded(results) = &mut app.search.results {
+                    results.tracks = None;
+                    results.episodes = None;
+                }
+                let section = if selected == SearchFilter::All {
+                    filter.label()
+                } else {
+                    "All"
+                };
+                check_card_menu(
+                    &mut app,
+                    &ctx,
+                    crate::ui::search::show,
+                    section,
+                    &title,
+                    &uri,
+                    &labels,
+                );
+                app.backend.shutdown();
+            }
+        }
+    }
+
+    #[test]
+    fn home_cards_open_item_menus() {
+        for (section, title, uri, labels) in [
+            (
+                crate::util::greeting(),
+                playlist(1).name,
+                playlist(1).uri,
+                vec!["Edit details", "Delete"],
+            ),
+            (
+                crate::util::greeting(),
+                playlist(0).name,
+                playlist(0).uri,
+                vec!["Remove from Your Library"],
+            ),
+            (
+                "Made for you",
+                playlist(0).name,
+                playlist(0).uri,
+                vec!["Remove from Your Library"],
+            ),
+            (
+                "Recently played",
+                track(5).name,
+                track(5).uri,
+                vec!["Play next", "Add to playlist", "Go to song radio"],
+            ),
+            (
+                "Your top artists",
+                artist(1).name,
+                artist(1).uri,
+                vec!["Follow"],
+            ),
+        ] {
+            let (ctx, mut app) = accessible_app(&format!("home-card-{section}-{title}"));
+            check_card_menu(
+                &mut app,
+                &ctx,
+                crate::ui::home::show,
+                section,
+                &title,
+                &uri,
+                &labels,
+            );
+            app.backend.shutdown();
+        }
+    }
+
+    #[test]
+    fn home_liked_songs_tile_keeps_its_primary_click_only() {
+        let (ctx, mut app) = accessible_app("home-liked-tile");
+        let view = crate::ui::home::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let text = view_frame(&ctx, &mut app, vec![], view);
+        let pos = text
+            .iter()
+            .find(|(text, _)| text == "Liked Songs")
+            .unwrap()
+            .1
+            .center();
+        app.actions.clear();
+        view_frame(
+            &ctx,
+            &mut app,
+            pointer_click(pos, egui::PointerButton::Secondary),
+            view,
+        );
+        let text = view_frame(&ctx, &mut app, vec![], view);
+        assert!(app.actions.is_empty());
+        assert!(!text.iter().any(|(text, _)| text == "Copy link"));
+        view_frame(
+            &ctx,
+            &mut app,
+            pointer_click(pos, egui::PointerButton::Primary),
+            view,
+        );
+        assert!(matches!(
+            app.actions.as_slice(),
+            [Action::Open(Page::LikedSongs)]
+        ));
+        app.backend.shutdown();
     }
 
     fn frame_events(ctx: &egui::Context, app: &mut App, events: Vec<egui::Event>) {

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1340,6 +1340,179 @@ mod tests {
         frame_events(ctx, app, Vec::new());
     }
 
+    fn search_frame(
+        ctx: &egui::Context,
+        app: &mut App,
+        events: Vec<egui::Event>,
+    ) -> Vec<(String, egui::Rect)> {
+        let mut output = ctx.run_ui(
+            egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::Pos2::ZERO,
+                    egui::vec2(1280.0, 800.0),
+                )),
+                events,
+                ..Default::default()
+            },
+            |ui| crate::ui::search::show(app, ui),
+        );
+        output.textures_delta.clear();
+        fn walk(shape: &egui::epaint::Shape, text: &mut Vec<(String, egui::Rect)>) {
+            match shape {
+                egui::epaint::Shape::Text(shape) => text.push((
+                    shape.galley.job.text.clone(),
+                    shape.galley.rect.translate(shape.pos.to_vec2()),
+                )),
+                egui::epaint::Shape::Vec(shapes) => {
+                    shapes.iter().for_each(|shape| walk(shape, text));
+                }
+                _ => {}
+            }
+        }
+        let mut text = Vec::new();
+        for shape in &output.shapes {
+            walk(&shape.shape, &mut text);
+        }
+        text
+    }
+
+    fn pointer_click(pos: egui::Pos2, button: egui::PointerButton) -> Vec<egui::Event> {
+        vec![
+            egui::Event::PointerMoved(pos),
+            egui::Event::PointerButton {
+                pos,
+                button,
+                pressed: true,
+                modifiers: egui::Modifiers::NONE,
+            },
+            egui::Event::PointerButton {
+                pos,
+                button,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            },
+        ]
+    }
+
+    #[test]
+    fn search_top_result_opens_the_menu_for_its_item() {
+        for kind in ["track", "artist", "album", "playlist", "show"] {
+            let (ctx, mut app) = accessible_app(&format!("top-result-{kind}"));
+            let (results, title, uri) = match kind {
+                "track" => {
+                    let item = track(0);
+                    (
+                        SearchResults {
+                            tracks: Some(page(vec![item.clone()])),
+                            ..Default::default()
+                        },
+                        item.name,
+                        item.uri,
+                    )
+                }
+                "artist" => {
+                    let item = artist(0);
+                    (
+                        SearchResults {
+                            artists: Some(page(vec![item.clone()])),
+                            ..Default::default()
+                        },
+                        item.name,
+                        item.uri,
+                    )
+                }
+                "album" => {
+                    let item = album(0);
+                    (
+                        SearchResults {
+                            albums: Some(page(vec![item.clone()])),
+                            ..Default::default()
+                        },
+                        item.name,
+                        item.uri,
+                    )
+                }
+                "playlist" => {
+                    let item = playlist(0);
+                    (
+                        SearchResults {
+                            playlists: Some(page(vec![item.clone()])),
+                            ..Default::default()
+                        },
+                        item.name,
+                        item.uri,
+                    )
+                }
+                _ => {
+                    let item = show(0);
+                    (
+                        SearchResults {
+                            shows: Some(page(vec![item.clone()])),
+                            ..Default::default()
+                        },
+                        item.name,
+                        item.uri,
+                    )
+                }
+            };
+            app.search.results = Loadable::Loaded(results);
+            app.saved.clear();
+            search_frame(&ctx, &mut app, vec![]);
+            let text = search_frame(&ctx, &mut app, vec![]);
+            let pos = text
+                .iter()
+                .find(|(text, _)| text == &title)
+                .expect("top result title")
+                .1
+                .center();
+            app.actions.clear();
+            search_frame(
+                &ctx,
+                &mut app,
+                pointer_click(pos, egui::PointerButton::Secondary),
+            );
+            let text = search_frame(&ctx, &mut app, vec![]);
+            assert!(
+                app.actions.is_empty(),
+                "right-clicking {kind} must not navigate or play"
+            );
+            let expected = match kind {
+                "track" => &[
+                    "Play next",
+                    "Save to Liked Songs",
+                    "Add to playlist",
+                    "Go to song radio",
+                    "Go to artist",
+                    "Go to album",
+                ][..],
+                "artist" => &["Play", "Follow"][..],
+                "album" => &["Play", "Shuffle play", "Play next", "Add to Your Library"][..],
+                _ => &["Play", "Add to Your Library"][..],
+            };
+            for label in expected {
+                assert!(
+                    text.iter().any(|(text, _)| text == label),
+                    "{kind} menu is missing {label}"
+                );
+            }
+            let copy = text
+                .iter()
+                .find(|(text, _)| text == "Copy link")
+                .unwrap_or_else(|| {
+                    panic!("right-clicking the {kind} top result must open its menu")
+                });
+            search_frame(
+                &ctx,
+                &mut app,
+                pointer_click(copy.1.center(), egui::PointerButton::Primary),
+            );
+            assert!(
+                matches!(app.actions.as_slice(), [crate::model::Action::CopyLink(link)] if link == &uri)
+            );
+            app.backend.shutdown();
+        }
+    }
+
     fn frame_events(ctx: &egui::Context, app: &mut App, events: Vec<egui::Event>) {
         let input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -32,6 +32,7 @@ struct Tile {
     page: Page,
     uri: Option<String>,
     liked: bool,
+    owned_playlist: Option<Playlist>,
 }
 
 fn quick_access(app: &mut App, ui: &mut egui::Ui) {
@@ -45,6 +46,7 @@ fn quick_access(app: &mut App, ui: &mut egui::Ui) {
             .as_ref()
             .map(|user| format!("spotify:user:{}:collection", user.id)),
         liked: true,
+        owned_playlist: None,
     }];
     if let Some(playlists) = app.library.playlists.get() {
         for playlist in playlists.iter().take(7) {
@@ -54,6 +56,10 @@ fn quick_access(app: &mut App, ui: &mut egui::Ui) {
                 page: Page::Playlist(playlist.id.clone()),
                 uri: Some(playlist.uri.clone()),
                 liked: false,
+                owned_playlist: app
+                    .user_id()
+                    .is_some_and(|id| playlist.owned_by(id))
+                    .then(|| playlist.clone()),
             });
         }
     }
@@ -72,6 +78,7 @@ fn quick_access(app: &mut App, ui: &mut egui::Ui) {
                     page,
                     uri,
                     liked,
+                    owned_playlist,
                 }) = tiles.get(row * columns + column)
                 else {
                     break;
@@ -142,11 +149,23 @@ fn quick_access(app: &mut App, ui: &mut egui::Ui) {
                         }
                     }
                 }
-                if response
-                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                    .clicked()
-                {
+                let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+                if response.clicked() {
                     app.actions.push(Action::Open(page.clone()));
+                }
+                if !liked && let Some(uri) = uri {
+                    egui::Popup::context_menu(&response)
+                        .id(ui.make_persistent_id(("quick-access-menu", uri)))
+                        .frame(widgets::menu_frame(&palette))
+                        .show(|ui| {
+                            widgets::context_menu_items(
+                                ui,
+                                app,
+                                uri,
+                                name,
+                                owned_playlist.as_ref(),
+                            );
+                        });
                 }
             }
         });
@@ -212,6 +231,19 @@ fn made_for_you(app: &mut App, ui: &mut egui::Ui) {
                 app.actions
                     .push(Action::Open(Page::Playlist(playlist.id.clone())));
             }
+            egui::Popup::context_menu(&card.response)
+                .id(ui.make_persistent_id(("home-made_for_you-menu", &playlist.uri)))
+                .frame(widgets::menu_frame(&palette))
+                .show(|ui| {
+                    let owned = app.user_id().is_some_and(|id| playlist.owned_by(id));
+                    widgets::context_menu_items(
+                        ui,
+                        app,
+                        &playlist.uri,
+                        &playlist.name,
+                        owned.then_some(playlist),
+                    );
+                });
         }
     });
 }
@@ -273,6 +305,12 @@ fn recently_played(app: &mut App, ui: &mut egui::Ui) {
                 app.actions
                     .push(Action::Open(Page::Album(album.id.clone())));
             }
+            egui::Popup::context_menu(&card.response)
+                .id(ui.make_persistent_id(("home-recently_played-menu", &track.uri)))
+                .frame(widgets::menu_frame(&palette))
+                .show(|ui| {
+                    widgets::item_menu(ui, app, &PlayableItem::Track(track.clone()), None, None);
+                });
         }
     });
 }
@@ -319,6 +357,12 @@ fn top_artists(app: &mut App, ui: &mut egui::Ui) {
                 app.actions
                     .push(Action::Open(Page::Artist(artist.id.clone())));
             }
+            egui::Popup::context_menu(&card.response)
+                .id(ui.make_persistent_id(("home-top_artists-menu", &artist.uri)))
+                .frame(widgets::menu_frame(&palette))
+                .show(|ui| {
+                    widgets::context_menu_items(ui, app, &artist.uri, &artist.name, None);
+                });
         }
     });
 }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -181,7 +181,14 @@ fn all(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
                     Some(playlist.uri.clone()),
                     Page::Playlist(playlist.id.clone()),
                     |ui, app| {
-                        widgets::context_menu_items(ui, app, &playlist.uri, &playlist.name, None);
+                        let owned = app.user_id().is_some_and(|id| playlist.owned_by(id));
+                        widgets::context_menu_items(
+                            ui,
+                            app,
+                            &playlist.uri,
+                            &playlist.name,
+                            owned.then_some(playlist),
+                        );
                     },
                 );
             } else if let Some(show) = results.shows.as_ref().and_then(|page| page.items.first()) {
@@ -398,6 +405,12 @@ fn artist_card(app: &mut App, ui: &mut egui::Ui, artist: &Artist) {
         app.actions
             .push(Action::Open(Page::Artist(artist.id.clone())));
     }
+    egui::Popup::context_menu(&card.response)
+        .id(ui.make_persistent_id(("search-artist-menu", &artist.uri)))
+        .frame(widgets::menu_frame(&app.palette))
+        .show(|ui| {
+            widgets::context_menu_items(ui, app, &artist.uri, &artist.name, None);
+        });
 }
 
 fn shelf_artists(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
@@ -448,6 +461,12 @@ fn album_card(app: &mut App, ui: &mut egui::Ui, album: &crate::api::models::Albu
         app.actions
             .push(Action::Open(Page::Album(album.id.clone())));
     }
+    egui::Popup::context_menu(&card.response)
+        .id(ui.make_persistent_id(("search-album-menu", &album.uri)))
+        .frame(widgets::menu_frame(&app.palette))
+        .show(|ui| {
+            widgets::context_menu_items(ui, app, &album.uri, &album.name, None);
+        });
 }
 
 fn shelf_albums(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
@@ -493,6 +512,19 @@ fn playlist_card(app: &mut App, ui: &mut egui::Ui, playlist: &crate::api::models
         app.actions
             .push(Action::Open(Page::Playlist(playlist.id.clone())));
     }
+    egui::Popup::context_menu(&card.response)
+        .id(ui.make_persistent_id(("search-playlist-menu", &playlist.uri)))
+        .frame(widgets::menu_frame(&app.palette))
+        .show(|ui| {
+            let owned = app.user_id().is_some_and(|id| playlist.owned_by(id));
+            widgets::context_menu_items(
+                ui,
+                app,
+                &playlist.uri,
+                &playlist.name,
+                owned.then_some(playlist),
+            );
+        });
 }
 
 fn shelf_playlists(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
@@ -534,6 +566,12 @@ fn show_card(app: &mut App, ui: &mut egui::Ui, show: &crate::api::models::Show) 
     if card.clicked {
         app.actions.push(Action::Open(Page::Show(show.id.clone())));
     }
+    egui::Popup::context_menu(&card.response)
+        .id(ui.make_persistent_id(("search-show-menu", &show.uri)))
+        .frame(widgets::menu_frame(&app.palette))
+        .show(|ui| {
+            widgets::context_menu_items(ui, app, &show.uri, &show.name, None);
+        });
 }
 
 fn shelf_shows(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -116,6 +116,9 @@ fn all(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
                     true,
                     Some(artist.uri.clone()),
                     Page::Artist(artist.id.clone()),
+                    |ui, app| {
+                        widgets::context_menu_items(ui, app, &artist.uri, &artist.name, None);
+                    },
                 );
             } else if let Some(track) = results.tracks.as_ref().and_then(|page| page.items.first())
             {
@@ -133,6 +136,15 @@ fn all(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
                     false,
                     Some(track.uri.clone()),
                     page,
+                    |ui, app| {
+                        widgets::item_menu(
+                            ui,
+                            app,
+                            &PlayableItem::Track(track.clone()),
+                            None,
+                            None,
+                        );
+                    },
                 );
             } else if let Some(album) = results.albums.as_ref().and_then(|page| page.items.first())
             {
@@ -150,6 +162,9 @@ fn all(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
                     false,
                     Some(album.uri.clone()),
                     Page::Album(album.id.clone()),
+                    |ui, app| {
+                        widgets::context_menu_items(ui, app, &album.uri, &album.name, None);
+                    },
                 );
             } else if let Some(playlist) = results
                 .playlists
@@ -165,6 +180,9 @@ fn all(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
                     false,
                     Some(playlist.uri.clone()),
                     Page::Playlist(playlist.id.clone()),
+                    |ui, app| {
+                        widgets::context_menu_items(ui, app, &playlist.uri, &playlist.name, None);
+                    },
                 );
             } else if let Some(show) = results.shows.as_ref().and_then(|page| page.items.first()) {
                 top_result(
@@ -176,6 +194,9 @@ fn all(app: &mut App, ui: &mut egui::Ui, results: &SearchResults) {
                     false,
                     Some(show.uri.clone()),
                     Page::Show(show.id.clone()),
+                    |ui, app| {
+                        widgets::context_menu_items(ui, app, &show.uri, &show.name, None);
+                    },
                 );
             }
         });
@@ -216,6 +237,7 @@ fn top_result(
     round: bool,
     play_uri: Option<String>,
     page: Page,
+    menu: impl FnOnce(&mut egui::Ui, &mut App),
 ) {
     let palette = app.palette;
     let (rect, response) =
@@ -299,13 +321,13 @@ fn top_result(
             }
         }
     }
-    if response
-        .on_hover_cursor(egui::CursorIcon::PointingHand)
-        .clicked()
-        && page != Page::Search
-    {
+    let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+    if response.clicked() && page != Page::Search {
         app.actions.push(Action::Open(page));
     }
+    egui::Popup::context_menu(&response)
+        .frame(widgets::menu_frame(&palette))
+        .show(|ui| menu(ui, app));
 }
 
 fn songs(app: &mut App, ui: &mut egui::Ui, results: &SearchResults, limit: usize) {

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1585,6 +1585,9 @@ pub fn ellipsized(
 }
 
 pub struct CardResponse {
+    /// Give attached menus an item-based ID: hovering a Play button can shift
+    /// later cards' automatic response IDs.
+    pub response: egui::Response,
     pub clicked: bool,
     pub play: bool,
 }
@@ -1731,6 +1734,7 @@ pub fn card(
     theme::focus_ring(ui, &response);
     CardResponse {
         clicked: response.clicked() && !play,
+        response,
         play,
     }
 }


### PR DESCRIPTION
## Why

- Top Result and several Search/Home cards ignore right-clicks because they never register a context menu. This makes common actions available on song rows but unavailable on the cards.
- Parity with the official spotify app

Fixes: #357

## What changed

- Register the existing item menus on Top Result, Search shelves and filtered grids, and Home playlist shortcuts, Made for you, Recently played, and top artists. Owned playlists include Edit details and Delete.
- Keep menus attached to the selected item when earlier cards show their Play buttons on hover, using persistent popup IDs. Add pointer-input regression tests and update the user guide.

| Surface | Before fix, after right-click | After fix, after right-click |
| --- | --- | --- |
| Top Result | ![Before: Top Result](https://github.com/user-attachments/assets/1fb92a86-2219-4aa7-b287-e38ce2bdaaf8) | ![After: Top Result](https://github.com/user-attachments/assets/5f35e47b-b722-49b7-8252-6ae3da43a51e) |
| Search artist shelf | ![Before: Search artist shelf](https://github.com/user-attachments/assets/053303d2-da7b-436f-bc1f-7195df8cef66) | ![After: Search artist shelf](https://github.com/user-attachments/assets/00c90787-ae75-4720-b02a-2a0b12eb6b45) |
| Home playlist shortcut | ![Before: Home playlist shortcut](https://github.com/user-attachments/assets/62bfa131-644f-4204-851d-bb15cdff26fa) | ![After: Home playlist shortcut](https://github.com/user-attachments/assets/c99686c0-cb57-4427-aa41-bdfdb1678dd8) |

<details>
<summary>Additional working menus</summary>

![Home playlist shortcut, light theme at 1000×800](https://github.com/user-attachments/assets/33d85f22-299e-4f22-8e06-e5affca2e701)

![Search playlist grid, light theme](https://github.com/user-attachments/assets/8813628f-dd0b-4a28-9b5a-ced120ef011d)

![Home Recently played, Add to playlist submenu](https://github.com/user-attachments/assets/1b40e24a-506c-4434-aeec-5360d3be686d)

![Home top artists](https://github.com/user-attachments/assets/e7e21788-8c2f-49be-972c-b541452bdf03)

![Playlist Edit details dialog](https://github.com/user-attachments/assets/c8f34211-2d82-45b1-abfa-63b91d1ea91b)

</details>

## Verification

- Manually drove the Linux demo UI in dark and light themes at 1440×1100 and 1000×800. Checked all five Top Result types, the affected Search/Home cards, clipboard URLs, the playlist edit dialog, submenus, normal navigation, and Liked Songs. Screenshots use demo fixtures.
- All repository checks passed: 360 library tests and 5 binary tests in each feature configuration, plus 24 Node tests. Native playback and server-side persistence were not tested in the offline demo; Windows and macOS were not tested locally.

<details>
<summary>Commands run</summary>

```sh
node --test .github/scripts/issue-assessment.test.cjs
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets
cargo test --locked --all-targets --all-features
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
cargo build --locked --features demo
bundle exec jekyll build
```

Jekyll used an isolated Bundler Gemfile and gem directory.

</details>

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
