### PR TITLE
Add search to the Settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
 from artwork, and the mini player's skin and size.
 Playback settings apply when you press **Apply and restart playback**.
+The Settings page has its own search: type under the title to narrow the
+rows, clear the field to see everything again.
 You can also check for a new release from Settings. On macOS, the same command
 is in the application menu.
 

--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -11,7 +11,6 @@ Home, and hold `Shift` while turning the mouse wheel. The shelf moves while
 the surrounding page stays put. Release `Shift` to scroll the page normally.
 
 ## Dragging beyond the visible list
-
 On `main`, for the release after 0.7.1, hold a dragged song near the top or
 bottom of an editable playlist's visible area to scroll. Scrolling gets faster
 closer to the edge and stops when you move away or release the mouse. This
@@ -32,6 +31,12 @@ of the playlist scrolls to positions beyond the visible rows.
 
 The Library sidebar also scrolls near its edges when you drag a song toward a
 playlist or reorder its entries. Only the list under the pointer scrolls.
+
+## Finding a setting
+
+The Settings page has its own search field under the title. Type to narrow
+the page to matching rows; sections without matches disappear. Clear the
+field to see everything again.
 
 ## Keyboard and screen readers
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6207,6 +6207,9 @@ impl App {
                 self.settings_dirty = true;
                 self.dialog = None;
                 self.open(Page::Settings);
+                // A saved search could be hiding the Client ID field the
+                // flow is about to focus, so drop it before landing.
+                crate::ui::settings::clear_search(ctx);
                 ctx.data_mut(|data| {
                     data.insert_temp(
                         egui::Id::new(crate::ui::settings::PERSONAL_APP_FOCUS_ID),

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1188,6 +1188,122 @@ mod tests {
         app.backend.shutdown();
     }
 
+    fn settings_filter(ctx: &egui::Context) -> String {
+        ctx.data_mut(|data| {
+            data.get_temp::<String>(egui::Id::new("settings-filter"))
+                .unwrap_or_default()
+        })
+    }
+
+    #[test]
+    fn settings_search_filters_rows_clearing_and_empty_state() {
+        use egui::accesskit::{Action as AccessibleAction, Role};
+        let (ctx, mut app) = accessible_app("settings-search");
+        app.open(Page::Settings);
+        accessible_frame(&ctx, &mut app, vec![]);
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let field = accessible_node(&tree, "Search settings", Role::TextInput);
+        // Typing narrows the page to matching rows.
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(field, AccessibleAction::Focus, None)],
+        );
+        let tree = accessible_frame(&ctx, &mut app, vec![egui::Event::Text("volume".into())]);
+        assert_eq!(settings_filter(&ctx), "volume");
+        accessible_node(&tree, "Normalize volume", Role::CheckBox);
+        assert!(
+            !tree
+                .nodes
+                .iter()
+                .any(|(_, node)| node.label() == Some("Compact track list")),
+            "non-matching rows stay hidden while filtering"
+        );
+        // Clearing the field brings every row back.
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let clear = accessible_node(&tree, "Clear", Role::Button);
+        let tree = accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(clear, AccessibleAction::Click, None)],
+        );
+        assert!(settings_filter(&ctx).is_empty());
+        accessible_node(&tree, "Compact track list", Role::CheckBox);
+        // Gibberish matches nothing: every section's controls disappear
+        // and the empty state takes the page. (Plain labels expose no
+        // accesskit name, so the empty state itself is covered through
+        // the absence of each section's controls.)
+        let field = accessible_node(&tree, "Search settings", Role::TextInput);
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(field, AccessibleAction::Focus, None)],
+        );
+        let tree = accessible_frame(&ctx, &mut app, vec![egui::Event::Text("zzznope".into())]);
+        assert_eq!(settings_filter(&ctx), "zzznope");
+        for (label, role) in [
+            ("Sign out", Role::Button),
+            ("Normalize volume", Role::CheckBox),
+            ("Dark", Role::Button),
+            ("Switch to it", Role::Button),
+            ("MilkDrop window", Role::CheckBox),
+            ("Equalizer", Role::CheckBox),
+            ("Clear artwork", Role::Button),
+            ("Check for updates", Role::Button),
+        ] {
+            assert!(
+                tree.nodes
+                    .iter()
+                    .all(|(_, node)| !(node.label() == Some(label) && node.role() == role)),
+                "{label} is hidden when nothing matches"
+            );
+        }
+        app.backend.shutdown();
+    }
+
+    #[test]
+    fn personal_app_setup_clears_a_saved_settings_search() {
+        use egui::accesskit::{Action as AccessibleAction, Role};
+        let (ctx, mut app) = accessible_app("settings-search-setup");
+        app.open(Page::Settings);
+        accessible_frame(&ctx, &mut app, vec![]);
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let field = accessible_node(&tree, "Search settings", Role::TextInput);
+        // Search for something that hides the Account section...
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(field, AccessibleAction::Focus, None)],
+        );
+        accessible_frame(&ctx, &mut app, vec![egui::Event::Text("theme".into())]);
+        assert_eq!(settings_filter(&ctx), "theme");
+        // ...leave Settings...
+        app.open(Page::Home);
+        accessible_frame(&ctx, &mut app, vec![]);
+        // ...and enter Personal App setup, which must reveal and focus
+        // the Client ID field instead of landing on a filtered-out row.
+        app.dialog = Some(Dialog::PersonalAppIntro);
+        accessible_frame(&ctx, &mut app, vec![]);
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let setup = accessible_node(&tree, "Set up personal app", Role::Button);
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(setup, AccessibleAction::Click, None)],
+        );
+        assert_eq!(app.page(), &Page::Settings);
+        assert!(
+            settings_filter(&ctx).is_empty(),
+            "setup must drop the saved search so its row is visible"
+        );
+        accessible_frame(&ctx, &mut app, vec![]);
+        assert!(
+            ctx.memory(|memory| memory.has_focus(egui::Id::new("personal-web-client-id"))),
+            "the Client ID field takes focus once its row is visible"
+        );
+        app.backend.shutdown();
+    }
+
     #[test]
     fn accessible_sliders_accept_keyboard_and_screen_reader_values() {
         use crate::ui::widgets::{SliderEvent, thin_slider};

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -12,6 +12,47 @@ use super::widgets;
 
 const PLAYBACK_DIRTY_ID: &str = "playback-settings-dirty";
 pub(crate) const PERSONAL_APP_FOCUS_ID: &str = "focus-personal-app-setup";
+const SETTINGS_FILTER_ID: &str = "settings-filter";
+
+/// Whether a settings row matches the filter query (case-insensitive).
+/// An empty query matches everything, so the page reads exactly as
+/// before when the search field is empty.
+pub(crate) fn row_matches(needle: &str, title: &str, description: &str) -> bool {
+    let needle = needle.trim().to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    title.to_lowercase().contains(&needle) || description.to_lowercase().contains(&needle)
+}
+
+fn section_matches(needle: &str, title: &str, rows: &[(&str, &str)]) -> bool {
+    let needle = needle.trim().to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    if title.to_lowercase().contains(&needle) {
+        return true;
+    }
+    rows.iter()
+        .any(|(title, description)| row_matches(&needle, title, description))
+}
+
+fn filtered_row(
+    ui: &mut egui::Ui,
+    palette: &Palette,
+    needle: &str,
+    section: &str,
+    title: &str,
+    description: &str,
+    control: impl FnOnce(&mut egui::Ui),
+) {
+    if needle.is_empty()
+        || section.to_lowercase().contains(needle)
+        || row_matches(needle, title, description)
+    {
+        widgets::setting_row(ui, palette, title, description, control);
+    }
+}
 
 fn section(
     ui: &mut egui::Ui,
@@ -43,355 +84,361 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     ui.add_space(8.0);
     theme::text(ui, "Settings", theme::bold(28.0), palette.text);
     ui.add_space(4.0);
+    let mut filter = ui
+        .data(|data| data.get_temp::<String>(egui::Id::new(SETTINGS_FILTER_ID)))
+        .unwrap_or_default();
+    widgets::search_field(
+        ui,
+        &palette,
+        egui::Id::new("settings-search-field"),
+        &mut filter,
+        "Search settings",
+        ui.available_width().min(400.0),
+    );
+    let needle = filter.trim().to_lowercase();
+    ui.data_mut(|data| data.insert_temp(egui::Id::new(SETTINGS_FILTER_ID), filter));
+    ui.add_space(4.0);
     let dirty_id = egui::Id::new(PLAYBACK_DIRTY_ID);
     let mut playback_dirty = ui
         .data(|data| data.get_temp::<bool>(dirty_id))
         .unwrap_or(false);
     let mut changed = false;
+    let mut any_visible = false;
 
-    section(ui, &palette, "Account", |ui| {
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = 14.0;
-            let avatar = app
-                .user
-                .as_ref()
-                .and_then(|user| pick_image(&user.images, 64).map(str::to_string));
-            widgets::cover(ui, &palette, avatar.as_deref(), 56.0, 28.0, Icon::User);
-            ui.vertical(|ui| {
-                let name = app
-                    .user
-                    .as_ref()
-                    .map(|user| user.name().to_string())
-                    .unwrap_or_default();
-                theme::text(ui, name, theme::semibold(16.0), palette.text);
-                let product = app
-                    .user
-                    .as_ref()
-                    .and_then(|user| user.product.clone())
-                    .map(|product| match product.as_str() {
-                        "premium" => "Spotify Premium".to_string(),
-                        "free" | "open" => "Spotify Free, local playback needs Premium".to_string(),
-                        other => other.to_string(),
-                    })
-                    .unwrap_or_default();
-                theme::text(ui, product, theme::regular(13.0), palette.secondary);
-                if let Some(username) = app.local.connected.then(|| app.local.username.clone())
-                    && !username.is_empty()
-                {
-                    theme::text(
-                        ui,
-                        format!("Connected as {username}"),
-                        theme::regular(12.0),
-                        palette.dim,
-                    );
-                }
-            });
-            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                if theme::pill_button(ui, &palette, "Sign out", false).clicked() {
-                    app.actions.push(Action::SignOut);
-                }
-            });
-        });
-        ui.add_space(10.0);
-        let mut client_id = app.settings.web_client_id.clone().unwrap_or_default();
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Personal Spotify app",
-            "Use a personal Development Mode app for a separate API quota. The shared app stays active.",
-            |ui| {
-                let response = Frame::new()
-                    .fill(palette.surface)
-                    .corner_radius(CornerRadius::same(6))
-                    .inner_margin(Margin::symmetric(10, 6))
-                    .show(ui, |ui| {
-                        ui.add(
-                            egui::TextEdit::singleline(&mut client_id)
-                                .id(egui::Id::new("personal-web-client-id"))
-                                .hint_text(egui::RichText::new("Client ID").color(palette.dim))
-                                .font(theme::regular(13.0))
-                                .frame(egui::Frame::NONE)
-                                .desired_width(200.0),
-                        )
-                    })
-                    .inner;
-                if ui
-                    .data_mut(|data| data.remove_temp::<bool>(egui::Id::new(PERSONAL_APP_FOCUS_ID)))
-                    .unwrap_or(false)
-                {
-                    response.scroll_to_me(Some(Align::Center));
-                    response.request_focus();
-                }
-                if response.changed() {
-                    let trimmed = client_id.trim().to_string();
-                    app.settings.web_client_id = (!trimmed.is_empty()).then_some(trimmed);
-                    changed = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Create an app",
-            "Create one for free in Spotify's developer dashboard.",
-            |ui| {
-                if theme::pill_button(ui, &palette, "Setup guide", false).clicked() {
-                    app.actions.push(Action::OpenUrl(
-                        "https://fastpotify.rocks/make-it-even-faster/".into(),
-                    ));
-                }
-            },
-        );
-        let wanted = app
-            .settings
-            .web_client_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|id| !id.is_empty())
-            .map(str::to_string);
-        let in_use = wanted
-            .as_deref()
-            .is_some_and(|wanted| app.web_app.as_deref() == Some(wanted));
-        if in_use {
-            widgets::setting_row(
-                ui,
-                &palette,
+    if section_matches(
+        &needle,
+        "Account",
+        &[
+            ("Sign out", ""),
+            (
+                "Personal Spotify app",
+                "Use a personal Development Mode app for a separate API quota. The shared app stays active.",
+            ),
+            (
+                "Create an app",
+                "Create one for free in Spotify's developer dashboard.",
+            ),
+            (
                 "Personal app ready",
                 "Supported requests use your app. Other requests use the shared app.",
-                |ui| {
-                    if theme::pill_button(ui, &palette, "Remove", false).clicked() {
-                        app.settings.web_client_id = None;
-                        app.actions.push(Action::ConfigurePersonalWebApp);
-                    }
-                },
-            );
-        } else if wanted.is_some() {
-            widgets::setting_row(
-                ui,
-                &palette,
+            ),
+            (
                 "Authorize your personal app",
                 "Spotify opens in your browser to verify the account.",
-                |ui| {
-                    if theme::pill_button(ui, &palette, "Authorize", true).clicked() {
-                        app.actions.push(Action::ConfigurePersonalWebApp);
-                    }
-                },
-            );
-        } else if app.web_app.is_some() {
-            widgets::setting_row(
+            ),
+            ("Remove personal app", "Shared access remains signed in."),
+        ],
+    ) {
+        any_visible = true;
+        section(ui, &palette, "Account", |ui| {
+            if row_matches(&needle, "Sign out Account", "") {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 14.0;
+                    let avatar = app
+                        .user
+                        .as_ref()
+                        .and_then(|user| pick_image(&user.images, 64).map(str::to_string));
+                    widgets::cover(ui, &palette, avatar.as_deref(), 56.0, 28.0, Icon::User);
+                    ui.vertical(|ui| {
+                        let name = app
+                            .user
+                            .as_ref()
+                            .map(|user| user.name().to_string())
+                            .unwrap_or_default();
+                        theme::text(ui, name, theme::semibold(16.0), palette.text);
+                        let product = app
+                            .user
+                            .as_ref()
+                            .and_then(|user| user.product.clone())
+                            .map(|product| match product.as_str() {
+                                "premium" => "Spotify Premium".to_string(),
+                                "free" | "open" => {
+                                    "Spotify Free, local playback needs Premium".to_string()
+                                }
+                                other => other.to_string(),
+                            })
+                            .unwrap_or_default();
+                        theme::text(ui, product, theme::regular(13.0), palette.secondary);
+                        if let Some(username) =
+                            app.local.connected.then(|| app.local.username.clone())
+                            && !username.is_empty()
+                        {
+                            theme::text(
+                                ui,
+                                format!("Connected as {username}"),
+                                theme::regular(12.0),
+                                palette.dim,
+                            );
+                        }
+                    });
+                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                        if theme::pill_button(ui, &palette, "Sign out", false).clicked() {
+                            app.actions.push(Action::SignOut);
+                        }
+                    });
+                });
+                ui.add_space(10.0);
+            }
+            let mut client_id = app.settings.web_client_id.clone().unwrap_or_default();
+            filtered_row(
                 ui,
                 &palette,
-                "Remove personal app",
-                "Shared access remains signed in.",
+                &needle,
+                "Account",
+                "Personal Spotify app",
+                "Use a personal Development Mode app for a separate API quota. The shared app stays active.",
                 |ui| {
-                    if theme::pill_button(ui, &palette, "Remove", false).clicked() {
-                        app.actions.push(Action::ConfigurePersonalWebApp);
+                    let response = Frame::new()
+                        .fill(palette.surface)
+                        .corner_radius(CornerRadius::same(6))
+                        .inner_margin(Margin::symmetric(10, 6))
+                        .show(ui, |ui| {
+                            ui.add(
+                                egui::TextEdit::singleline(&mut client_id)
+                                    .id(egui::Id::new("personal-web-client-id"))
+                                    .hint_text(egui::RichText::new("Client ID").color(palette.dim))
+                                    .font(theme::regular(13.0))
+                                    .frame(egui::Frame::NONE)
+                                    .desired_width(200.0),
+                            )
+                        })
+                        .inner;
+                    if ui
+                        .data_mut(|data| {
+                            data.remove_temp::<bool>(egui::Id::new(PERSONAL_APP_FOCUS_ID))
+                        })
+                        .unwrap_or(false)
+                    {
+                        response.scroll_to_me(Some(Align::Center));
+                        response.request_focus();
+                    }
+                    if response.changed() {
+                        let trimmed = client_id.trim().to_string();
+                        app.settings.web_client_id = (!trimmed.is_empty()).then_some(trimmed);
+                        changed = true;
                     }
                 },
             );
-        }
-    });
-
-    section(ui, &palette, "Playback on this computer", |ui| {
-        let (status, detail, action) = match &app.local_playback {
-            crate::backend::LocalPlayback::Ready { .. } => (
-                "Ready",
-                "This computer is a Spotify Connect device.".to_string(),
-                None,
-            ),
-            crate::backend::LocalPlayback::Authorizing => (
-                "Setting up",
-                "Finish authorizing in your browser.".to_string(),
-                None,
-            ),
-            crate::backend::LocalPlayback::Connecting => {
-                ("Connecting", "Connecting to Spotify…".to_string(), None)
-            }
-            crate::backend::LocalPlayback::Failed(message) => {
-                ("Unavailable", message.clone(), Some("Try again"))
-            }
-            crate::backend::LocalPlayback::Unavailable => (
-                "Not set up",
-                "Requires Spotify Premium and a one-time browser sign-in.".to_string(),
-                Some("Enable playback here"),
-            ),
-        };
-        widgets::setting_row(ui, &palette, &format!("Status: {status}"), &detail, |ui| {
-            if let Some(label) = action {
-                if theme::pill_button(ui, &palette, label, true).clicked() {
-                    app.actions.push(Action::EnablePlayback);
-                }
-            } else if app.local_ready
-                && theme::soft_button(ui, &palette, Some(Icon::Refresh), "Reconnect", false)
-                    .clicked()
-            {
-                app.actions.push(Action::RestartEngine);
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Account",
+                "Create an app",
+                "Create one for free in Spotify's developer dashboard.",
+                |ui| {
+                    if theme::pill_button(ui, &palette, "Setup guide", false).clicked() {
+                        app.actions.push(Action::OpenUrl(
+                            "https://fastpotify.rocks/make-it-even-faster/".into(),
+                        ));
+                    }
+                },
+            );
+            let wanted = app
+                .settings
+                .web_client_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string);
+            let in_use = wanted
+                .as_deref()
+                .is_some_and(|wanted| app.web_app.as_deref() == Some(wanted));
+            if in_use {
+                filtered_row(
+                    ui,
+                    &palette,
+                    &needle,
+                    "Account",
+                    "Personal app ready",
+                    "Supported requests use your app. Other requests use the shared app.",
+                    |ui| {
+                        if theme::pill_button(ui, &palette, "Remove", false).clicked() {
+                            app.settings.web_client_id = None;
+                            app.actions.push(Action::ConfigurePersonalWebApp);
+                        }
+                    },
+                );
+            } else if wanted.is_some() {
+                filtered_row(
+                    ui,
+                    &palette,
+                    &needle,
+                    "Account",
+                    "Authorize your personal app",
+                    "Spotify opens in your browser to verify the account.",
+                    |ui| {
+                        if theme::pill_button(ui, &palette, "Authorize", true).clicked() {
+                            app.actions.push(Action::ConfigurePersonalWebApp);
+                        }
+                    },
+                );
+            } else if app.web_app.is_some() {
+                filtered_row(
+                    ui,
+                    &palette,
+                    &needle,
+                    "Account",
+                    "Remove personal app",
+                    "Shared access remains signed in.",
+                    |ui| {
+                        if theme::pill_button(ui, &palette, "Remove", false).clicked() {
+                            app.actions.push(Action::ConfigurePersonalWebApp);
+                        }
+                    },
+                );
             }
         });
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Device name",
-            "How this computer appears in Spotify Connect.",
-            |ui| {
-                let response = Frame::new()
-                    .fill(palette.surface)
-                    .corner_radius(CornerRadius::same(6))
-                    .inner_margin(Margin::symmetric(10, 6))
-                    .show(ui, |ui| {
-                        ui.add(
-                            egui::TextEdit::singleline(&mut app.settings.device_name)
-                                .font(theme::regular(14.0))
-                                .frame(egui::Frame::NONE)
-                                .desired_width(200.0),
-                        )
-                    })
-                    .inner;
-                if response.changed() {
-                    changed = true;
-                    playback_dirty = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Audio quality",
-            "Higher bitrates use more data and cache space.",
-            |ui| {
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 6.0;
-                    for (kbps, label) in [
-                        (320u16, "Very high · 320 kbps"),
-                        (160, "High · 160 kbps"),
-                        (96, "Normal · 96 kbps"),
-                    ] {
-                        if theme::soft_button(
-                            ui,
-                            &palette,
-                            None,
-                            label,
-                            app.settings.bitrate == kbps,
-                        )
-                        .clicked()
-                            && app.settings.bitrate != kbps
-                        {
-                            app.settings.bitrate = kbps;
-                            changed = true;
-                            playback_dirty = true;
-                        }
-                    }
-                });
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Normalize volume",
-            "Keep loud and quiet tracks at a similar level.",
-            |ui| {
-                if widgets::switch(
-                    ui,
-                    &palette,
-                    "Normalize volume",
-                    &mut app.settings.normalisation,
-                )
-                .changed()
-                {
-                    changed = true;
-                    playback_dirty = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Autoplay",
-            "Keep playing similar songs when your music ends.",
-            |ui| {
-                if widgets::switch(ui, &palette, "Autoplay", &mut app.settings.autoplay).changed() {
-                    changed = true;
-                    playback_dirty = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Gapless playback",
-            "Play tracks without silence between them.",
-            |ui| {
-                if widgets::switch(ui, &palette, "Gapless playback", &mut app.settings.gapless)
-                    .changed()
-                {
-                    changed = true;
-                    playback_dirty = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Keep music playing when the window closes",
-            super::keys::platform_shortcut(
-                "Fastpotify hides to the system tray. Quit from the tray menu or with Ctrl+Q.",
-                "Fastpotify hides to the system tray. Quit from the tray menu or with Cmd+Q.",
+    }
+
+    if section_matches(
+        &needle,
+        "Playback on this computer",
+        &[
+            ("Status", "Spotify Connect"),
+            (
+                "Device name",
+                "How this computer appears in Spotify Connect.",
             ),
-            |ui| {
-                if widgets::switch(
+            (
+                "Audio quality",
+                "Higher bitrates use more data and cache space.",
+            ),
+            (
+                "Normalize volume",
+                "Keep loud and quiet tracks at a similar level.",
+            ),
+            (
+                "Autoplay",
+                "Keep playing similar songs when your music ends.",
+            ),
+            (
+                "Gapless playback",
+                "Play tracks without silence between them.",
+            ),
+            (
+                "Keep music playing when the window closes",
+                "Fastpotify hides to the system tray.",
+            ),
+            (
+                "Automatic update checks",
+                "Checks GitHub once a day. No personal data is sent.",
+            ),
+            ("Audio output", "PulseAudio also covers PipeWire."),
+            ("Output buffer", "More buffering can prevent clicks"),
+            ("Audio cache", "Save downloaded audio for later playback."),
+        ],
+    ) {
+        any_visible = true;
+        section(ui, &palette, "Playback on this computer", |ui| {
+            let (status, detail, action) = match &app.local_playback {
+                crate::backend::LocalPlayback::Ready { .. } => (
+                    "Ready",
+                    "This computer is a Spotify Connect device.".to_string(),
+                    None,
+                ),
+                crate::backend::LocalPlayback::Authorizing => (
+                    "Setting up",
+                    "Finish authorizing in your browser.".to_string(),
+                    None,
+                ),
+                crate::backend::LocalPlayback::Connecting => {
+                    ("Connecting", "Connecting to Spotify…".to_string(), None)
+                }
+                crate::backend::LocalPlayback::Failed(message) => {
+                    ("Unavailable", message.clone(), Some("Try again"))
+                }
+                crate::backend::LocalPlayback::Unavailable => (
+                    "Not set up",
+                    "Requires Spotify Premium and a one-time browser sign-in.".to_string(),
+                    Some("Enable playback here"),
+                ),
+            };
+            if needle.is_empty()
+                || format!("Status: {status} {detail} playback connect reconnect enable")
+                    .to_lowercase()
+                    .contains(&needle)
+            {
+                filtered_row(
                     ui,
                     &palette,
-                    "Keep music playing when the window closes",
-                    &mut app.settings.keep_playing_in_background,
-                )
-                .changed()
-                {
-                    changed = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Automatic update checks",
-            "Checks GitHub once a day. No personal data is sent.",
-            |ui| {
-                if widgets::switch(
-                    ui,
-                    &palette,
-                    "Automatic update checks",
-                    &mut app.settings.check_for_updates,
-                )
-                .changed()
-                {
-                    changed = true;
-                }
-            },
-        );
-        if cfg!(target_os = "linux") {
-            widgets::setting_row(
+                    &needle,
+                    "Playback on this computer",
+                    &format!("Status: {status}"),
+                    &detail,
+                    |ui| {
+                        if let Some(label) = action {
+                            if theme::pill_button(ui, &palette, label, true).clicked() {
+                                app.actions.push(Action::EnablePlayback);
+                            }
+                        } else if app.local_ready
+                            && theme::soft_button(
+                                ui,
+                                &palette,
+                                Some(Icon::Refresh),
+                                "Reconnect",
+                                false,
+                            )
+                            .clicked()
+                        {
+                            app.actions.push(Action::RestartEngine);
+                        }
+                    },
+                );
+            }
+            filtered_row(
                 ui,
                 &palette,
-                "Audio output",
-                "PulseAudio also covers PipeWire. Rodio talks to ALSA directly.",
+                &needle,
+                "Playback on this computer",
+                "Device name",
+                "How this computer appears in Spotify Connect.",
                 |ui| {
-                    let current = app
-                        .settings
-                        .platform_backend()
-                        .unwrap_or_else(|| "rodio".into());
+                    let response = Frame::new()
+                        .fill(palette.surface)
+                        .corner_radius(CornerRadius::same(6))
+                        .inner_margin(Margin::symmetric(10, 6))
+                        .show(ui, |ui| {
+                            ui.add(
+                                egui::TextEdit::singleline(&mut app.settings.device_name)
+                                    .font(theme::regular(14.0))
+                                    .frame(egui::Frame::NONE)
+                                    .desired_width(200.0),
+                            )
+                        })
+                        .inner;
+                    if response.changed() {
+                        changed = true;
+                        playback_dirty = true;
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Audio quality",
+                "Higher bitrates use more data and cache space.",
+                |ui| {
                     ui.horizontal(|ui| {
                         ui.spacing_mut().item_spacing.x = 6.0;
-                        for backend in ["rodio", "pulseaudio"] {
-                            let label = if backend == "pulseaudio" {
-                                "PulseAudio / PipeWire"
-                            } else {
-                                "ALSA (rodio)"
-                            };
-                            if theme::soft_button(ui, &palette, None, label, current == backend)
-                                .clicked()
-                                && current != backend
+                        for (kbps, label) in [
+                            (320u16, "Very high · 320 kbps"),
+                            (160, "High · 160 kbps"),
+                            (96, "Normal · 96 kbps"),
+                        ] {
+                            if theme::soft_button(
+                                ui,
+                                &palette,
+                                None,
+                                label,
+                                app.settings.bitrate == kbps,
+                            )
+                            .clicked()
+                                && app.settings.bitrate != kbps
                             {
-                                app.settings.audio_backend = Some(backend.to_string());
+                                app.settings.bitrate = kbps;
                                 changed = true;
                                 playback_dirty = true;
                             }
@@ -399,227 +446,617 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     });
                 },
             );
-        }
-        #[cfg(windows)]
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Output buffer",
-            "More buffering can prevent clicks on busy computers. Less buffering makes controls respond sooner.",
-            |ui| {
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 6.0;
-                    let current = app.settings.audio_buffer_ms;
-                    for ms in [50u32, 100, 200] {
-                        let label = format!("{ms} ms");
-                        if theme::soft_button(ui, &palette, None, &label, current == ms).clicked()
-                            && current != ms
-                        {
-                            app.settings.audio_buffer_ms = ms;
-                            changed = true;
-                            playback_dirty = true;
-                        }
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Normalize volume",
+                "Keep loud and quiet tracks at a similar level.",
+                |ui| {
+                    if widgets::switch(
+                        ui,
+                        &palette,
+                        "Normalize volume",
+                        &mut app.settings.normalisation,
+                    )
+                    .changed()
+                    {
+                        changed = true;
+                        playback_dirty = true;
                     }
-                });
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Audio cache",
-            "Save downloaded audio for later playback.",
-            |ui| {
-                // The control area lays out right-to-left: add the rightmost item first.
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 6.0;
-                    if widgets::switch(ui, &palette, "Audio cache", &mut app.settings.audio_cache)
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Autoplay",
+                "Keep playing similar songs when your music ends.",
+                |ui| {
+                    if widgets::switch(ui, &palette, "Autoplay", &mut app.settings.autoplay)
                         .changed()
                     {
                         changed = true;
                         playback_dirty = true;
                     }
-                    if app.settings.audio_cache {
-                        ui.add_space(6.0);
-                        for (mb, label) in [(4096u64, "4 GB"), (1024, "1 GB"), (512, "512 MB")] {
-                            if theme::soft_button(
-                                ui,
-                                &palette,
-                                None,
-                                label,
-                                app.settings.audio_cache_mb == mb,
-                            )
-                            .clicked()
-                                && app.settings.audio_cache_mb != mb
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Gapless playback",
+                "Play tracks without silence between them.",
+                |ui| {
+                    if widgets::switch(ui, &palette, "Gapless playback", &mut app.settings.gapless)
+                        .changed()
+                    {
+                        changed = true;
+                        playback_dirty = true;
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Keep music playing when the window closes",
+                super::keys::platform_shortcut(
+                    "Fastpotify hides to the system tray. Quit from the tray menu or with Ctrl+Q.",
+                    "Fastpotify hides to the system tray. Quit from the tray menu or with Cmd+Q.",
+                ),
+                |ui| {
+                    if widgets::switch(
+                        ui,
+                        &palette,
+                        "Keep music playing when the window closes",
+                        &mut app.settings.keep_playing_in_background,
+                    )
+                    .changed()
+                    {
+                        changed = true;
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Automatic update checks",
+                "Checks GitHub once a day. No personal data is sent.",
+                |ui| {
+                    if widgets::switch(
+                        ui,
+                        &palette,
+                        "Automatic update checks",
+                        &mut app.settings.check_for_updates,
+                    )
+                    .changed()
+                    {
+                        changed = true;
+                    }
+                },
+            );
+            if cfg!(target_os = "linux") {
+                filtered_row(
+                    ui,
+                    &palette,
+                    &needle,
+                    "Playback on this computer",
+                    "Audio output",
+                    "PulseAudio also covers PipeWire. Rodio talks to ALSA directly.",
+                    |ui| {
+                        let current = app
+                            .settings
+                            .platform_backend()
+                            .unwrap_or_else(|| "rodio".into());
+                        ui.horizontal(|ui| {
+                            ui.spacing_mut().item_spacing.x = 6.0;
+                            for backend in ["rodio", "pulseaudio"] {
+                                let label = if backend == "pulseaudio" {
+                                    "PulseAudio / PipeWire"
+                                } else {
+                                    "ALSA (rodio)"
+                                };
+                                if theme::soft_button(ui, &palette, None, label, current == backend)
+                                    .clicked()
+                                    && current != backend
+                                {
+                                    app.settings.audio_backend = Some(backend.to_string());
+                                    changed = true;
+                                    playback_dirty = true;
+                                }
+                            }
+                        });
+                    },
+                );
+            }
+            #[cfg(windows)]
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Output buffer",
+                "More buffering can prevent clicks on busy computers. Less buffering makes controls respond sooner.",
+                |ui| {
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        let current = app.settings.audio_buffer_ms;
+                        for ms in [50u32, 100, 200] {
+                            let label = format!("{ms} ms");
+                            if theme::soft_button(ui, &palette, None, &label, current == ms)
+                                .clicked()
+                                && current != ms
                             {
-                                app.settings.audio_cache_mb = mb;
+                                app.settings.audio_buffer_ms = ms;
                                 changed = true;
                                 playback_dirty = true;
                             }
                         }
+                    });
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Playback on this computer",
+                "Audio cache",
+                "Save downloaded audio for later playback.",
+                |ui| {
+                    // The control area lays out right-to-left: add the rightmost item first.
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        if widgets::switch(
+                            ui,
+                            &palette,
+                            "Audio cache",
+                            &mut app.settings.audio_cache,
+                        )
+                        .changed()
+                        {
+                            changed = true;
+                            playback_dirty = true;
+                        }
+                        if app.settings.audio_cache {
+                            ui.add_space(6.0);
+                            for (mb, label) in [(4096u64, "4 GB"), (1024, "1 GB"), (512, "512 MB")]
+                            {
+                                if theme::soft_button(
+                                    ui,
+                                    &palette,
+                                    None,
+                                    label,
+                                    app.settings.audio_cache_mb == mb,
+                                )
+                                .clicked()
+                                    && app.settings.audio_cache_mb != mb
+                                {
+                                    app.settings.audio_cache_mb = mb;
+                                    changed = true;
+                                    playback_dirty = true;
+                                }
+                            }
+                        }
+                    });
+                },
+            );
+            ui.add_space(4.0);
+            if needle.is_empty()
+                || "playback on this computer".contains(&needle)
+                || row_matches(
+                    &needle,
+                    "Apply and restart playback",
+                    "Restart local playback",
+                )
+                || row_matches(
+                    &needle,
+                    "Playback settings applied",
+                    "Playback settings applied",
+                )
+            {
+                ui.horizontal(|ui| {
+                    if playback_dirty {
+                        if theme::pill_button(ui, &palette, "Apply and restart playback", true)
+                            .clicked()
+                        {
+                            app.actions.push(Action::RestartEngine);
+                            playback_dirty = false;
+                        }
+                        theme::subtle(
+                            ui,
+                            &palette,
+                            "Restart local playback to apply these settings.",
+                        );
+                    } else {
+                        theme::subtle(ui, &palette, "Playback settings applied.");
                     }
                 });
-            },
-        );
-        ui.add_space(4.0);
-        ui.horizontal(|ui| {
-            if playback_dirty {
-                if theme::pill_button(ui, &palette, "Apply and restart playback", true).clicked() {
-                    app.actions.push(Action::RestartEngine);
-                    playback_dirty = false;
-                }
-                theme::subtle(
-                    ui,
-                    &palette,
-                    "Restart local playback to apply these settings.",
-                );
-            } else {
-                theme::subtle(ui, &palette, "Playback settings applied.");
             }
         });
-    });
+    }
 
-    section(ui, &palette, "Appearance", |ui| {
-        widgets::setting_row(ui, &palette, "Theme", "", |ui| {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                for choice in ThemeChoice::ALL {
-                    if theme::soft_button(
-                        ui,
-                        &palette,
-                        None,
-                        choice.label(),
-                        app.settings.theme == choice,
-                    )
-                    .clicked()
-                        && app.settings.theme != choice
-                    {
-                        app.settings.theme = choice;
-                        changed = true;
-                    }
-                }
-            });
-        });
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Colour from album art",
-            "Use the current cover's colour on pages and the player bar.",
-            |ui| {
-                if widgets::switch(
-                    ui,
-                    &palette,
-                    "Colour from album art",
-                    &mut app.settings.accent_from_art,
-                )
-                .changed()
-                {
-                    changed = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Compact library sidebar",
-            "Show names without covers in the sidebar.",
-            |ui| {
-                if widgets::switch(
-                    ui,
-                    &palette,
-                    "Compact library sidebar",
-                    &mut app.settings.sidebar_compact,
-                )
-                .changed()
-                {
-                    changed = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Compact track list",
-            "Show each track on one line without a cover.",
-            |ui| {
-                if widgets::switch(
-                    ui,
-                    &palette,
-                    "Compact track list",
-                    &mut app.settings.tracklist_compact,
-                )
-                .changed()
-                {
-                    changed = true;
-                }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Interface zoom",
-            super::keys::platform_shortcut(
-                "Ctrl+Plus and Ctrl+Minus work anywhere; Ctrl+0 resets.",
-                "Cmd+Plus and Cmd+Minus work anywhere; Cmd+0 resets.",
-            ),
-            |ui| {
+    if section_matches(
+        &needle,
+        "Appearance",
+        &[
+            ("Theme", ""),
+            ("Colour from album art", "Use the current cover"),
+            ("Compact library sidebar", "Show names"),
+            ("Compact track list", "Show each"),
+            ("Interface zoom", "Plus and"),
+        ],
+    ) {
+        any_visible = true;
+        section(ui, &palette, "Appearance", |ui| {
+            filtered_row(ui, &palette, &needle, "Appearance", "Theme", "", |ui| {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 6.0;
-                    let mut zoom = app.settings.zoom;
-                    if theme::soft_button(ui, &palette, None, "+", false).clicked() {
-                        zoom = (zoom + 0.1).min(2.5);
-                    }
-                    theme::text(
-                        ui,
-                        format!("{:.0}%", zoom * 100.0),
-                        theme::medium(13.5),
-                        palette.text,
-                    );
-                    if theme::soft_button(ui, &palette, None, "-", false).clicked() {
-                        zoom = (zoom - 0.1).max(0.5);
-                    }
-                    if (zoom - app.settings.zoom).abs() > 0.001 {
-                        app.settings.zoom = zoom;
-                        ui.ctx().set_zoom_factor(zoom);
-                        app.mark_settings_dirty();
+                    for choice in ThemeChoice::ALL {
+                        if theme::soft_button(
+                            ui,
+                            &palette,
+                            None,
+                            choice.label(),
+                            app.settings.theme == choice,
+                        )
+                        .clicked()
+                            && app.settings.theme != choice
+                        {
+                            app.settings.theme = choice;
+                            changed = true;
+                        }
                     }
                 });
-            },
-        );
-    });
+            });
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Appearance",
+                "Colour from album art",
+                "Use the current cover's colour on pages and the player bar.",
+                |ui| {
+                    if widgets::switch(
+                        ui,
+                        &palette,
+                        "Colour from album art",
+                        &mut app.settings.accent_from_art,
+                    )
+                    .changed()
+                    {
+                        changed = true;
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Appearance",
+                "Compact library sidebar",
+                "Show names without covers in the sidebar.",
+                |ui| {
+                    if widgets::switch(
+                        ui,
+                        &palette,
+                        "Compact library sidebar",
+                        &mut app.settings.sidebar_compact,
+                    )
+                    .changed()
+                    {
+                        changed = true;
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Appearance",
+                "Compact track list",
+                "Show each track on one line without a cover.",
+                |ui| {
+                    if widgets::switch(
+                        ui,
+                        &palette,
+                        "Compact track list",
+                        &mut app.settings.tracklist_compact,
+                    )
+                    .changed()
+                    {
+                        changed = true;
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Appearance",
+                "Interface zoom",
+                super::keys::platform_shortcut(
+                    "Ctrl+Plus and Ctrl+Minus work anywhere; Ctrl+0 resets.",
+                    "Cmd+Plus and Cmd+Minus work anywhere; Cmd+0 resets.",
+                ),
+                |ui| {
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        let mut zoom = app.settings.zoom;
+                        if theme::soft_button(ui, &palette, None, "+", false).clicked() {
+                            zoom = (zoom + 0.1).min(2.5);
+                        }
+                        theme::text(
+                            ui,
+                            format!("{:.0}%", zoom * 100.0),
+                            theme::medium(13.5),
+                            palette.text,
+                        );
+                        if theme::soft_button(ui, &palette, None, "-", false).clicked() {
+                            zoom = (zoom - 0.1).max(0.5);
+                        }
+                        if (zoom - app.settings.zoom).abs() > 0.001 {
+                            app.settings.zoom = zoom;
+                            ui.ctx().set_zoom_factor(zoom);
+                            app.mark_settings_dirty();
+                        }
+                    });
+                },
+            );
+        });
+    }
 
-    section(ui, &palette, "Winamp skins", |ui| {
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Mini player",
-            super::keys::platform_shortcut(
-                "Use classic Winamp .wsz skins. Press Ctrl+M or click the skin logo to return. Drop a skin on either window to add it.",
-                "Use classic Winamp .wsz skins. Press Cmd+Shift+M or click the skin logo to return. Drop a skin on either window to add it.",
-            ),
-            |ui| {
-                if theme::pill_button(ui, &palette, "Switch to it", true).clicked() {
-                    app.actions.push(Action::ToggleWinampWindow);
+    if section_matches(
+        &needle,
+        "Winamp skins",
+        &[
+            ("Mini player", "Winamp"),
+            ("Skin", "Installed skins"),
+            ("Size", "Whole-number"),
+            ("Always on top", "Keep the Winamp"),
+            ("Show in taskbar", "Keep a taskbar button"),
+        ],
+    ) || (!needle.is_empty()
+        && app
+            .winamp
+            .choices
+            .iter()
+            .any(|choice| choice.name.to_lowercase().contains(&needle)))
+    {
+        any_visible = true;
+        section(ui, &palette, "Winamp skins", |ui| {
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Winamp skins",
+                "Mini player",
+                super::keys::platform_shortcut(
+                    "Use classic Winamp .wsz skins. Press Ctrl+M or click the skin logo to return. Drop a skin on either window to add it.",
+                    "Use classic Winamp .wsz skins. Press Cmd+Shift+M or click the skin logo to return. Drop a skin on either window to add it.",
+                ),
+                |ui| {
+                    if theme::pill_button(ui, &palette, "Switch to it", true).clicked() {
+                        app.actions.push(Action::ToggleWinampWindow);
+                    }
+                },
+            );
+            let folder = app.dirs.skins_dir();
+            app.winamp.refresh_choices(&folder);
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Winamp skins",
+                "Skin",
+                &format!(
+                    "Installed skins are in {}. Find more at the Winamp Skin Museum.",
+                    folder.display()
+                ),
+                |ui| {
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        if theme::soft_button(ui, &palette, Some(Icon::Globe), "Skin Museum", false)
+                            .clicked()
+                        {
+                            app.actions
+                                .push(Action::OpenUrl("https://skins.webamp.org/".into()));
+                        }
+                        if theme::soft_button(
+                            ui,
+                            &palette,
+                            Some(Icon::ExternalLink),
+                            "Open folder",
+                            false,
+                        )
+                        .clicked()
+                        {
+                            app.actions.push(Action::OpenSkinsFolder);
+                        }
+                    });
+                },
+            );
+            let choices = app.winamp.choices.clone();
+            if needle.is_empty()
+                || "winamp skins".contains(&needle)
+                || row_matches(&needle, "Skin", "Installed skins Winamp Skin Museum")
+                || choices
+                    .iter()
+                    .any(|choice| choice.name.to_lowercase().contains(&needle))
+            {
+                let mut options: Vec<(usize, &str)> = vec![(0, "Fastpotify")];
+                options.extend(
+                    choices
+                        .iter()
+                        .enumerate()
+                        .map(|(index, choice)| (index + 1, choice.label())),
+                );
+                let current = app
+                    .settings
+                    .skin
+                    .as_deref()
+                    .and_then(|name| choices.iter().position(|choice| choice.name == name))
+                    .map_or(0, |index| index + 1);
+                if let Some(picked) = widgets::chips(ui, &palette, &options, current)
+                    && picked != current
+                {
+                    let name = picked
+                        .checked_sub(1)
+                        .map(|index| choices[index].name.clone());
+                    app.actions.push(Action::SetSkin(name));
                 }
-            },
-        );
-        let folder = app.dirs.skins_dir();
-        app.winamp.refresh_choices(&folder);
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Skin",
-            &format!(
-                "Installed skins are in {}. Find more at the Winamp Skin Museum.",
-                folder.display()
-            ),
-            |ui| {
+                ui.add_space(4.0);
+            }
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Winamp skins",
+                "Size",
+                "Whole-number scaling keeps skin pixels sharp.",
+                |ui| {
+                    let scale = crate::winamp::WinampState::scale(
+                        &app.settings,
+                        ui.ctx().pixels_per_point(),
+                    );
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        for candidate in 1..=crate::winamp::MAX_SCALE {
+                            let label = format!("{candidate}x");
+                            if theme::soft_button(ui, &palette, None, &label, candidate == scale)
+                                .clicked()
+                                && candidate != scale
+                            {
+                                app.actions.push(Action::SetSkinScale(candidate as u8));
+                            }
+                        }
+                    });
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Winamp skins",
+                "Always on top",
+                "Keep the Winamp window above everything else.",
+                |ui| {
+                    let mut on_top = app.settings.winamp_on_top;
+                    if widgets::switch(ui, &palette, "Always on top", &mut on_top).changed() {
+                        app.actions.push(Action::ToggleWinampOnTop);
+                    }
+                },
+            );
+            if app.windows_controls_visible() {
+                filtered_row(
+                    ui,
+                    &palette,
+                    &needle,
+                    "Winamp skins",
+                    "Show in taskbar",
+                    "Keep a taskbar button for the mini player. The tray icon stays available when hidden.",
+                    |ui| {
+                        let mut visible = app.settings.winamp_show_taskbar;
+                        let response =
+                            widgets::switch(ui, &palette, "Show Winamp in taskbar", &mut visible);
+                        if response.changed() {
+                            app.actions.push(Action::SetWinampTaskbar(visible));
+                        }
+                        #[cfg(any(test, feature = "demo"))]
+                        if app.demo_windows_controls {
+                            let id = egui::Id::new("demo-winamp-taskbar-focus");
+                            if !ui.data(|data| data.get_temp::<bool>(id)).unwrap_or(false) {
+                                response.scroll_to_me(Some(Align::Center));
+                                ui.data_mut(|data| data.insert_temp(id, true));
+                            }
+                        }
+                    },
+                );
+            }
+        });
+    }
+
+    if section_matches(
+        &needle,
+        "MilkDrop",
+        &[
+            ("MilkDrop window", "projectM"),
+            ("Presets", "presets"),
+            ("Time per preset", "How long"),
+            ("Frame rate", "Lower rates"),
+            ("Resolution", "Half and Quarter"),
+        ],
+    ) || (!needle.is_empty()
+        && crate::milkdrop::PACKS
+            .iter()
+            .any(|pack| pack.name.to_lowercase().contains(&needle)))
+    {
+        any_visible = true;
+        section(ui, &palette, "MilkDrop", |ui| {
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "MilkDrop",
+                "MilkDrop window",
+                super::keys::platform_shortcut(
+                    "A projectM visualiser for local playback. Open it here, from the top bar, with Ctrl+Shift+K, or from the mini player's V menu. Press ? or F1 for its shortcuts.",
+                    "A projectM visualiser for local playback. Open it here, from the top bar, with Cmd+Shift+K, or from the mini player's V menu. Press ? or F1 for its shortcuts.",
+                ),
+                |ui| {
+                    let mut open = app.settings.milkdrop_open;
+                    if widgets::switch(ui, &palette, "MilkDrop window", &mut open).changed() {
+                        app.actions.push(Action::ToggleWinampMilkdrop);
+                    }
+                },
+            );
+            let folder = app.dirs.milkdrop_dir();
+            app.winamp.presets.refresh(&folder);
+            let count = app.winamp.presets.count();
+            let downloading = app.winamp.presets.downloading();
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "MilkDrop",
+                "Presets",
+                &format!(
+                    "{} in {}. Add .milk files here. Fastpotify downloads presets when MilkDrop first opens with an empty folder.",
+                    match count {
+                        0 => "None yet".to_string(),
+                        1 => "One preset".to_string(),
+                        n => format!("{n} presets"),
+                    },
+                    folder.display(),
+                ),
+                |_ui| {},
+            );
+            // Three buttons are wider than a row's control slot; they get a
+            // line of their own under the words.
+            if needle.is_empty()
+                || "milkdrop".contains(&needle)
+                || row_matches(&needle, "Presets", "presets milk files download")
+            {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 6.0;
-                    if theme::soft_button(ui, &palette, Some(Icon::Globe), "Skin Museum", false)
-                        .clicked()
-                    {
-                        app.actions
-                            .push(Action::OpenUrl("https://skins.webamp.org/".into()));
+                    for (index, pack) in crate::milkdrop::PACKS.iter().enumerate() {
+                        let label = match downloading {
+                            Some(name) if name == pack.name => "Fetching...".to_string(),
+                            _ => format!("Get {}", pack.name),
+                        };
+                        if theme::soft_button(ui, &palette, Some(Icon::Globe), &label, false)
+                            .on_hover_text(pack.note)
+                            .clicked()
+                            && downloading.is_none()
+                        {
+                            app.actions.push(Action::DownloadMilkdropPack(index));
+                        }
                     }
                     if theme::soft_button(
                         ui,
@@ -630,386 +1067,321 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     )
                     .clicked()
                     {
-                        app.actions.push(Action::OpenSkinsFolder);
+                        app.actions.push(Action::OpenMilkdropFolder);
                     }
                 });
-            },
-        );
-        let choices = app.winamp.choices.clone();
-        let mut options: Vec<(usize, &str)> = vec![(0, "Fastpotify")];
-        options.extend(
-            choices
-                .iter()
-                .enumerate()
-                .map(|(index, choice)| (index + 1, choice.label())),
-        );
-        let current = app
-            .settings
-            .skin
-            .as_deref()
-            .and_then(|name| choices.iter().position(|choice| choice.name == name))
-            .map_or(0, |index| index + 1);
-        if let Some(picked) = widgets::chips(ui, &palette, &options, current)
-            && picked != current
-        {
-            let name = picked
-                .checked_sub(1)
-                .map(|index| choices[index].name.clone());
-            app.actions.push(Action::SetSkin(name));
-        }
-        ui.add_space(4.0);
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Size",
-            "Whole-number scaling keeps skin pixels sharp.",
-            |ui| {
-                let scale =
-                    crate::winamp::WinampState::scale(&app.settings, ui.ctx().pixels_per_point());
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 6.0;
-                    for candidate in 1..=crate::winamp::MAX_SCALE {
-                        let label = format!("{candidate}x");
-                        if theme::soft_button(ui, &palette, None, &label, candidate == scale)
-                            .clicked()
-                            && candidate != scale
-                        {
-                            app.actions.push(Action::SetSkinScale(candidate as u8));
-                        }
-                    }
-                });
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Always on top",
-            "Keep the Winamp window above everything else.",
-            |ui| {
-                let mut on_top = app.settings.winamp_on_top;
-                if widgets::switch(ui, &palette, "Always on top", &mut on_top).changed() {
-                    app.actions.push(Action::ToggleWinampOnTop);
-                }
-            },
-        );
-        if app.windows_controls_visible() {
-            widgets::setting_row(
+                ui.add_space(10.0);
+            }
+            filtered_row(
                 ui,
                 &palette,
-                "Show in taskbar",
-                "Keep a taskbar button for the mini player. The tray icon stays available when hidden.",
+                &needle,
+                "MilkDrop",
+                "Time per preset",
+                "How long each preset plays before the next fades in.",
                 |ui| {
-                    let mut visible = app.settings.winamp_show_taskbar;
-                    let response =
-                        widgets::switch(ui, &palette, "Show Winamp in taskbar", &mut visible);
-                    if response.changed() {
-                        app.actions.push(Action::SetWinampTaskbar(visible));
-                    }
-                    #[cfg(any(test, feature = "demo"))]
-                    if app.demo_windows_controls {
-                        let id = egui::Id::new("demo-winamp-taskbar-focus");
-                        if !ui.data(|data| data.get_temp::<bool>(id)).unwrap_or(false) {
-                            response.scroll_to_me(Some(Align::Center));
-                            ui.data_mut(|data| data.insert_temp(id, true));
-                        }
+                    let mut seconds = app.settings.milkdrop_seconds.clamp(2, 300);
+                    let slider = egui::Slider::new(&mut seconds, 2..=300)
+                        .logarithmic(true)
+                        .suffix(" s");
+                    if ui.add(slider).changed() {
+                        app.actions.push(Action::SetMilkdropSeconds(seconds));
                     }
                 },
             );
-        }
-    });
-
-    section(ui, &palette, "MilkDrop", |ui| {
-        widgets::setting_row(
-            ui,
-            &palette,
-            "MilkDrop window",
-            super::keys::platform_shortcut(
-                "A projectM visualiser for local playback. Open it here, from the top bar, with Ctrl+Shift+K, or from the mini player's V menu. Press ? or F1 for its shortcuts.",
-                "A projectM visualiser for local playback. Open it here, from the top bar, with Cmd+Shift+K, or from the mini player's V menu. Press ? or F1 for its shortcuts.",
-            ),
-            |ui| {
-                let mut open = app.settings.milkdrop_open;
-                if widgets::switch(ui, &palette, "MilkDrop window", &mut open).changed() {
-                    app.actions.push(Action::ToggleWinampMilkdrop);
-                }
-            },
-        );
-        let folder = app.dirs.milkdrop_dir();
-        app.winamp.presets.refresh(&folder);
-        let count = app.winamp.presets.count();
-        let downloading = app.winamp.presets.downloading();
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Presets",
-            &format!(
-                "{} in {}. Add .milk files here. Fastpotify downloads presets when MilkDrop first opens with an empty folder.",
-                match count {
-                    0 => "None yet".to_string(),
-                    1 => "One preset".to_string(),
-                    n => format!("{n} presets"),
+            let screen_hz = app.settings.milkdrop_screen_hz;
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "MilkDrop",
+                "Frame rate",
+                &match screen_hz {
+                    0 => "Lower rates use fewer resources. Uncapped draws as fast as possible."
+                        .to_string(),
+                    hz => format!(
+                        "Your screen refreshes at {hz} Hz. Higher rates do not add visible frames. Uncapped draws as fast as possible."
+                    ),
                 },
-                folder.display(),
-            ),
-            |_ui| {},
-        );
-        // Three buttons are wider than a row's control slot; they get a
-        // line of their own under the words.
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = 6.0;
-            for (index, pack) in crate::milkdrop::PACKS.iter().enumerate() {
-                let label = match downloading {
-                    Some(name) if name == pack.name => "Fetching...".to_string(),
-                    _ => format!("Get {}", pack.name),
-                };
-                if theme::soft_button(ui, &palette, Some(Icon::Globe), &label, false)
-                    .on_hover_text(pack.note)
-                    .clicked()
-                    && downloading.is_none()
-                {
-                    app.actions.push(Action::DownloadMilkdropPack(index));
-                }
-            }
-            if theme::soft_button(ui, &palette, Some(Icon::ExternalLink), "Open folder", false)
-                .clicked()
-            {
-                app.actions.push(Action::OpenMilkdropFolder);
-            }
-        });
-        ui.add_space(10.0);
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Time per preset",
-            "How long each preset plays before the next fades in.",
-            |ui| {
-                let mut seconds = app.settings.milkdrop_seconds.clamp(2, 300);
-                let slider = egui::Slider::new(&mut seconds, 2..=300)
-                    .logarithmic(true)
-                    .suffix(" s");
-                if ui.add(slider).changed() {
-                    app.actions.push(Action::SetMilkdropSeconds(seconds));
-                }
-            },
-        );
-        let screen_hz = app.settings.milkdrop_screen_hz;
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Frame rate",
-            &match screen_hz {
-                0 => "Lower rates use fewer resources. Uncapped draws as fast as possible."
-                    .to_string(),
-                hz => format!(
-                    "Your screen refreshes at {hz} Hz. Higher rates do not add visible frames. Uncapped draws as fast as possible."
-                ),
-            },
-            |ui| {
-                let fps = app.settings.milkdrop_fps;
-                // The dial stops at the rates worth having and passes
-                // through nothing in between, the way a gear lever does.
-                let stops = crate::milkdrop::fps_stops(screen_hz, fps);
-                let last = stops.len().saturating_sub(1);
-                let mut at = stops.iter().position(|rate| *rate == fps).unwrap_or(1);
-                let labels: Vec<String> = stops
-                    .iter()
-                    .map(|rate| crate::milkdrop::fps_label(*rate, screen_hz))
-                    .collect();
-                let shown = labels.clone();
-                let typed = stops.clone();
-                let slider = egui::Slider::new(&mut at, 0..=last)
-                    .step_by(1.0)
-                    .custom_formatter(move |value, _| {
-                        shown
-                            .get((value.round().max(0.0) as usize).min(shown.len() - 1))
-                            .cloned()
-                            .unwrap_or_default()
-                    })
-                    .custom_parser(move |text| {
-                        // A rate typed in lands on the nearest stop, since
-                        // the stops are all this dial can hold.
-                        let text = text.trim().to_lowercase();
-                        if text.starts_with("un") {
-                            return Some(typed.len().saturating_sub(1) as f64);
+                |ui| {
+                    let fps = app.settings.milkdrop_fps;
+                    // The dial stops at the rates worth having and passes
+                    // through nothing in between, the way a gear lever does.
+                    let stops = crate::milkdrop::fps_stops(screen_hz, fps);
+                    let last = stops.len().saturating_sub(1);
+                    let mut at = stops.iter().position(|rate| *rate == fps).unwrap_or(1);
+                    let labels: Vec<String> = stops
+                        .iter()
+                        .map(|rate| crate::milkdrop::fps_label(*rate, screen_hz))
+                        .collect();
+                    let shown = labels.clone();
+                    let typed = stops.clone();
+                    let slider = egui::Slider::new(&mut at, 0..=last)
+                        .step_by(1.0)
+                        .custom_formatter(move |value, _| {
+                            shown
+                                .get((value.round().max(0.0) as usize).min(shown.len() - 1))
+                                .cloned()
+                                .unwrap_or_default()
+                        })
+                        .custom_parser(move |text| {
+                            // A rate typed in lands on the nearest stop, since
+                            // the stops are all this dial can hold.
+                            let text = text.trim().to_lowercase();
+                            if text.starts_with("un") {
+                                return Some(typed.len().saturating_sub(1) as f64);
+                            }
+                            let wanted: u32 = text
+                                .trim_end_matches("fps")
+                                .trim()
+                                .split(',')
+                                .next()?
+                                .trim()
+                                .parse()
+                                .ok()?;
+                            typed
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, rate)| **rate > 0)
+                                .min_by_key(|(_, rate)| rate.abs_diff(wanted))
+                                .map(|(index, _)| index as f64)
+                        });
+                    if ui.add(slider).changed()
+                        && let Some(rate) = stops.get(at)
+                    {
+                        app.actions.push(Action::SetMilkdropFps(*rate));
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "MilkDrop",
+                "Resolution",
+                "Half and Quarter use fewer resources and scale the image back up.",
+                |ui| {
+                    let current = app.settings.milkdrop_scale.max(1);
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = 6.0;
+                        for (scale, label) in [(1u32, "Full"), (2, "Half"), (4, "Quarter")] {
+                            if theme::soft_button(ui, &palette, None, label, scale == current)
+                                .clicked()
+                                && scale != current
+                            {
+                                app.actions.push(Action::SetMilkdropScale(scale));
+                            }
                         }
-                        let wanted: u32 = text
-                            .trim_end_matches("fps")
-                            .trim()
-                            .split(',')
-                            .next()?
-                            .trim()
-                            .parse()
-                            .ok()?;
-                        typed
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, rate)| **rate > 0)
-                            .min_by_key(|(_, rate)| rate.abs_diff(wanted))
-                            .map(|(index, _)| index as f64)
                     });
-                if ui.add(slider).changed()
-                    && let Some(rate) = stops.get(at)
-                {
-                    app.actions.push(Action::SetMilkdropFps(*rate));
+                },
+            );
+        });
+    }
+
+    if section_matches(
+        &needle,
+        "Equalizer",
+        &[
+            ("Equalizer", "ten-band"),
+            ("Presets", "preset"),
+            ("Preamp", "Pre"),
+            ("Bands", "dB"),
+        ],
+    ) || (!needle.is_empty()
+        && crate::eq::PRESETS
+            .iter()
+            .any(|preset| preset.name.to_lowercase().contains(&needle)))
+    {
+        any_visible = true;
+        section(ui, &palette, "Equalizer", |ui| {
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Equalizer",
+                "Equalizer",
+                "A ten-band equalizer for playback on this computer. It does not affect other devices.",
+                |ui| {
+                    let mut on = app.settings.eq_on;
+                    if widgets::switch(ui, &palette, "Equalizer", &mut on).changed() {
+                        app.actions.push(Action::ToggleEq);
+                    }
+                },
+            );
+            let names: Vec<(usize, &str)> = crate::eq::PRESETS
+                .iter()
+                .enumerate()
+                .map(|(index, preset)| (index, preset.name))
+                .collect();
+            let current = crate::eq::PRESETS
+                .iter()
+                .position(|preset| preset.bands_db == app.settings.eq_bands_db)
+                .unwrap_or(usize::MAX);
+            let eq_extra_visible = needle.is_empty()
+                || "equalizer".contains(&needle)
+                || row_matches(&needle, "Equalizer presets", "preset preamp band equalizer")
+                || names
+                    .iter()
+                    .any(|(_, name)| name.to_lowercase().contains(&needle));
+            if eq_extra_visible {
+                if let Some(picked) = widgets::chips(ui, &palette, &names, current) {
+                    app.actions.push(Action::ApplyEqPreset(picked));
                 }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Resolution",
-            "Half and Quarter use fewer resources and scale the image back up.",
-            |ui| {
-                let current = app.settings.milkdrop_scale.max(1);
+                ui.add_space(10.0);
+                eq_curve(ui, &palette, &crate::app::eq_settings(&app.settings));
+                ui.add_space(10.0);
                 ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 6.0;
-                    for (scale, label) in [(1u32, "Full"), (2, "Half"), (4, "Quarter")] {
-                        if theme::soft_button(ui, &palette, None, label, scale == current).clicked()
-                            && scale != current
-                        {
-                            app.actions.push(Action::SetMilkdropScale(scale));
+                    ui.spacing_mut().item_spacing.x = 14.0;
+                    let on = app.settings.eq_on;
+                    let mut preamp = app.settings.eq_preamp_db;
+                    if eq_slider(ui, &palette, "Pre", &mut preamp, on) {
+                        app.actions.push(Action::SetEqPreamp(preamp));
+                    }
+                    for (band, hz) in crate::eq::BANDS.iter().enumerate() {
+                        let mut gain = app.settings.eq_bands_db[band];
+                        if eq_slider(ui, &palette, &hertz(*hz), &mut gain, on) {
+                            app.actions.push(Action::SetEqBand(band, gain));
                         }
                     }
                 });
-            },
-        );
-    });
-
-    section(ui, &palette, "Equalizer", |ui| {
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Equalizer",
-            "A ten-band equalizer for playback on this computer. It does not affect other devices.",
-            |ui| {
-                let mut on = app.settings.eq_on;
-                if widgets::switch(ui, &palette, "Equalizer", &mut on).changed() {
-                    app.actions.push(Action::ToggleEq);
-                }
-            },
-        );
-        let names: Vec<(usize, &str)> = crate::eq::PRESETS
-            .iter()
-            .enumerate()
-            .map(|(index, preset)| (index, preset.name))
-            .collect();
-        let current = crate::eq::PRESETS
-            .iter()
-            .position(|preset| preset.bands_db == app.settings.eq_bands_db)
-            .unwrap_or(usize::MAX);
-        if let Some(picked) = widgets::chips(ui, &palette, &names, current) {
-            app.actions.push(Action::ApplyEqPreset(picked));
-        }
-        ui.add_space(10.0);
-        eq_curve(ui, &palette, &crate::app::eq_settings(&app.settings));
-        ui.add_space(10.0);
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = 14.0;
-            let on = app.settings.eq_on;
-            let mut preamp = app.settings.eq_preamp_db;
-            if eq_slider(ui, &palette, "Pre", &mut preamp, on) {
-                app.actions.push(Action::SetEqPreamp(preamp));
-            }
-            for (band, hz) in crate::eq::BANDS.iter().enumerate() {
-                let mut gain = app.settings.eq_bands_db[band];
-                if eq_slider(ui, &palette, &hertz(*hz), &mut gain, on) {
-                    app.actions.push(Action::SetEqBand(band, gain));
-                }
             }
         });
-    });
+    }
 
-    section(ui, &palette, "Storage", |ui| {
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Artwork cache",
-            &format!("Stored in {}", app.dirs.art_cache_dir().display()),
-            |ui| {
-                if theme::soft_button(ui, &palette, Some(Icon::Trash), "Clear artwork", false)
+    if section_matches(
+        &needle,
+        "Storage",
+        &[
+            ("Artwork cache", "Stored in"),
+            ("Audio cache", "Stored in"),
+            ("Play history", "Tracks played"),
+            ("Sign-in", "credential store"),
+        ],
+    ) {
+        any_visible = true;
+        section(ui, &palette, "Storage", |ui| {
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Storage",
+                "Artwork cache",
+                &format!("Stored in {}", app.dirs.art_cache_dir().display()),
+                |ui| {
+                    if theme::soft_button(ui, &palette, Some(Icon::Trash), "Clear artwork", false)
+                        .clicked()
+                    {
+                        app.actions.push(Action::ClearArtCache);
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Storage",
+                "Audio cache",
+                &format!("Stored in {}", app.dirs.audio_cache_dir().display()),
+                |_| {},
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Storage",
+                "Play history",
+                &format!(
+                    "Tracks played here are stored in {}. This file is never uploaded.",
+                    app.dirs.history_file().display()
+                ),
+                |ui| {
+                    if theme::soft_button(ui, &palette, Some(Icon::Trash), "Clear history", false)
+                        .clicked()
+                    {
+                        app.actions.push(Action::ClearPlayHistory);
+                    }
+                },
+            );
+            filtered_row(
+                ui,
+                &palette,
+                &needle,
+                "Storage",
+                "Sign-in",
+                "Sign-ins are saved in the system credential store when available.",
+                |_| {},
+            );
+        });
+    }
+
+    if section_matches(
+        &needle,
+        "About",
+        &[
+            ("About", "Fastpotify"),
+            ("Check for updates", "Check for updates"),
+            ("Keyboard shortcuts", "Keyboard shortcuts"),
+            ("Source code", "Source code"),
+        ],
+    ) {
+        any_visible = true;
+        section(ui, &palette, "About", |ui| {
+            ui.horizontal(|ui| {
+                let (logo, _) = ui.allocate_exact_size(Vec2::splat(40.0), egui::Sense::hover());
+                theme::logo(ui, logo.center(), 40.0, palette.accent, palette.on_accent);
+                ui.vertical(|ui| {
+                    theme::text(
+                        ui,
+                        format!("Fastpotify {}", env!("CARGO_PKG_VERSION")),
+                        theme::semibold(15.0),
+                        palette.text,
+                    );
+                    theme::text(
+                        ui,
+                        "Built with Rust, egui, and librespot. Not affiliated with Spotify.",
+                        theme::regular(13.0),
+                        palette.secondary,
+                    );
+                });
+            });
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 8.0;
+                let check_label = if app.update_checking {
+                    "Checking…"
+                } else {
+                    "Check for updates"
+                };
+                if theme::soft_button(ui, &palette, Some(Icon::Refresh), check_label, false)
+                    .clicked()
+                    && !app.update_checking
+                {
+                    app.actions.push(Action::CheckForUpdates);
+                }
+                if theme::soft_button(ui, &palette, Some(Icon::Info), "Keyboard shortcuts", false)
                     .clicked()
                 {
-                    app.actions.push(Action::ClearArtCache);
+                    app.actions.push(Action::ShowDialog(Dialog::Shortcuts));
                 }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Audio cache",
-            &format!("Stored in {}", app.dirs.audio_cache_dir().display()),
-            |_| {},
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Play history",
-            &format!(
-                "Tracks played here are stored in {}. This file is never uploaded.",
-                app.dirs.history_file().display()
-            ),
-            |ui| {
-                if theme::soft_button(ui, &palette, Some(Icon::Trash), "Clear history", false)
+                if theme::soft_button(ui, &palette, Some(Icon::ExternalLink), "Source code", false)
                     .clicked()
                 {
-                    app.actions.push(Action::ClearPlayHistory);
+                    ui.ctx()
+                        .open_url(egui::OpenUrl::new_tab(env!("CARGO_PKG_REPOSITORY")));
                 }
-            },
-        );
-        widgets::setting_row(
-            ui,
-            &palette,
-            "Sign-in",
-            "Sign-ins are saved in the system credential store when available.",
-            |_| {},
-        );
-    });
-
-    section(ui, &palette, "About", |ui| {
-        ui.horizontal(|ui| {
-            let (logo, _) = ui.allocate_exact_size(Vec2::splat(40.0), egui::Sense::hover());
-            theme::logo(ui, logo.center(), 40.0, palette.accent, palette.on_accent);
-            ui.vertical(|ui| {
-                theme::text(
-                    ui,
-                    format!("Fastpotify {}", env!("CARGO_PKG_VERSION")),
-                    theme::semibold(15.0),
-                    palette.text,
-                );
-                theme::text(
-                    ui,
-                    "Built with Rust, egui, and librespot. Not affiliated with Spotify.",
-                    theme::regular(13.0),
-                    palette.secondary,
-                );
             });
         });
-        ui.add_space(8.0);
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = 8.0;
-            let check_label = if app.update_checking {
-                "Checking…"
-            } else {
-                "Check for updates"
-            };
-            if theme::soft_button(ui, &palette, Some(Icon::Refresh), check_label, false).clicked()
-                && !app.update_checking
-            {
-                app.actions.push(Action::CheckForUpdates);
-            }
-            if theme::soft_button(ui, &palette, Some(Icon::Info), "Keyboard shortcuts", false)
-                .clicked()
-            {
-                app.actions.push(Action::ShowDialog(Dialog::Shortcuts));
-            }
-            if theme::soft_button(ui, &palette, Some(Icon::ExternalLink), "Source code", false)
-                .clicked()
-            {
-                ui.ctx()
-                    .open_url(egui::OpenUrl::new_tab(env!("CARGO_PKG_REPOSITORY")));
-            }
-        });
-    });
+    }
+
+    if !needle.is_empty() && !any_visible {
+        widgets::empty_state(
+            ui,
+            &palette,
+            Icon::Search,
+            &format!("No settings for “{needle}”"),
+            "Try fewer words, or check the spelling.",
+        );
+    }
 
     ui.data_mut(|data| data.insert_temp(dirty_id, playback_dirty));
     if changed {
@@ -1129,5 +1501,72 @@ fn eq_curve(ui: &mut egui::Ui, palette: &Palette, settings: &crate::eq::EqSettin
     painter.add(Shape::line(points, Stroke::new(2.0, color)));
     for (hz, db) in crate::eq::BANDS.iter().zip(settings.bands_db) {
         painter.circle_filled(pos2(x_of(*hz), y_of(db + settings.preamp_db)), 3.0, color);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{row_matches, section_matches};
+
+    #[test]
+    fn empty_filter_matches_everything() {
+        assert!(row_matches(
+            "",
+            "Normalize volume",
+            "Keep loud tracks level"
+        ));
+        assert!(section_matches(
+            "",
+            "Playback on this computer",
+            &[("Status", "Spotify")]
+        ));
+    }
+
+    #[test]
+    fn row_matches_title_or_description_case_insensitively() {
+        assert!(row_matches(
+            "volume",
+            "Normalize volume",
+            "Keep loud tracks level"
+        ));
+        assert!(row_matches(
+            "VOLUME",
+            "Normalize volume",
+            "Keep loud tracks level"
+        ));
+        assert!(row_matches(
+            "quiet",
+            "Normalize volume",
+            "Keep loud and quiet tracks level"
+        ));
+        assert!(!row_matches(
+            "theme",
+            "Normalize volume",
+            "Keep loud tracks level"
+        ));
+    }
+
+    #[test]
+    fn section_matches_title_or_any_row() {
+        let rows = [
+            ("Normalize volume", "Keep loud and quiet tracks level"),
+            ("Autoplay", "Keep playing similar songs"),
+        ];
+        assert!(section_matches(
+            "playback",
+            "Playback on this computer",
+            &rows
+        ));
+        assert!(section_matches(
+            "autoplay",
+            "Playback on this computer",
+            &rows
+        ));
+        assert!(section_matches("quiet", "Playback on this computer", &rows));
+        assert!(!section_matches(
+            "theme",
+            "Playback on this computer",
+            &rows
+        ));
     }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -46,12 +46,19 @@ fn filtered_row(
     description: &str,
     control: impl FnOnce(&mut egui::Ui),
 ) {
+    let needle = needle.trim().to_lowercase();
     if needle.is_empty()
-        || section.to_lowercase().contains(needle)
-        || row_matches(needle, title, description)
+        || section.to_lowercase().contains(&needle)
+        || row_matches(&needle, title, description)
     {
         widgets::setting_row(ui, palette, title, description, control);
     }
+}
+
+/// Forget the search text, so a flow that lands on a specific row (like
+/// the Personal App setup) always finds that row visible and focusable.
+pub(crate) fn clear_search(ctx: &egui::Context) {
+    ctx.data_mut(|data| data.remove::<String>(egui::Id::new(SETTINGS_FILTER_ID)));
 }
 
 fn section(


### PR DESCRIPTION
The Settings page had no way to find a row without scrolling all eight sections.

**Interface change:** one new "Search settings" field under the Settings title. Nothing else moves; an empty query renders the page exactly as before.

What changed:
- New search field reusing the shared search-field widget.
- Typing filters rows by title and description and hides sections with no matches; a section-name match shows the whole section. Skin names, EQ preset names, and MilkDrop pack names also match.
- A "No settings for ..." empty state appears when nothing matches. Clearing the field restores the full page.
- Opening Personal App setup from the Premium introduction now drops any saved search first, so the Client ID row it focuses is always visible.
- Documented in the README Settings section and the Everyday Use guide ("Finding a setting").

Screenshots (demo data, Settings page):

| | Before | After |
|---|---|---|
| Wide, dark | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/before-wide-dark.png) | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/after-wide-dark.png) |
| Wide, light | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/before-wide-light.png) | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/after-wide-light.png) |
| Narrow, dark | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/before-narrow-dark.png) | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/after-narrow-dark.png) |
| Narrow, light | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/before-narrow-light.png) | ![](https://raw.githubusercontent.com/KartikeyaKotkar/fastpotify/shots/settings-search/shots/settings-search/after-narrow-light.png) |

Tests:
- New matcher unit tests in src/ui/settings.rs.
- New demo regressions in src/demo.rs: typing narrows rows, Clear restores them, gibberish shows the empty state, and entering Personal App setup with a saved search clears it and focuses the Client ID field.
- cargo fmt, node issue-assessment tests, cargo clippy (default features, all targets), and cargo test --locked --all-targets all pass (456 lib passed, 0 failed). All-features clippy, all-features tests (456 lib passed, 0 failed), doc tests, and rustdoc -D warnings all pass. Only the Jekyll docs build did not run locally (no bundler here); it rides on CI.