### PR TITLE
Sort playlists by artist and offer a sort menu

### DIFF
--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -113,6 +113,13 @@ Changing the option while the mini player is open replaces that window while
 playback continues. This setting is available on Windows; it does not change
 Linux panels or the macOS Dock.
 
+## Sorting
+
+Playlists and Liked Songs can be sorted by title, artist, album, date added, or
+duration. Choose an order from the sort dropdown next to the filter field, or
+click a table column heading. Selecting the active sort again reverses it, and
+**Custom order** restores the list's natural sequence.
+
 ## Recent
 
 The queue panel's second tab combines Spotify's history with tracks played

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1089,6 +1089,69 @@ mod tests {
     }
 
     #[test]
+    fn playlist_sort_menu_opens_and_selects_with_keyboard() {
+        use egui::accesskit::{Action as AccessibleAction, Role};
+        let (ctx, mut app) = accessible_app("playlist-sort-menu");
+        app.open(Page::Playlist("pl1".into()));
+        accessible_frame(&ctx, &mut app, vec![]);
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let sort = accessible_node(&tree, "Custom order", Role::Button);
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(sort, AccessibleAction::Focus, None)],
+        );
+        let tree = accessible_frame(
+            &ctx,
+            &mut app,
+            vec![keyboard(egui::Key::Enter, egui::Modifiers::NONE)],
+        );
+        let artist = accessible_node(&tree, "Artist", Role::Button);
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(artist, AccessibleAction::Focus, None)],
+        );
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![keyboard(egui::Key::Enter, egui::Modifiers::NONE)],
+        );
+        assert_eq!(
+            app.table_sorts.get(&Page::Playlist("pl1".into())),
+            Some(&crate::model::TableSort {
+                column: crate::model::SortColumn::Artist,
+                ascending: true,
+            })
+        );
+        let tree = accessible_frame(&ctx, &mut app, vec![]);
+        let sort = accessible_node(&tree, "Artist", Role::Button);
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(sort, AccessibleAction::Focus, None)],
+        );
+        let tree = accessible_frame(
+            &ctx,
+            &mut app,
+            vec![keyboard(egui::Key::Enter, egui::Modifiers::NONE)],
+        );
+        let custom = accessible_node(&tree, "Custom order", Role::Button);
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![accessible_action(custom, AccessibleAction::Focus, None)],
+        );
+        accessible_frame(
+            &ctx,
+            &mut app,
+            vec![keyboard(egui::Key::Enter, egui::Modifiers::NONE)],
+        );
+        assert_eq!(app.table_sorts.get(&Page::Playlist("pl1".into())), None);
+        app.backend.shutdown();
+    }
+
+    #[test]
     fn library_sorts_finish_paging_without_retrying_failed_pages() {
         use crate::settings::{LibraryShelf, LibrarySort};
         for (shelf, label, page) in [

--- a/src/model.rs
+++ b/src/model.rs
@@ -601,6 +601,7 @@ pub struct TableSort {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum SortColumn {
     Title,
+    Artist,
     Album,
     Added,
     Duration,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -593,4 +593,20 @@ mod session_tests {
         assert!(!path.with_extension("json.tmp").exists());
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[test]
+    fn table_sort_with_artist_round_trips_in_session() {
+        let state = SessionState {
+            sorts: vec![(
+                "playlist:test".into(),
+                crate::model::TableSort {
+                    column: crate::model::SortColumn::Artist,
+                    ascending: true,
+                },
+            )],
+            ..SessionState::default()
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        assert_eq!(serde_json::from_str::<SessionState>(&json).unwrap(), state);
+    }
 }

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -117,6 +117,8 @@ pub struct Actions<'a> {
     pub saved_tooltips: (&'a str, &'a str),
     pub owned_playlist: Option<Playlist>,
     pub name: &'a str,
+    pub sort_page: Option<Page>,
+    pub show_added_by: bool,
 }
 
 /// The big play button and its neighbours; returns the filter text if a
@@ -241,16 +243,41 @@ pub fn actions_row(
                     )
                 });
         }
-        if let Some(filter) = filter {
+        if filter.is_some() || actions.sort_page.is_some() {
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                widgets::search_field(
-                    ui,
-                    &palette,
-                    egui::Id::new(("collection-filter", actions.name)),
-                    filter,
-                    "Filter",
-                    220.0,
-                );
+                if let Some(sort_page) = &actions.sort_page {
+                    let sort = app.table_sorts.get(sort_page).copied();
+                    if let Some(pick) =
+                        widgets::sort_menu(ui, &palette, sort, actions.show_added_by)
+                    {
+                        match pick {
+                            widgets::SortPick::Clear => {
+                                app.table_sorts.remove(sort_page);
+                                app.note_session_change();
+                            }
+                            widgets::SortPick::Set(new_sort) => {
+                                app.table_sorts.insert(sort_page.clone(), new_sort);
+                                app.note_session_change();
+                                app.actions.push(Action::LoadMore(sort_page.clone()));
+                            }
+                        }
+                    }
+                    if filter.is_some() {
+                        ui.add_space(8.0);
+                    }
+                }
+                if let Some(filter) = filter {
+                    let available = ui.available_width();
+                    let width = (available - 12.0).clamp(120.0, 220.0);
+                    widgets::search_field(
+                        ui,
+                        &palette,
+                        egui::Id::new(("collection-filter", actions.name)),
+                        filter,
+                        "Filter",
+                        width,
+                    );
+                }
             });
         }
     });
