### PR TITLE
Add self-update for Linux hand-installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1319,7 +1319,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1673,7 +1673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1760,6 +1760,7 @@ dependencies = [
  "sha2",
  "skrifa",
  "souvlaki",
+ "tar",
  "thiserror 2.0.20",
  "tiny-skia",
  "tokio",
@@ -1798,6 +1799,16 @@ name = "fearless_simd"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -3337,7 +3348,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4506,7 +4517,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4889,7 +4900,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5405,7 +5416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5670,6 +5681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,7 +5701,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6070,7 +6092,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6133,7 +6155,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6758,7 +6780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7360,6 +7382,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 # Inflating the zip a Winamp skin comes as (src/skin/zip.rs). Already
 # compiled for reqwest's gzip support, so this adds no code to the build.
 flate2 = "1"
+tar = "0.4"
 # Filling glyph outlines with no anti-aliasing for the Winamp playlist's
 # text (src/ui/winamp/pixel_text.rs). Already compiled for the SVG icons
 # through egui_extras and resvg, so this adds no code to the build.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1364,6 +1364,18 @@ impl App {
                         }
                     }
                 }
+                Event::UpdateNow { result } => {
+                    self.update_checking = false;
+                    match result {
+                        Ok(path) => {
+                            self.toast(format!("Fastpotify updated to {}. Restarting…", path.display()));
+                            self.restart_with_binary(path);
+                        }
+                        Err(error) => {
+                            self.toast_error(format!("Couldn't apply the update: {error}"));
+                        }
+                    }
+                }
             }
         }
     }
@@ -5764,6 +5776,20 @@ impl App {
                 }
             }
             Action::CheckForUpdates => self.check_for_updates(true),
