### PR TITLE
[agent] Report Fastpotify listens to Spotify history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "aes 0.8.4",
  "bytes",
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "aes 0.8.4",
  "base64",
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "log",
  "oauth2",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "cpal",
  "form_urlencoded",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "git+https://github.com/crmne/librespot?branch=fastpotify-0.8#8d3932a64aa7aae84e6920ba7356cf7ce7c0283d"
+source = "git+https://github.com/alexng353/librespot?rev=f5800363c98dd2f714b39d479099c78b3916378f#f5800363c98dd2f714b39d479099c78b3916378f"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,13 +198,14 @@ projectm-sys = { git = "https://github.com/crmne/projectm-rs", branch = "respect
 # librespot 0.8.0 plus the small patches Fastpotify needs: queue controls,
 # normalisation-factor reporting for the visualisers, and a distinct event
 # when Spotify refuses an audio key, and a connection deadline that includes
-# socket setup, plus an in-memory credential cache for platform storage.
+# socket setup, plus an in-memory credential cache for platform storage and
+# Spotify listening reports. The reporting backport is proposed upstream.
 # Every librespot crate comes from the
 # fork so one copy exists. Drop patches as upstream takes them.
-librespot-audio = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-connect = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-core = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-metadata = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-oauth = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-playback = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
-librespot-protocol = { git = "https://github.com/crmne/librespot", branch = "fastpotify-0.8" }
+librespot-audio = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }
+librespot-connect = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }
+librespot-core = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }
+librespot-metadata = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }
+librespot-oauth = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }
+librespot-playback = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }
+librespot-protocol = { git = "https://github.com/alexng353/librespot", rev = "f5800363c98dd2f714b39d479099c78b3916378f" }

--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -116,12 +116,15 @@ Linux panels or the macOS Dock.
 ## Recent
 
 The queue panel's second tab combines Spotify's history with tracks played
-through Fastpotify, which Spotify does not record.
+through Fastpotify. Completed and interrupted listens are also reported to
+Spotify, so they can appear in Spotify's recently played history. Pauses and
+seeks do not add listening time.
 
 A song is added after about 30 seconds, or halfway through a shorter song.
 Paused time and seeking do not count.
 
-The local list is stored in `history.json` and is never uploaded. Settings →
+The local list is stored in `history.json`. This file is never uploaded;
+librespot reports each new listen separately when playback ends. Settings →
 Storage shows its location and has a **Clear history** button.
 
 On Windows, the main window's minimize, maximize, and close buttons share the

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -144,3 +144,11 @@ Each access-point attempt gives socket setup and the handshake a combined
 five seconds. A stalled TCP connection or HTTP proxy tunnel therefore lets
 librespot retry and move on to another endpoint instead of waiting for the
 operating system's longer connection timeout.
+
+## Listening history
+
+The playback session reports completed and interrupted listens through librespot.
+Reports use the audio delivered to the output, excluding paused time and seek
+jumps. Closing Fastpotify waits up to ten seconds for pending reports. Network
+failures are logged; reports are not persisted for a later launch. This does not
+require the optional personal Web API app, which is used to read recent history.

--- a/docs/_reference/what-spotify-allows.md
+++ b/docs/_reference/what-spotify-allows.md
@@ -58,6 +58,9 @@ clients. Fastpotify uses its session for:
 
 librespot provides:
 
+- **Listening history:** reports completed and interrupted local playback to
+  Spotify, using rendered audio time.
+
 - Spotify catalogue playback at up to 320 kbps.
 - Gapless playback, normalisation, and a local audio cache.
 - Spotify Connect, so another Spotify client can transfer playback to this

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
                 pname = "fastpotify";
                 version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
                 src = self;