@@ -703,6 +730,14 @@ fn view_indices(items: &[TableItem], needle: &str, sort: Option<TableSort>) -> V
             PlayableItem::Track(track) => track.duration_ms,
             PlayableItem::Episode(episode) => episode.duration_ms,
         };
+        let artist_of = |item: &PlayableItem| match item {
+            PlayableItem::Track(track) => track.artist_names().to_lowercase(),
+            PlayableItem::Episode(episode) => episode
+                .show
+                .as_ref()
+                .map(|show| show.name.to_lowercase())
+                .unwrap_or_default(),
+        };
         visible.sort_by(|a, b| {
             let (item_a, added_a, adder_a) = &items[*a];
             let (item_b, added_b, adder_b) = &items[*b];
@@ -711,6 +746,12 @@ fn view_indices(items: &[TableItem], needle: &str, sort: Option<TableSort>) -> V
                     .name()
                     .to_lowercase()
                     .cmp(&item_b.name().to_lowercase()),
+                SortColumn::Artist => artist_of(item_a).cmp(&artist_of(item_b)).then_with(|| {
+                    item_a
+                        .name()
+                        .to_lowercase()
+                        .cmp(&item_b.name().to_lowercase())
+                }),
                 SortColumn::Album => album_of(item_a).cmp(&album_of(item_b)),
                 SortColumn::Added => added_a.cmp(added_b),
                 SortColumn::Index => a.cmp(b),
@@ -950,6 +991,8 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                     saved_tooltips: ("Add to Your Library", "Remove from Your Library"),
                     owned_playlist: owned.then_some(playlist_clone),
                     name: &playlist.name,
+                    sort_page: Some(Page::Playlist(id.to_string())),
+                    show_added_by: made_together,
                 },
                 Some(&mut page.filter),
             );
@@ -1066,6 +1109,8 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                     saved_tooltips: ("Save to Your Library", "Remove from Your Library"),
                     owned_playlist: None,
                     name: &album.name,
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 None,
             );
@@ -1266,6 +1311,8 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
             saved_tooltips: ("", ""),
             owned_playlist: None,
             name: "Liked Songs",
+            sort_page: Some(Page::LikedSongs),
+            show_added_by: false,
         },
         Some(&mut filter),
     );
@@ -1479,6 +1526,123 @@ mod tests {
         });
         let visible = view_indices(&items, "", sort);
         assert_eq!(visible, vec![3, 2, 1, 0]);
