### PR TITLE
fix(flatpak): persist the state directory so sign-in survives a quit

### DIFF
--- a/packaging/flatpak/rocks.fastpotify.Fastpotify.bundle.yml
+++ b/packaging/flatpak/rocks.fastpotify.Fastpotify.bundle.yml
@@ -16,6 +16,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.mpris.MediaPlayer2.fastpotify
   - --own-name=rocks.fastpotify.Instance
+  - --persist=.local/state
 modules:
   - name: fastpotify
     buildsystem: simple

--- a/packaging/flatpak/rocks.fastpotify.Fastpotify.yml
+++ b/packaging/flatpak/rocks.fastpotify.Fastpotify.yml
@@ -32,6 +32,11 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.mpris.MediaPlayer2.fastpotify
   - --own-name=rocks.fastpotify.Instance
+  # Sign-in tokens, playback credentials, the session, history and the run's
+  # log live under the state directory. Flatpak binds config, data and cache
+  # into the app's per-user directory but not state, so persist it or a quit
+  # signs the listener out and drops the approved devices.
+  - --persist=.local/state
 build-options:
   append-path: /usr/lib/sdk/rust-stable/bin
   env:


### PR DESCRIPTION
Fixes #125.

## Why

On Linux the Flatpak build asks the listener to sign in again on every launch, re-approves playback devices each time, and keeps no log — the three symptoms in #125.

Flatpak points `XDG_CONFIG_HOME`, `XDG_DATA_HOME` and `XDG_CACHE_HOME` into `~/.var/app/rocks.fastpotify.Fastpotify/{config,data,cache}`, which persist, but leaves `XDG_STATE_HOME` unset. `AppDirs::discover` (`src/paths.rs`) then resolves the state directory to `$HOME/.local/state/fastpotify`, and inside the sandbox `$HOME` is an ephemeral overlay that no `--filesystem` permission persists. Every durable file kept there — `shared_web_api_token.json`, `personal_web_api_token.json`, `credentials/`, `session.json`, `history.json` and `fastpotify.log` — is written to that volatile path and lost when the app fully quits. Config (`settings.json`) and data (`app.ron`) survive precisely because their XDG dirs are bound into the per-user directory.

## What changed

Add `--persist=.local/state` to `finish-args` in both `packaging/flatpak/rocks.fastpotify.Fastpotify.yml` and `packaging/flatpak/rocks.fastpotify.Fastpotify.bundle.yml`. `flathub.sh` copies the finish-args verbatim, so the Flathub manifest inherits the fix. No app code changes; the paths already documented in `docs/_reference/settings-and-files.md` become true on Flatpak.

## How tested

Reproduced on 0.7.1 (Flatpak): a full quit (tray → Quit, with no `fastpotify` process left running) followed by a relaunch returned to the sign-in screen. Confirmed inside the sandbox that `XDG_STATE_HOME` is empty and the state directory resolves under the ephemeral `$HOME`.

Verified the fix by applying its equivalent with `flatpak override --user --persist=.local/state rocks.fastpotify.Fastpotify`: a probe written to `$HOME/.local/state/fastpotify/` then survived across separate launches and appeared in `~/.var/app/rocks.fastpotify.Fastpotify/.local/state/`, which is exactly where the sign-in and credential files are written.