-                hash = "sha256-LpLYZQxU8PinThuibkiUR5mxh/UYTD7rRtE6SnG37wc=";
+                hash = "sha256-XGk5VvqM7wEW8vOP/v+kcEqTtLqqDaSSv7h6NG2teWA=";
               };
 
               nativeBuildInputs =

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -850,6 +850,7 @@ struct Worker {
     commands: mpsc::UnboundedSender<Command>,
     waker: Waker,
     engine: Option<Arc<Engine>>,
+    engine_shutdowns: tokio::task::JoinSet<()>,
     /// True while a playback grant or engine connection is in flight, so a
     /// second attempt does not pile up.
     engine_busy: bool,
@@ -901,6 +902,7 @@ impl Worker {
             commands,
             waker,
             engine: None,
+            engine_shutdowns: tokio::task::JoinSet::new(),
             engine_busy: false,
             signed_in: false,
             premium: None,
@@ -1062,7 +1064,7 @@ impl Worker {
                     if lease.current() && self.signed_in {
                         self.on_engine_connected(*engine, error)
                     } else if let Some(engine) = *engine {
-                        engine.shutdown();
+                        self.retire_engine(engine);
                     }
                 }
                 Command::SignInEnded { source, attempt } => {
@@ -1138,8 +1140,21 @@ impl Worker {
             }
         }
         if let Some(engine) = self.engine.take() {
-            engine.shutdown();
+            self.retire_engine(engine);
         }
+        while let Some(result) = self.engine_shutdowns.join_next().await {
+            if let Err(error) = result {
+                log::warn!("player shutdown failed: {error}");
+            }
+        }
+    }
+
+    fn retire_engine(&mut self, engine: impl Into<Arc<Engine>>) {
+        let engine = engine.into();
+        while self.engine_shutdowns.try_join_next().is_some() {}
+        self.engine_shutdowns.spawn(async move {
+            engine.shutdown_and_wait().await;
+        });
     }
 
     // ---- Web API sign-in --------------------------------------------------
@@ -1554,7 +1569,7 @@ impl Worker {
         self.resume = None;
         self.resume_verify = None;
         if let Some(engine) = self.engine.take() {
-            engine.shutdown();
+            self.retire_engine(engine);
         }
         if let Some(cancel) = self.cancel_signin.take() {
             let _ = cancel.send(true);
@@ -1643,7 +1658,7 @@ impl Worker {
                 play: interrupted.playing,
                 ..LoadSpec::default()
             });
-            engine.shutdown();
+            self.retire_engine(engine);
         }
         let now = Instant::now();
         self.reconnects
@@ -1800,7 +1815,7 @@ impl Worker {
             Some(engine) => {
                 if let Some(grant) = engine.credentials() {
                     if !playback_account_matches(&grant, self.api.account()) {
-                        engine.shutdown();
+                        self.retire_engine(engine);
                         self.emit(Event::Playback(LocalPlayback::Failed("Playback was authorized for another Spotify account. Enable playback again with the signed-in account.".into())));
                         return;
                     }
@@ -1842,7 +1857,7 @@ impl Worker {
         self.premium = premium;
         if premium == Some(false) {
             if let Some(engine) = self.engine.take() {
-                engine.shutdown();
+                self.retire_engine(engine);
             }
             let credential_stored = self.playback_grant.is_some();
             if credential_stored {
@@ -2824,6 +2839,29 @@ mod authorization_tests {
             Waker::default(),
         );
         (runtime, worker, events)
+    }
+
+    #[test]
+    fn quitting_waits_for_a_retired_engine_without_a_current_engine() {
+        let (runtime, mut worker, _) = worker("retired-engine-shutdown");
+        runtime.block_on(async {
+            let (release, released) = tokio::sync::oneshot::channel();
+            worker.engine_shutdowns.spawn(async move {
+                released.await.unwrap();
+            });
+            assert!(worker.engine.is_none());
+            let (commands, receiver) = mpsc::unbounded_channel();
+            commands.send(Command::Shutdown).unwrap();
+            let shutdown = worker.run(receiver);
+            tokio::pin!(shutdown);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(10), &mut shutdown)
+                    .await
+                    .is_err()
+            );
+            release.send(()).unwrap();
+            shutdown.await;
+        });
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,8 +1,7 @@
 //! Local play history.
 //!
-//! Spotify does not record playback from librespot clients. Fastpotify stores
-//! local plays and merges them with `/me/player/recently-played`, which covers
-//! other devices. A track counts only after enough listening time, so skips do
+//! Fastpotify stores local plays and merges them with Spotify history, including
+//! listens reported by librespot and plays from other devices. A track counts only after enough listening time, so skips do
 //! not fill the history.
 
 use std::collections::HashMap;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -57,8 +57,8 @@ impl AppDirs {
         self.state.join("session.json")
     }
 
-    /// What was played here, which Spotify never hears about and so
-    /// cannot tell us later. See [`crate::history`].
+    /// Local play history, retained independently of Spotify history.
+    /// See [`crate::history`].
     pub fn history_file(&self) -> PathBuf {
         self.state.join("history.json")
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -265,6 +265,7 @@ pub type Notify = Arc<dyn Fn(EngineEvent) + Send + Sync>;
 pub struct Engine {
     player: Arc<Player>,
     spirc: Arc<Spirc>,
+    spirc_task: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     session: Session,
     mixer: Arc<dyn Mixer>,
     device_id: String,
@@ -372,7 +373,7 @@ impl Engine {
         let ended_notify = Arc::clone(&notify);
         let ended_state = Arc::clone(&state);
         let ended_interrupted = Arc::clone(&interrupted);
-        tokio::spawn(async move {
+        let spirc_task = tokio::spawn(async move {
             spirc_task.await;
             {
                 let mut current = ended_state.lock().unwrap_or_else(|p| p.into_inner());
@@ -393,6 +394,7 @@ impl Engine {
         Ok(Self {
             player,
             spirc: Arc::new(spirc),
+            spirc_task: tokio::sync::Mutex::new(Some(spirc_task)),
             session,
             mixer,
             device_id,
@@ -490,11 +492,33 @@ impl Engine {
             .map(str::to_string)
     }
 
-    pub fn shutdown(&self) {
+    pub async fn shutdown_and_wait(&self) {
         self.shutting_down
             .store(true, std::sync::atomic::Ordering::SeqCst);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         let _ = self.spirc.shutdown();
-        self.player.stop();
+        // Stop the command producer before the final drain, so remote commands
+        // and end-of-track transitions cannot start another listen during it.
+        if let Some(mut task) = self.spirc_task.lock().await.take() {
+            match tokio::time::timeout_at(deadline, &mut task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => log::warn!("Spotify Connect shutdown failed: {error}"),
+                Err(_) => {
+                    task.abort();
+                    let _ = task.await;
+                    log::warn!("Spotify Connect shutdown timed out");
+                }
+            }
+        }
+        // Spirc may already have ended because the connection dropped.
+        match tokio::time::timeout_at(deadline, self.player.stop_and_flush()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => log::warn!("unable to flush Spotify listening history: {error}"),
+            Err(_) => {
+                self.player.stop();
+                log::warn!("Spotify listening history flush timed out");
+            }
+        }
     }
 
     pub fn command(&self, command: PlayerCommand) -> Result<()> {


### PR DESCRIPTION
[agent] Fastpotify playback now reports listens to Spotify through librespot, so completed tracks can appear in Spotify's recently played history.

- Pin the reporting backport proposed in https://github.com/crmne/librespot/pull/6, also submitted upstream at https://github.com/librespot-org/librespot/pull/1759. Replace this temporary fork pin after the backport lands.
- Wait for active and retired engines to finish reporting before the runtime exits. Stop the Connect command producer before the final drain, including during sign-out and reconnect.
- Keep the local history cache and document how Spotify reporting differs. A real completed track was verified in Spotify history. Interrupted reports were accepted, but the tested interrupted listens were absent from recent history in both Fastpotify and the official-client control.

Co-Authored-By: GPT-6 (OpenAI) <noreply@openai.com>