+
+        // 6. Sort ascending by artist
+        let sort = Some(TableSort {
+            column: SortColumn::Artist,
+            ascending: true,
+        });
+        let visible = view_indices(&items, "", sort);
+        assert_eq!(visible, vec![2, 0, 3, 1]);
+
+        // 7. Sort descending by artist
+        let sort = Some(TableSort {
+            column: SortColumn::Artist,
+            ascending: false,
+        });
+        let visible = view_indices(&items, "", sort);
+        assert_eq!(visible, vec![1, 3, 0, 2]);
+    }
+
+    #[test]
+    fn test_artist_sorting_tie_break() {
+        let make_track = |title: &str, artist: &str| {
+            (
+                PlayableItem::Track(Track {
+                    name: title.to_string(),
+                    artists: vec![ArtistRef {
+                        id: Some("a1".into()),
+                        name: artist.to_string(),
+                        uri: None,
+                    }],
+                    ..Default::default()
+                }),
+                None,
+                None,
+            )
+        };
+        let items = vec![
+            make_track("Under Pressure", "Queen"),
+            make_track("Bohemian Rhapsody", "Queen"),
+            make_track("Another One Bites the Dust", "Queen"),
+        ];
+        let sort_asc = Some(TableSort {
+            column: SortColumn::Artist,
+            ascending: true,
+        });
+        let visible_asc = view_indices(&items, "", sort_asc);
+        assert_eq!(visible_asc, vec![2, 1, 0]);
+
+        let sort_desc = Some(TableSort {
+            column: SortColumn::Artist,
+            ascending: false,
+        });
+        let visible_desc = view_indices(&items, "", sort_desc);
+        assert_eq!(visible_desc, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_artist_sorting_multi_artist_case_and_episodes() {
+        use crate::api::models::{Episode, Show};
+        let make_track = |title: &str, artists: &[&str]| {
+            (
+                PlayableItem::Track(Track {
+                    name: title.to_string(),
+                    artists: artists
+                        .iter()
+                        .map(|name| ArtistRef {
+                            id: None,
+                            name: name.to_string(),
+                            uri: None,
+                        })
+                        .collect(),
+                    ..Default::default()
+                }),
+                None,
+                None,
+            )
+        };
+        let make_episode = |title: &str, show_name: &str| {
+            (
+                PlayableItem::Episode(Episode {
+                    name: title.to_string(),
+                    show: Some(Show {
+                        name: show_name.to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                None,
+                None,
+            )
+        };
+        let items = vec![
+            // 0: David Bowie (lowercase artist name)
+            make_track("Starman", &["david bowie"]),
+            // 1: Multiple artists
+            make_track("Under Pressure", &["Queen", "David Bowie"]),
+            // 2: Queen (uppercase artist name)
+            make_track("Bohemian Rhapsody", &["QUEEN"]),
+            // 3: Podcast episode (show name acts as artist)
+            make_episode("The Fall of Rome", "Dan Carlin's Hardcore History"),
+            // 4: ABBA
+            make_track("Dancing Queen", &["ABBA"]),
+        ];
+
+        let sort_asc = Some(TableSort {
+            column: SortColumn::Artist,
+            ascending: true,
+        });
+        let visible_asc = view_indices(&items, "", sort_asc);
+        // "abba" (4) < "dan carlin's hardcore history" (3) < "david bowie" (0) < "queen" (2) < "queen, david bowie" (1)
+        assert_eq!(visible_asc, vec![4, 3, 0, 2, 1]);
+
+        let sort_desc = Some(TableSort {
+            column: SortColumn::Artist,
+            ascending: false,
+        });
+        let visible_desc = view_indices(&items, "", sort_desc);
+        assert_eq!(visible_desc, vec![1, 2, 0, 3, 4]);
     }
 
     #[test]
@@ -1625,6 +1789,8 @@ mod tests {
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
                     name: "Test",
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 None,
             );
@@ -1670,6 +1836,8 @@ mod tests {
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
                     name: "Test",
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 None,
             );
@@ -1719,6 +1887,8 @@ mod tests {
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
                     name: "Test",
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 None,
             );
@@ -1764,6 +1934,8 @@ mod tests {
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
                     name: "Test",
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 None,
             );
@@ -1814,6 +1986,8 @@ mod tests {
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
                     name: "Test",
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 Some(&mut filter),
             );
@@ -1859,6 +2033,8 @@ mod tests {
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
                     name: "Test",
+                    sort_page: None,
+                    show_added_by: false,
                 },
                 Some(&mut filter),
             );

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1526,7 +1526,7 @@ pub fn table_header(
         }
         if response
             .on_hover_cursor(egui::CursorIcon::PointingHand)
-            .on_hover_text("Original order, reversed")
+            .on_hover_text("Custom order, reversed")
             .clicked()
         {
             number_clicked = true;
@@ -2136,6 +2136,146 @@ pub fn search_field(
     response
 }
 
+/// What was chosen from the sort dropdown menu.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortPick {
+    Clear,
+    Set(crate::model::TableSort),
+}
+
+/// A dropdown menu for choosing how to sort a track list.
+pub fn sort_menu(
+    ui: &mut Ui,
+    palette: &Palette,
+    sort: Option<crate::model::TableSort>,
+    show_added_by: bool,
+) -> Option<SortPick> {
+    use crate::model::SortColumn;
+    let label = match sort {
+        None => "Custom order",
+        Some(s) => match s.column {
+            SortColumn::Title => "Title",
+            SortColumn::Artist => "Artist",
+            SortColumn::Album => "Album",
+            SortColumn::Added => "Date added",
+            SortColumn::Duration => "Duration",
+            SortColumn::AddedBy => "Added by",
+            SortColumn::Index => {
+                if s.ascending {
+                    "Custom order"
+                } else {
+                    "Custom order, reversed"
+                }
+            }
+        },
+    };
+    let font = theme::medium(13.0);
+    let is_active = sort.is_some();
+    let text_color = if is_active {
+        palette.text
+    } else {
+        palette.secondary
+    };
+    let galley = ui.painter().layout_no_wrap(
+        crate::bidi::display_text(label).into_owned(),
+        font,
+        text_color,
+    );
+    let size = vec2(galley.size().x + 44.0, 34.0);
+    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+    response.widget_info(|| {
+        egui::WidgetInfo::labeled(egui::WidgetType::Button, ui.is_enabled(), label)
+    });
+    if ui.is_rect_visible(rect) {
+        let hovered = response.hovered();
+        let fill = if hovered {
+            palette.surface_hover
+        } else {
+            palette.surface
+        };
+        ui.painter().rect_filled(rect, rect.height() / 2.0, fill);
+        if is_active {
+            ui.painter().rect_stroke(
+                rect,
+                rect.height() / 2.0,
+                Stroke::new(1.0, palette.outline),
+                egui::StrokeKind::Inside,
+            );
+        }
+        let text_pos = pos2(rect.left() + 12.0, rect.center().y - galley.size().y / 2.0);
+        let color = if hovered || is_active {
+            palette.text
+        } else {
+            palette.secondary
+        };
+        ui.painter().galley(text_pos, galley, color);
+
+        let icon = match sort {
+            Some(s) if s.ascending => Icon::ChevronUp,
+            _ => Icon::ChevronDown,
+        };
+        let icon_rect = Rect::from_center_size(
+            pos2(rect.right() - 12.0 - 7.0, rect.center().y),
+            Vec2::splat(14.0),
+        );
+        icon.image(color, 14.0).paint_at(ui, icon_rect);
+    }
+    theme::focus_ring(ui, &response);
+    let response = response
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text("Sort");
+
+    let mut picked = None;
+    egui::Popup::menu(&response)
+        .frame(menu_frame(palette))
+        .show(|ui| {
+            ui.set_min_width(170.0);
+            ui.add_space(2.0);
+
+            let custom_active = sort.is_none()
+                || sort.is_some_and(|s| s.column == SortColumn::Index && s.ascending);
+            if menu_item(
+                ui,
+                palette,
+                custom_active.then_some(Icon::Check),
+                "Custom order",
+            ) {
+                picked = Some(SortPick::Clear);
+            }
+            menu_separator(ui, palette);
+
+            let mut option = |col: SortColumn, name: &str| {
+                let active = sort.is_some_and(|s| s.column == col);
+                let icon = if active { Some(Icon::Check) } else { None };
+                if menu_item(ui, palette, icon, name) {
+                    let next = match sort {
+                        Some(s) if s.column == col => crate::model::TableSort {
+                            column: col,
+                            ascending: !s.ascending,
+                        },
+                        _ => crate::model::TableSort {
+                            column: col,
+                            ascending: true,
+                        },
+                    };
+                    picked = Some(SortPick::Set(next));
+                }
+            };
+
+            option(SortColumn::Title, "Title");
+            option(SortColumn::Artist, "Artist");
+            option(SortColumn::Album, "Album");
+            option(SortColumn::Added, "Date added");
+            option(SortColumn::Duration, "Duration");
+            if show_added_by {
+                option(SortColumn::AddedBy, "Added by");
+            }
+            ui.add_space(2.0);
+        });
+
+    picked
+}
+
 /// A toggle drawn as a switch.
 pub fn switch(ui: &mut Ui, palette: &Palette, label: &str, on: &mut bool) -> egui::Response {
     let size = vec2(40.0, 22.0);
@@ -2486,5 +2626,33 @@ mod tests {
         );
         assert!(!painted.is_empty());
         assert_eq!(painted[0], 0);
+    }
+
+    #[test]
+    fn sort_menu_renders_with_both_custom_and_active_order() {
+        use crate::model::{SortColumn, TableSort};
+        let ctx = egui::Context::default();
+        crate::theme::install(&ctx);
+        let palette = Palette::dark();
+        let size = vec2(300.0, 100.0);
+        let clip = Rect::from_min_size(pos2(0.0, 0.0), size);
+        run_on(&ctx, size, clip, Vec::new(), |ui| {
+            let pick = sort_menu(ui, &palette, None, true);
+            assert_eq!(pick, None);
+
+            let sort = Some(TableSort {
+                column: SortColumn::Artist,
+                ascending: true,
+            });
+            let pick = sort_menu(ui, &palette, sort, false);
+            assert_eq!(pick, None);
+
+            let sort_reversed_index = Some(TableSort {
+                column: SortColumn::Index,
+                ascending: false,
+            });
+            let pick = sort_menu(ui, &palette, sort_reversed_index, true);
+            assert_eq!(pick, None);
+        });
     }
 }


### PR DESCRIPTION
## Why
Listeners frequently browse large playlists and Liked Songs grouped or sorted alphabetically by artist name, mirroring Spotify's desktop client. Because track rows combine the song title and artist names into a single column, clicking a dedicated table column header for artist is not available. Adding an explicit sort dropdown menu in the playlist header gives listeners convenient access to all ordering choices, including sorting by artist, toggling direction, and restoring custom order.

## What changed
- **Model** (`src/model.rs`): Added the `Artist` variant to `SortColumn`.                                                              
- **UI Widgets** (`src/ui/widgets.rs`): Implemented `sort_menu`, rendering a dropdown menu to select Custom order, Title, Artist, Album, Date added, and Duration (as well as Added by when applicable), supporting direction toggling.                                           
- **Collection View** (`src/ui/collection.rs`):                                                                                        
- Updated `view_indices` to sort case-insensitively by artist, using track name as an alphabetical tie-breaker.                      
- Handled podcast episode items in playlist views by resolving the podcast show name as the artist key.                              
- Integrated `sort_menu` into `actions_row` for playlists and Liked Songs. Setting a sort emits `Action::LoadMore` to ensure long    
  collections load completely for sorting and notes session changes.                                                                       
- **Settings** (`src/settings.rs`): Preserved `SortColumn::Artist` table sorts in `SessionState` across restarts.                      
- **Documentation** (`docs/_guide/using-fastpotify.md`): Documented the sort dropdown menu and artist sorting capability.

## Verification
Tested on Windows (x86_64) using the following commands:                                                                               
    - `cargo fmt --all --check`                                                                                                            
    - `cargo test --lib --no-default-features -j 2 ui::collection::tests`                                                                  
    - `cargo test --lib --no-default-features -j 2 settings::session_tests`                                                                
    - `cargo test --lib --no-default-features -j 2 ui::widgets::tests`

Added unit test coverage:                                                                                                              
    - Ascending and descending artist sorting in `test_view_indices_filtering_and_sorting`.                                                
    - Title tie-breaking in both directions for tracks by the same artist in `test_artist_sorting_tie_break`.                              
    - Case-insensitivity, multiple artists joined by comma, and podcast episodes in `test_artist_sorting_multi_artist_case_and_episodes`.  
    - Headless rendering of the sort dropdown widget in `sort_menu_renders_with_both_custom_and_active_order`.                             
    - Session state round-trip serialization with artist sort in `table_sort_with_artist_round_trips_in_session`.


- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