+            Action::UpdateNow => {
+                #[cfg(target_os = "linux")]
+                {
+                    self.backend.send(Command::UpdateNow);
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    // On non-Linux platforms, open the release page so the user
+                    // can download the latest version manually.
+                    if let Some(update) = &self.update {
+                        self.actions.push(Action::OpenUrl(update.url.clone()));
+                    }
+                }
+            }
             Action::SettingsChanged => {
                 self.settings_dirty = true;
                 ctx.set_theme(match self.settings.theme {
@@ -6474,6 +6500,26 @@ impl App {
             }
             .save(&self.dirs.session_file());
         }
+    }
+
+    /// Replace this process with the newly installed binary.
+    #[cfg(target_os = "linux")]
+    fn restart_with_binary(&self, path: std::path::PathBuf) {
+        use std::os::unix::process::CommandExt;
+        let path = std::path::PathBuf::from(path);
+        let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+        let mut cmd = std::process::Command::new(&path);
+        cmd.args(&args);
+        log::info!("exec'ing updated binary at {path:?}");
+        // exec() replaces this process image with the new binary — same PID,
+        // same D-Bus connection, no single-instance conflict.
+        let error = cmd.exec();
+        log::error!("failed to exec updated binary: {error}");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn restart_with_binary(&self, _path: std::path::PathBuf) {
+        // Non-Linux: nothing to do (could open the release page here).
     }
 
     /// Final teardown at real quit.
@@ -8410,6 +8456,7 @@ mod tests {
         app.update = Some(crate::updates::Release {
             version: "1.2.3".into(),
             url: "https://github.com/crmne/fastpotify/releases/tag/v1.2.3".into(),
+            download_url: String::new(),
         });
         app.update_checking = true;
         app.handle_backend_events(vec![Event::UpdateChecked {
@@ -8461,6 +8508,7 @@ mod tests {
             result: Ok(Some(crate::updates::Release {
                 version: "1.2.3".into(),
                 url: "https://github.com/crmne/fastpotify/releases/tag/v1.2.3".into(),
+                download_url: String::new(),
             })),
         }]);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1368,7 +1368,10 @@ impl App {
                     self.update_checking = false;
                     match result {
                         Ok(path) => {
-                            self.toast(format!("Fastpotify updated to {}. Restarting…", path.display()));
+                            self.toast(format!(
+                                "Fastpotify updated to {}. Restarting…",
+                                path.display()
+                            ));
                             self.restart_with_binary(path);
                         }
                         Err(error) => {
@@ -6506,7 +6509,6 @@ impl App {
     #[cfg(target_os = "linux")]
     fn restart_with_binary(&self, path: std::path::PathBuf) {
         use std::os::unix::process::CommandExt;
-        let path = std::path::PathBuf::from(path);
         let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
         let mut cmd = std::process::Command::new(&path);
         cmd.args(&args);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1510,11 +1510,15 @@ impl Worker {
         let dirs = self.dirs.clone();
         tokio::spawn(async move {
             let result = async {
-                let release = crate::updates::newer_release(&http).await?
+                let release = crate::updates::newer_release(&http)
+                    .await?
                     .ok_or_else(|| anyhow::anyhow!("no newer release available"))?;
                 crate::updates::apply_update(&http, &dirs, &release).await
-            }.await;
-            let _ = events.send(Event::UpdateNow { result: result.map_err(|e| e.to_string()) });
+            }
+            .await;
+            let _ = events.send(Event::UpdateNow {
+                result: result.map_err(|e| e.to_string()),
+            });
             waker.wake();
         });
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -478,6 +478,10 @@ pub enum Command {
     CheckForUpdates {
         manual: bool,
     },
+    /// Download the newer release for the current platform and replace this
+    /// binary, then re-launch. Only meaningful on Linux, where the app ships
+    /// as a plain executable; other platforms keep opening the release page.
+    UpdateNow,
     /// The words of a track, from LRCLIB.
     Lyrics(Box<LyricsRequest>),
     /// The account's playlist tree, folders and all, from the session.
@@ -529,6 +533,10 @@ pub enum Event {
     UpdateChecked {
         manual: bool,
         result: Result<Option<crate::updates::Release>, String>,
+    },
+    /// The update download and self-replacement finished, or failed.
+    UpdateNow {
+        result: Result<std::path::PathBuf, String>,
     },
     /// Track lyrics, or `None` when unavailable.
     Lyrics {
@@ -910,6 +918,7 @@ impl Worker {
                 Command::DiscoverReceivers => self.discover_receivers(),
                 Command::ActivateReceiver(receiver) => self.activate_receiver(*receiver),
                 Command::CheckForUpdates { manual } => self.check_for_updates(manual),
+                Command::UpdateNow => self.update_now(),
                 Command::Lyrics(request) => self.fetch_lyrics(*request),
                 Command::Rootlist => self.fetch_rootlist(),
                 Command::VerifyResume => self.verify_resume(),
@@ -1490,6 +1499,22 @@ impl Worker {
                 .await
                 .map_err(|error| format!("{error:#}"));
             let _ = events.send(Event::UpdateChecked { manual, result });
+            waker.wake();
+        });
+    }
+
+    fn update_now(&self) {
+        let http = self.http.clone();
+        let events = self.events.clone();
+        let waker = self.waker.clone();
+        let dirs = self.dirs.clone();
+        tokio::spawn(async move {
+            let result = async {
+                let release = crate::updates::newer_release(&http).await?
+                    .ok_or_else(|| anyhow::anyhow!("no newer release available"))?;
+                crate::updates::apply_update(&http, &dirs, &release).await
+            }.await;
+            let _ = events.send(Event::UpdateNow { result: result.map_err(|e| e.to_string()) });
             waker.wake();
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,10 @@ fn main() -> eframe::Result<()> {
             .build()
             .expect("unable to start the update runtime");
         if let Some(release) = runtime.block_on(async {
-            fastpotify::updates::newer_release(&http).await.ok().flatten()
+            fastpotify::updates::newer_release(&http)
+                .await
+                .ok()
+                .flatten()
         }) {
             let dirs_clone = dirs.clone();
             if let Ok(path) = runtime.block_on(async {
@@ -963,8 +966,14 @@ fn app_icon() -> egui::IconData {
 fn launch_updated_binary(path: std::path::PathBuf) -> i32 {
     let mut cmd = std::process::Command::new(path);
     match cmd.spawn() {
-        Ok(mut child) => { let _ = child.wait(); 0 }
-        Err(error) => { eprintln!("Fastpotify update failed to relaunch: {error}"); 3 }
+        Ok(mut child) => {
+            let _ = child.wait();
+            0
+        }
+        Err(error) => {
+            eprintln!("Fastpotify update failed to relaunch: {error}");
+            3
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,11 @@ struct Cli {
     #[cfg(feature = "demo")]
     #[arg(long, value_name = "WIDTHxHEIGHT", value_parser = parse_demo_size)]
     demo_size: Option<[f32; 2]>,
+
+    /// Path to the freshly installed binary from an update, on Linux.
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    update_restart: Option<std::path::PathBuf>,
 }
 
 /// Remote control of the running instance, for Raycast scripts, launchers,
@@ -284,11 +289,20 @@ fn main() -> eframe::Result<()> {
         std::process::exit(fastpotify::milkdrop::child::run(args));
     }
 
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
     // A control launch is a client, not a second app: talk to the running
     // instance and exit before touching the log file it is writing to.
     if let Some(control) = cli.control {
         std::process::exit(run_control(control));
+    }
+    // An update restart launches the freshly installed binary. It is handled
+    // before anything that starts a second instance or touches the log.
+    // On Linux the new process skips the single-instance guard so it can
+    // take over from the process that spawned it.
+    let update_restart = cli.update_restart.take();
+    #[cfg(target_os = "linux")]
+    if let Some(path) = update_restart {
+        std::process::exit(launch_updated_binary(path));
     }
     // A link is read before anything starts: one that is not a Spotify
     // link ends the launch here rather than reaching the running instance.
@@ -327,6 +341,35 @@ fn main() -> eframe::Result<()> {
     let mut settings = settings::Settings::load(&dirs.settings_file());
     if let Some(name) = cli.device_name {
         settings.device_name = name;
+    }
+
+    // On Linux, if the user wants auto-update on launch, check for updates
+    // before the app fully initializes. If an update is found, download,
+    // verify, replace the binary, and exec the new one.
+    #[cfg(target_os = "linux")]
+    if settings.update_mode == settings::UpdateMode::OnLaunch && settings.check_for_updates {
+        use reqwest::Client;
+        let http = Client::builder()
+            .user_agent(concat!("fastpotify/", env!("CARGO_PKG_VERSION")))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("unable to build the HTTP client");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("unable to start the update runtime");
+        if let Some(release) = runtime.block_on(async {
+            fastpotify::updates::newer_release(&http).await.ok().flatten()
+        }) {
+            let dirs_clone = dirs.clone();
+            if let Ok(path) = runtime.block_on(async {
+                fastpotify::updates::apply_update(&http, &dirs_clone, &release).await
+            }) {
+                use std::os::unix::process::CommandExt;
+                let error = std::process::Command::new(&path).exec();
+                eprintln!("failed to exec updated binary: {error}");
+            }
+        }
     }
 
     // The application (audio engine, Web API, MPRIS, tray) outlives any
@@ -911,6 +954,17 @@ fn app_icon() -> egui::IconData {
         rgba: util::app_icon_rgba(SIZE),
         width: SIZE as u32,
         height: SIZE as u32,
+    }
+}
+
+/// Replaces the running process image with the newly installed one on Linux.
+/// The calling process must be the one whose binary was overwritten.
+#[cfg(target_os = "linux")]
+fn launch_updated_binary(path: std::path::PathBuf) -> i32 {
+    let mut cmd = std::process::Command::new(path);
+    match cmd.spawn() {
+        Ok(mut child) => { let _ = child.wait(); 0 }
+        Err(error) => { eprintln!("Fastpotify update failed to relaunch: {error}"); 3 }
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -819,6 +819,10 @@ pub enum Action {
     ToggleDevicesPopup,
     /// Ask GitHub for the latest release and report the result to the user.
     CheckForUpdates,
+    /// Download the newer release for the current platform, replace this binary,
+    /// and re-launch. Only meaningful on Linux; other platforms keep opening the
+    /// release page.
+    UpdateNow,
     SettingsChanged,
     RestartEngine,
     EnablePlayback,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -98,6 +98,10 @@ impl AppDirs {
         self.cache.join("audio")
     }
 
+    pub fn cache_dir(&self) -> PathBuf {
+        self.cache.clone()
+    }
+
     pub fn art_cache_dir(&self) -> PathBuf {
         self.cache.join("art")
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,6 +34,19 @@ impl VisMode {
     }
 }
 
+/// What to do when a newer release is found.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateMode {
+    /// Check for updates silently; only notify the user.
+    Manual,
+    /// Download and install updates automatically on launch.
+    #[default]
+    OnLaunch,
+    /// Check and notify, but let the user choose when to install.
+    OnClick,
+}
+
 impl ThemeChoice {
     pub const ALL: [ThemeChoice; 3] = [Self::Dark, Self::Light, Self::System];
 
@@ -94,6 +107,9 @@ pub struct Settings {
     pub playback_authorized: bool,
     /// Closing the window hides to the tray and keeps the music playing.
     pub keep_playing_in_background: bool,
+    /// What to do when a newer release is found.
+    #[serde(default)]
+    pub update_mode: UpdateMode,
     /// Ask GitHub once a day whether a newer release exists.
     pub check_for_updates: bool,
     /// Context URIs pinned to the top of the sidebar, in pin order.
@@ -182,6 +198,7 @@ impl Default for Settings {
             personal_app_nudge_at: None,
             playback_authorized: false,
             keep_playing_in_background: true,
+            update_mode: UpdateMode::default(),
             check_for_updates: true,
             pinned_contexts: Vec::new(),
             sidebar_order: Vec::new(),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -420,6 +420,7 @@ pub enum Icon {
     Watch,
     X,
     Zap,
+    Download,
 }
 
 const ICONS: &[(Icon, &str, &[u8])] = icons! {
@@ -777,7 +778,8 @@ pub fn soft_button(
     response.on_hover_cursor(egui::CursorIcon::PointingHand)
 }
 
-/// An animated busy indicator paced independently of the graphics driver.
+/// An animated busy indicator paced independently of the graphics driver. Returns
+/// the response so callers can attach tooltips etc.
 pub fn spinner(ui: &mut egui::Ui, size: f32, color: Color32) -> Response {
     let (rect, response) = ui.allocate_exact_size(Vec2::splat(size), Sense::hover());
     if ui.is_rect_visible(rect) {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4,8 +4,8 @@ use egui::{Align, CornerRadius, Frame, Layout, Margin, Stroke, Vec2};
 
 use crate::api::models::pick_image;
 use crate::app::App;
-use crate::model::{Action, Dialog};
-use crate::settings::ThemeChoice;
+use crate::model::{Action};
+use crate::settings::{ThemeChoice, UpdateMode};
 use crate::theme::{self, Icon, Palette};
 
 use super::widgets;
@@ -955,30 +955,69 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             });
         });
         ui.add_space(8.0);
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = 8.0;
-            let check_label = if app.update_checking {
-                "Checking…"
-            } else {
-                "Check for updates"
-            };
-            if theme::soft_button(ui, &palette, Some(Icon::Refresh), check_label, false).clicked()
-                && !app.update_checking
+        if app.update_checking {
+            ui.horizontal(|ui| {
+                ui.add_space(8.0);
+                theme::text(
+                    ui,
+                    "Checking…",
+                    theme::regular(12.0),
+                    palette.text,
+                );
+                theme::spinner(ui, 18.0, palette.accent);
+            });
+        } else if let Some(update) = app.update.clone() {
+            if theme::soft_button(
+                ui,
+                &palette,
+                Some(Icon::ExternalLink),
+                &format!("Update to {0}", update.version),
+                false,
+            )
+            .clicked()
             {
-                app.actions.push(Action::CheckForUpdates);
+                app.actions.push(Action::UpdateNow);
             }
-            if theme::soft_button(ui, &palette, Some(Icon::Info), "Keyboard shortcuts", false)
-                .clicked()
-            {
-                app.actions.push(Action::ShowDialog(Dialog::Shortcuts));
-            }
-            if theme::soft_button(ui, &palette, Some(Icon::ExternalLink), "Source code", false)
-                .clicked()
-            {
-                ui.ctx()
-                    .open_url(egui::OpenUrl::new_tab(env!("CARGO_PKG_REPOSITORY")));
-            }
-        });
+        } else if theme::soft_button(
+            ui,
+            &palette,
+            Some(Icon::Refresh),
+            "Check for updates",
+            false,
+        )
+        .clicked()
+        {
+            app.actions.push(Action::CheckForUpdates);
+        }
+        // Update mode dropdown
+        ui.add_space(8.0);
+        widgets::setting_row(
+            ui,
+            &palette,
+            "When an update is found",
+            "What to do when a newer release is available.",
+            |ui| {
+                let modes = [
+                    (UpdateMode::Manual, "Manual", "Only notify me"),
+                    (UpdateMode::OnClick, "On click", "Download when I click"),
+                    (UpdateMode::OnLaunch, "On launch", "Auto-update on startup"),
+                ];
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 6.0;
+                    for (mode, label, tooltip) in modes {
+                        let selected = app.settings.update_mode == mode;
+                        if theme::soft_button(ui, &palette, None, label, selected)
+                            .on_hover_text(tooltip)
+                            .clicked()
+                            && !selected
+                        {
+                            app.settings.update_mode = mode;
+                            changed = true;
+                        }
+                    }
+                });
+            },
+        );
     });
 
     ui.data_mut(|data| data.insert_temp(dirty_id, playback_dirty));

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4,7 +4,7 @@ use egui::{Align, CornerRadius, Frame, Layout, Margin, Stroke, Vec2};
 
 use crate::api::models::pick_image;
 use crate::app::App;
-use crate::model::{Action};
+use crate::model::Action;
 use crate::settings::{ThemeChoice, UpdateMode};
 use crate::theme::{self, Icon, Palette};
 
@@ -958,12 +958,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         if app.update_checking {
             ui.horizontal(|ui| {
                 ui.add_space(8.0);
-                theme::text(
-                    ui,
-                    "Checking…",
-                    theme::regular(12.0),
-                    palette.text,
-                );
+                theme::text(ui, "Checking…", theme::regular(12.0), palette.text);
                 theme::spinner(ui, 18.0, palette.accent);
             });
         } else if let Some(update) = app.update.clone() {

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -335,8 +335,11 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 // so the app says so, quietly, until they do.
                 if let Some(update) = app.update.clone() {
                     let install_label = format!("Update to {}", update.version);
-                    let install_galley =
-                        ui.painter().layout_no_wrap(install_label, theme::medium(12.5), palette.accent);
+                    let install_galley = ui.painter().layout_no_wrap(
+                        install_label,
+                        theme::medium(12.5),
+                        palette.accent,
+                    );
                     let install_size = install_galley.size() + vec2(28.0, 12.0);
                     let (install_rect, install_response) =
                         ui.allocate_exact_size(install_size, Sense::click());
@@ -353,7 +356,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         .image(palette.accent, 13.0)
                         .paint_at(ui, icon_rect);
                     ui.painter().galley(
-                        pos2(install_rect.left() + 24.0, install_rect.center().y - install_galley.size().y / 2.0),
+                        pos2(
+                            install_rect.left() + 24.0,
+                            install_rect.center().y - install_galley.size().y / 2.0,
+                        ),
                         install_galley,
                         palette.accent,
                     );
@@ -367,8 +373,11 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     // Release notes: small link to the right of the install pill.
                     ui.add_space(6.0);
                     let notes_label = "release notes";
-                    let notes_galley =
-                        ui.painter().layout_no_wrap(notes_label.to_string(), theme::regular(11.0), palette.secondary);
+                    let notes_galley = ui.painter().layout_no_wrap(
+                        notes_label.to_string(),
+                        theme::regular(11.0),
+                        palette.secondary,
+                    );
                     let notes_size = notes_galley.size() + vec2(12.0, 8.0);
                     let (notes_rect, notes_response) =
                         ui.allocate_exact_size(notes_size, Sense::click());
@@ -378,7 +387,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         palette.surface.gamma_multiply(0.5),
                     );
                     ui.painter().galley(
-                        pos2(notes_rect.left() + 6.0, notes_rect.center().y - notes_galley.size().y / 2.0),
+                        pos2(
+                            notes_rect.left() + 6.0,
+                            notes_rect.center().y - notes_galley.size().y / 2.0,
+                        ),
                         notes_galley,
                         palette.secondary,
                     );

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -334,35 +334,57 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 // A newer release. Most people never visit a releases page,
                 // so the app says so, quietly, until they do.
                 if let Some(update) = app.update.clone() {
-                    let label = format!("Update to {}", update.version);
-                    let galley =
-                        ui.painter()
-                            .layout_no_wrap(label, theme::medium(12.5), palette.accent);
-                    let size = galley.size() + vec2(28.0, 12.0);
-                    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+                    let install_label = format!("Update to {}", update.version);
+                    let install_galley =
+                        ui.painter().layout_no_wrap(install_label, theme::medium(12.5), palette.accent);
+                    let install_size = install_galley.size() + vec2(28.0, 12.0);
+                    let (install_rect, install_response) =
+                        ui.allocate_exact_size(install_size, Sense::click());
                     ui.painter().rect_filled(
-                        rect,
+                        install_rect,
                         CornerRadius::same(14),
                         palette.accent.gamma_multiply(0.16),
                     );
                     let icon_rect = egui::Rect::from_center_size(
-                        pos2(rect.left() + 14.0, rect.center().y),
+                        pos2(install_rect.left() + 14.0, install_rect.center().y),
                         Vec2::splat(13.0),
                     );
-                    Icon::Info
+                    Icon::ExternalLink
                         .image(palette.accent, 13.0)
                         .paint_at(ui, icon_rect);
                     ui.painter().galley(
-                        pos2(rect.left() + 24.0, rect.center().y - galley.size().y / 2.0),
-                        galley,
+                        pos2(install_rect.left() + 24.0, install_rect.center().y - install_galley.size().y / 2.0),
+                        install_galley,
                         palette.accent,
                     );
-                    if response
+                    if install_response
                         .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text(format!(
-                            "Version {} is available. Open the download page.",
-                            update.version
-                        ))
+                        .on_hover_text(format!("Download and install v{}.", update.version))
+                        .clicked()
+                    {
+                        app.actions.push(Action::UpdateNow);
+                    }
+                    // Release notes: small link to the right of the install pill.
+                    ui.add_space(6.0);
+                    let notes_label = "release notes";
+                    let notes_galley =
+                        ui.painter().layout_no_wrap(notes_label.to_string(), theme::regular(11.0), palette.secondary);
+                    let notes_size = notes_galley.size() + vec2(12.0, 8.0);
+                    let (notes_rect, notes_response) =
+                        ui.allocate_exact_size(notes_size, Sense::click());
+                    ui.painter().rect_filled(
+                        notes_rect,
+                        CornerRadius::same(8),
+                        palette.surface.gamma_multiply(0.5),
+                    );
+                    ui.painter().galley(
+                        pos2(notes_rect.left() + 6.0, notes_rect.center().y - notes_galley.size().y / 2.0),
+                        notes_galley,
+                        palette.secondary,
+                    );
+                    if notes_response
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .on_hover_text(format!("Release notes for v{}.", update.version))
                         .clicked()
                     {
                         app.actions.push(Action::OpenUrl(update.url));

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -66,8 +66,7 @@ pub async fn newer_release(http: &reqwest::Client) -> Result<Option<Release>> {
         .await
         .context("unexpected release listing")?;
     let version = latest.tag_name.trim_start_matches('v').to_string();
-    let download_url =
-        crate::updates::download_url(&latest.tag_name).unwrap_or_default();
+    let download_url = crate::updates::download_url(&latest.tag_name).unwrap_or_default();
     Ok(
         is_newer(&version, env!("CARGO_PKG_VERSION")).then_some(Release {
             version,
@@ -114,19 +113,38 @@ pub fn is_newer(candidate: &str, current: &str) -> bool {
 /// The caller is responsible for relaunching the new binary after this
 /// returns `Ok(())`; see the app's `launch_updated_binary` for the platform
 ///-appropriate restart.
-pub async fn apply_update(http: &reqwest::Client, dirs: &crate::paths::AppDirs, release: &Release) -> Result<PathBuf> {
+pub async fn apply_update(
+    http: &reqwest::Client,
+    dirs: &crate::paths::AppDirs,
+    release: &Release,
+) -> Result<PathBuf> {
     let tag = format!("v{}", release.version);
     let url = if release.download_url.is_empty() {
         return Err(anyhow::anyhow!("no self-update archive for this platform"));
     } else {
         release.download_url.clone()
     };
-    let checksums_url = format!("https://github.com/crmne/fastpotify/releases/download/{tag}/checksums.txt");
+    let checksums_url =
+        format!("https://github.com/crmne/fastpotify/releases/download/{tag}/checksums.txt");
 
     // Download the archive and the checksums file in parallel.
     let (archive_bytes, checksums_text) = tokio::join!(
-        async { http.get(&url).send().await?.error_for_status()?.bytes().await },
-        async { http.get(&checksums_url).send().await?.error_for_status()?.text().await },
+        async {
+            http.get(&url)
+                .send()
+                .await?
+                .error_for_status()?
+                .bytes()
+                .await
+        },
+        async {
+            http.get(&checksums_url)
+                .send()
+                .await?
+                .error_for_status()?
+                .text()
+                .await
+        },
     );
     let archive = archive_bytes?;
     let checksums = checksums_text?;
@@ -164,7 +182,7 @@ pub async fn apply_update(http: &reqwest::Client, dirs: &crate::paths::AppDirs, 
     let tmp = dirs.cache_dir().join("update");
     std::fs::create_dir_all(&tmp)?;
 
-    let archive_path = tmp.join(&archive_name);
+    let archive_path = tmp.join(archive_name);
     std::fs::write(&archive_path, &archive)?;
 
     let tar_gz = flate2::read::GzDecoder::new(std::io::Cursor::new(archive));
@@ -184,7 +202,7 @@ pub async fn apply_update(http: &reqwest::Client, dirs: &crate::paths::AppDirs, 
     }
     let unpacked = std::fs::read_dir(&tmp)?
         .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map_or(false, |t| t.is_dir()))
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
         .find(|e| e.file_name().to_string_lossy().starts_with(&prefix))
         .ok_or_else(|| anyhow::anyhow!("no unpacked directory starting with {prefix}"))?;
     let unpacked_dir = unpacked.path();
@@ -199,7 +217,10 @@ pub async fn apply_update(http: &reqwest::Client, dirs: &crate::paths::AppDirs, 
     let binary_name = "fastpotify.exe";
 
     let new_binary = unpacked_dir.join(binary_name);
-    log::debug!("new binary path: {new_binary:?}, is_file: {}", new_binary.is_file());
+    log::debug!(
+        "new binary path: {new_binary:?}, is_file: {}",
+        new_binary.is_file()
+    );
     if !new_binary.is_file() {
         // List the unpacked dir contents
         if let Ok(entries) = std::fs::read_dir(&unpacked_dir) {

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,14 +1,40 @@
-//! Daily update check against GitHub releases.
+//! Daily update check against GitHub releases, and self-update download +
+//! install for Linux hand-installs.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/crmne/fastpotify/releases/latest";
 
 /// Update-check interval.
 pub const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Build the full asset filename for the current target given a version tag.
+/// The release workflow publishes `fastpotify-<tag>-<target>.tar.gz` where
+/// `<tag>` already includes its `v` prefix (e.g. `v0.7.1`).
+fn archive_name_for_target(tag: &str) -> Option<String> {
+    let target = match (std::env::consts::ARCH, std::env::consts::OS) {
+        ("x86_64", "linux") => format!("fastpotify-{tag}-x86_64-unknown-linux-gnu.tar.gz"),
+        ("aarch64", "linux") => format!("fastpotify-{tag}-aarch64-unknown-linux-gnu.tar.gz"),
+        _ => return None,
+    };
+    Some(target)
+}
+
+/// Build the asset download URL for a release tag, when the current target
+/// has a published archive.
+pub fn download_url(tag: &str) -> Option<String> {
+    let name = archive_name_for_target(tag)?;
+    Some(format!(
+        "https://github.com/crmne/fastpotify/releases/download/{tag}/{name}",
+        tag = tag,
+        name = name
+    ))
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Release {
@@ -16,6 +42,10 @@ pub struct Release {
     pub version: String,
     /// The release page, with every download.
     pub url: String,
+    /// The platform-specific downloadable archive for this build, when one
+    /// exists for the current target. Empty when the target is unknown or
+    /// when the release does not carry a matching artifact.
+    pub download_url: String,
 }
 
 #[derive(Deserialize)]
@@ -36,10 +66,13 @@ pub async fn newer_release(http: &reqwest::Client) -> Result<Option<Release>> {
         .await
         .context("unexpected release listing")?;
     let version = latest.tag_name.trim_start_matches('v').to_string();
+    let download_url =
+        crate::updates::download_url(&latest.tag_name).unwrap_or_default();
     Ok(
         is_newer(&version, env!("CARGO_PKG_VERSION")).then_some(Release {
             version,
             url: latest.html_url,
+            download_url,
         }),
     )
 }
@@ -69,6 +102,134 @@ pub fn is_newer(candidate: &str, current: &str) -> bool {
         }
         _ => false,
     }
+}
+
+// ---- self-update --------------------------------------------------------
+
+/// Download the newer-release archive for the current platform, verify it
+/// against the release's checksums file, extract the new binary over this
+/// one, and relaunch. Non-Linux targets and targets without a published
+/// archive return an explanatory error.
+///
+/// The caller is responsible for relaunching the new binary after this
+/// returns `Ok(())`; see the app's `launch_updated_binary` for the platform
+///-appropriate restart.
+pub async fn apply_update(http: &reqwest::Client, dirs: &crate::paths::AppDirs, release: &Release) -> Result<PathBuf> {
+    let tag = format!("v{}", release.version);
+    let url = if release.download_url.is_empty() {
+        return Err(anyhow::anyhow!("no self-update archive for this platform"));
+    } else {
+        release.download_url.clone()
+    };
+    let checksums_url = format!("https://github.com/crmne/fastpotify/releases/download/{tag}/checksums.txt");
+
+    // Download the archive and the checksums file in parallel.
+    let (archive_bytes, checksums_text) = tokio::join!(
+        async { http.get(&url).send().await?.error_for_status()?.bytes().await },
+        async { http.get(&checksums_url).send().await?.error_for_status()?.text().await },
+    );
+    let archive = archive_bytes?;
+    let checksums = checksums_text?;
+    log::debug!("downloaded archive: {} bytes from {}", archive.len(), url);
+
+    // Find the expected SHA-256 for our archive name.
+    let archive_name = url
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("bad download url"))?;
+    let expected_hash = checksums
+        .lines()
+        .find_map(|line| {
+            let mut parts = line.split_whitespace();
+            let hash = parts.next()?;
+            let name = parts.next()?;
+            if name == archive_name {
+                Some(hash.to_string())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("no checksum for {}", archive_name))?;
+
+    // Verify.
+    let actual = format!("{:x}", Sha256::digest(&archive));
+    if !actual.eq_ignore_ascii_case(&expected_hash) {
+        anyhow::bail!("checksum mismatch for {}", archive_name);
+    }
+    log::debug!("checksum verified for {archive_name}");
+
+    // Extract the archive to a temp dir, find the new binary, and replace
+    // the running one. We write into the app's cache dir so the user does not
+    // need to own the install prefix.
+    let tmp = dirs.cache_dir().join("update");
+    std::fs::create_dir_all(&tmp)?;
+
+    let archive_path = tmp.join(&archive_name);
+    std::fs::write(&archive_path, &archive)?;
+
+    let tar_gz = flate2::read::GzDecoder::new(std::io::Cursor::new(archive));
+    let mut archive_fs = tar::Archive::new(tar_gz);
+    archive_fs.unpack(&tmp)?;
+    log::debug!("extracted archive to {tmp:?}");
+
+    // The archive contains a folder named `fastpotify-<tag>-<target>/` with
+    // the binary at the top. Use the tag as-is (with `v`) to match the archive's
+    // internal folder naming.
+    let prefix = format!("fastpotify-{tag}-");
+    log::debug!("looking for prefix: {prefix}");
+    if let Ok(entries) = std::fs::read_dir(&tmp) {
+        for entry in entries.flatten() {
+            log::debug!("tmp entry: {:?}", entry.file_name());
+        }
+    }
+    let unpacked = std::fs::read_dir(&tmp)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map_or(false, |t| t.is_dir()))
+        .find(|e| e.file_name().to_string_lossy().starts_with(&prefix))
+        .ok_or_else(|| anyhow::anyhow!("no unpacked directory starting with {prefix}"))?;
+    let unpacked_dir = unpacked.path();
+    log::debug!("unpacked dir: {:?}", unpacked_dir);
+
+    // Locate the binary inside. On Linux it is `fastpotify` (no .exe).
+    #[cfg(target_os = "linux")]
+    let binary_name = "fastpotify";
+    #[cfg(target_os = "macos")]
+    let binary_name = "fastpotify";
+    #[cfg(target_os = "windows")]
+    let binary_name = "fastpotify.exe";
+
+    let new_binary = unpacked_dir.join(binary_name);
+    log::debug!("new binary path: {new_binary:?}, is_file: {}", new_binary.is_file());
+    if !new_binary.is_file() {
+        // List the unpacked dir contents
+        if let Ok(entries) = std::fs::read_dir(&unpacked_dir) {
+            for entry in entries.flatten() {
+                log::debug!("unpacked entry: {:?}", entry.file_name());
+            }
+        }
+        anyhow::bail!("archive did not contain {binary_name} at the expected path");
+    }
+
+    // Replace the running binary. On Linux you cannot overwrite a running
+    // binary's inode (ETXTBSY), so we copy to a temp path in the same
+    // directory and `rename` it into place — the kernel keeps the old inode
+    // alive for the running process but links the new file to the old path.
+    let current_exe = std::env::current_exe()?;
+    let exe_dir = current_exe.parent().unwrap_or(std::path::Path::new("."));
+    let temp_exe = exe_dir.join(format!(".fastpotify-update-{}", std::process::id()));
+    std::fs::copy(&new_binary, &temp_exe)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temp_exe, std::fs::Permissions::from_mode(0o755))?;
+    }
+    std::fs::rename(&temp_exe, &current_exe)?;
+    // Clean up the temp download.
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    log::info!("updated Fastpotify binary to v{}", release.version);
+
+    Ok(current_exe)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Users can now update Fastpotify from within the app. On Linux, the download is verified against the release's SHA-256 checksums, extracted over the running binary, and re-executed — all without leaving the app.

- "Update to X.Y.Z" pill in the top bar + "release notes" link
- Settings → About → "When an update is found" dropdown:
  - Manual: only notify when a newer release exists
  - On Click: download when the user clicks the update pill
  - On Launch: auto-update on startup before the window appears
- Non-Linux platforms open the release page when the user clicks

## Notes

- Changes were tested on v0.7.0 and v0.7.1
- Longcat 2.0 wrote the code