### PR TITLE
Add in-app updates for Windows, macOS, and Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
             cp "target/${{ matrix.target }}/release/fastpotify" "dist/$name/"
           fi
           cp README.md LICENSE "dist/$name/"
+          cp packaging/fastpotify-portable.txt "dist/$name/"
           if [ "${{ runner.os }}" = "Linux" ]; then
             # Desktop integration for package builds and hand-installs.
             cp -r packaging "dist/$name/"

--- a/README.md
+++ b/README.md
@@ -317,6 +317,27 @@ Playback settings apply when you press **Apply and restart playback**.
 You can also check for a new release from Settings. On macOS, the same command
 is in the application menu.
 
+On Windows and Linux, update-enabled portable downloads can download a release
+in the app, verify its published SHA-256 checksum, and restart to install it.
+Windows installer builds use their installer for the replacement. Settings can
+enable automatic background downloads; restarting always requires a click.
+The update popup opens only when you click the green update pill. Update checks
+and automatic downloads leave it closed, and closing it keeps downloads running.
+A failed startup restores the previous installation. An interrupted or damaged
+download leaves the running app alone. Updates keep your settings and sign-in
+files. On macOS, a writable Fastpotify.app downloaded from the release page can
+update its whole app bundle from the universal DMG. Move the app out of the disk
+image before updating. The updater verifies the app signature and version;
+Developer ID builds also require the same signing team and macOS approval.
+Keep the app in Applications; macOS can require folder access when it is run
+from Documents.
+
+Package-managed installations continue to update through their package manager,
+including Homebrew, Flatpak, apt, dnf, pacman, Nix, and Cargo. Unrecognized
+installations use the download page. Portable archives identify themselves with
+`fastpotify-portable.txt`; older archives need one manual upgrade to an
+update-enabled build.
+
 Caches (audio, artwork) live under the cache directory and can be deleted at
 any time without signing you out.
 

--- a/docs/_reference/how-it-connects.md
+++ b/docs/_reference/how-it-connects.md
@@ -85,6 +85,26 @@ and dragging never write that order back to Spotify.
   Settings, or request one there at any time. On macOS, **Check for Updates**
   is also in the application menu.
 
+  On Windows and Linux, downloading an update fetches release metadata and
+  `checksums.txt` from the project's GitHub release, then the matching binary
+  archive, Windows installer, or universal macOS DMG. Fastpotify checks the published SHA-256 digest
+  and the portable executable's reported version before offering a restart.
+  Automatic downloads are optional; installation always waits for your click.
+  Checks and downloads do not open the update popup. The green update pill opens
+  it on request; closing the popup does not cancel a download.
+  No Spotify credential is sent. These are GitHub-hosted checksums, not a
+  separate publisher signature.
+
+  Updates stage their files in a private `.fastpotify-update-*` directory beside
+  the application so replacement stays on the same filesystem. The directory
+  retains the previous executable or Mac app bundle and `result.txt` for recovery and diagnosis.
+  Settings, caches and credential stores are not replaced. Package-manager
+  installs keep their package-manager update path. Mac updates verify the bundle
+  identifier, version and code signature before replacing the whole app bundle.
+  A Developer ID installation also requires the same signing team and a passing
+  macOS security assessment. Apps running from a disk image or an App Translocation
+  directory must be moved to a writable installation directory first.
+
 ## When Spotify pushes back
 
 Each Web API session has separate concurrency and rate limits. A `Retry-After`

--- a/examples/updater-inspect.rs
+++ b/examples/updater-inspect.rs
@@ -1,0 +1,11 @@
+fn main() -> anyhow::Result<()> {
+    let path = std::env::args_os()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("Pass the application executable path"))?;
+    let path = std::path::PathBuf::from(path).canonicalize()?;
+    match fastpotify::updates::install::detect_at(&path) {
+        Ok(installation) => println!("{}", serde_json::to_string(&installation)?),
+        Err(error) => println!("Managed or unsupported: {error:#}"),
+    }
+    Ok(())
+}

--- a/packaging/fastpotify-portable.txt
+++ b/packaging/fastpotify-portable.txt
@@ -1,0 +1,1 @@
+fastpotify-portable-v1

--- a/packaging/windows/fastpotify-installer.txt
+++ b/packaging/windows/fastpotify-installer.txt
@@ -1,0 +1,1 @@
+fastpotify-installer-v1

--- a/packaging/windows/fastpotify.iss
+++ b/packaging/windows/fastpotify.iss
@@ -73,6 +73,7 @@ Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription:
 Source: "{#Binary}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\README.md"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
+Source: "fastpotify-installer.txt"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"

--- a/src/app.rs
+++ b/src/app.rs
@@ -430,6 +430,12 @@ pub struct App {
     pub update: Option<crate::updates::Release>,
     last_update_check: Option<Instant>,
     pub update_checking: bool,
+    pub show_update: bool,
+    pub update_download: crate::updates::DownloadState,
+    pub update_source: crate::updates::Source,
+    pub update_support: Option<Result<crate::updates::install::Installation, String>>,
+    pub update_restart_arguments: Vec<String>,
+    pub update_receipt: Option<PathBuf>,
     /// Winamp window state and active skin.
     pub winamp: crate::winamp::WinampState,
 }
@@ -677,6 +683,12 @@ impl App {
             update: None,
             last_update_check: None,
             update_checking: false,
+            show_update: false,
+            update_download: crate::updates::DownloadState::Idle,
+            update_source: crate::updates::Source::default(),
+            update_support: None,
+            update_restart_arguments: Vec::new(),
+            update_receipt: None,
             winamp: crate::winamp::WinampState::new(session.winamp_pos, tap, eq),
         };
         app.local.volume = app.settings.volume;
@@ -1281,7 +1293,17 @@ impl App {
 
     fn handle_backend_events(&mut self, events: Vec<Event>) {
         for event in events {
-            if self.offline {
+            if self.offline
+                && (matches!(self.update_source, crate::updates::Source::GitHub)
+                    || !matches!(
+                        &event,
+                        Event::UpdateChecked { .. }
+                            | Event::UpdateSupport(_)
+                            | Event::UpdateProgress { .. }
+                            | Event::UpdateDownloaded(_)
+                            | Event::UpdateInstalling(_)
+                    ))
+            {
                 continue;
             }
             match event {
@@ -1368,6 +1390,31 @@ impl App {
                     self.set_user_name(id, name);
                 }
                 Event::WebApp { client_id } => self.web_app = client_id,
+                Event::UpdateSupport(result) => {
+                    if result.is_ok()
+                        && self.settings.download_updates_automatically
+                        && matches!(self.update_download, crate::updates::DownloadState::Idle)
+                    {
+                        self.actions.push(Action::DownloadUpdate);
+                    }
+                    self.update_support = Some(result);
+                }
+                Event::UpdateProgress { received, total } => {
+                    self.update_download =
+                        crate::updates::DownloadState::Downloading { received, total };
+                }
+                Event::UpdateDownloaded(result) => {
+                    self.update_download = match result {
+                        Ok(prepared) => crate::updates::DownloadState::Ready(prepared),
+                        Err(error) => crate::updates::DownloadState::Failed(error),
+                    };
+                }
+                Event::UpdateInstalling(result) => match result {
+                    Ok(()) => self.actions.push(Action::Quit),
+                    Err(error) => {
+                        self.update_download = crate::updates::DownloadState::Failed(error)
+                    }
+                },
                 Event::UpdateChecked { manual, result } => {
                     self.update_checking = false;
                     match result {
@@ -1376,6 +1423,14 @@ impl App {
                                 self.toast(format!("Fastpotify {} is available", notice.version));
                             }
                             self.update = Some(notice);
+                            if self.settings.download_updates_automatically
+                                && matches!(
+                                    self.update_download,
+                                    crate::updates::DownloadState::Idle
+                                )
+                            {
+                                self.backend.send(Command::InspectUpdate);
+                            }
                         }
                         Ok(None) => {
                             self.update = None;
@@ -6248,6 +6303,37 @@ impl App {
                 }
             }
             Action::CheckForUpdates => self.check_for_updates(true),
+            Action::ShowUpdate => {
+                self.show_update = true;
+                if self.update_support.is_none() {
+                    self.backend.send(Command::InspectUpdate);
+                }
+            }
+            Action::DownloadUpdate => {
+                if matches!(
+                    self.update_download,
+                    crate::updates::DownloadState::Idle | crate::updates::DownloadState::Failed(_)
+                ) && let Some(release) = self.update.clone()
+                {
+                    self.update_download = crate::updates::DownloadState::Downloading {
+                        received: 0,
+                        total: 0,
+                    };
+                    self.backend.send(Command::DownloadUpdate {
+                        release,
+                        source: self.update_source.clone(),
+                    });
+                }
+            }
+            Action::InstallUpdate => {
+                if let crate::updates::DownloadState::Ready(prepared) = &self.update_download {
+                    self.backend.send(Command::InstallUpdate {
+                        prepared: prepared.clone(),
+                        arguments: self.update_restart_arguments.clone(),
+                    });
+                    self.update_download = crate::updates::DownloadState::Installing;
+                }
+            }
             Action::SetLibrarySort { shelf, sort } => {
                 if sort.supports(shelf) {
                     self.settings.library_sort.insert(shelf, sort);
@@ -6562,13 +6648,26 @@ impl App {
         });
     }
 
+    pub fn report_update_failure(&mut self, error: String) {
+        self.toast_error(error);
+    }
+
     fn check_for_updates(&mut self, manual: bool) {
-        if self.update_checking || self.offline {
+        if self.update_checking
+            || (self.offline && matches!(self.update_source, crate::updates::Source::GitHub))
+            || !matches!(
+                self.update_download,
+                crate::updates::DownloadState::Idle | crate::updates::DownloadState::Failed(_)
+            )
+        {
             return;
         }
         self.update_checking = true;
         self.last_update_check = Some(Instant::now());
-        self.backend.send(Command::CheckForUpdates { manual });
+        self.backend.send(Command::CheckForUpdates {
+            manual,
+            source: self.update_source.clone(),
+        });
     }
 
     fn maybe_suggest_personal_app(&mut self) {
@@ -10151,6 +10250,26 @@ mod tests {
             !app.table_rows.contains_key(&Page::Playlist("pl0".into())),
             "its table-row copy must go with it"
         );
+    }
+
+    #[test]
+    fn update_checks_leave_the_popup_closed_until_requested() {
+        for manual in [false, true] {
+            let mut app = headless_app();
+            app.handle_backend_events(vec![Event::UpdateChecked {
+                manual,
+                result: Ok(Some(crate::updates::Release {
+                    version: "1.2.3".into(),
+                    url: "https://github.com/crmne/fastpotify/releases/tag/v1.2.3".into(),
+                })),
+            }]);
+            let ctx = egui::Context::default();
+            app.apply_actions(&ctx);
+            assert!(app.update.is_some());
+            assert!(!app.show_update);
+            app.apply(Action::ShowUpdate, &ctx);
+            assert!(app.show_update);
+        }
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -510,6 +510,16 @@ pub enum Command {
     /// outcome; the daily check only announces a new release.
     CheckForUpdates {
         manual: bool,
+        source: crate::updates::Source,
+    },
+    InspectUpdate,
+    DownloadUpdate {
+        release: crate::updates::Release,
+        source: crate::updates::Source,
+    },
+    InstallUpdate {
+        prepared: Box<crate::updates::install::Prepared>,
+        arguments: Vec<String>,
     },
     /// The words of a track, from LRCLIB.
     Lyrics(Box<LyricsRequest>),
@@ -547,6 +557,13 @@ pub struct LyricsRequest {
 }
 
 pub enum Event {
+    UpdateSupport(Result<crate::updates::install::Installation, String>),
+    UpdateProgress {
+        received: u64,
+        total: u64,
+    },
+    UpdateDownloaded(Result<Box<crate::updates::install::Prepared>, String>),
+    UpdateInstalling(Result<(), String>),
     Auth(AuthStatus),
     Playback(LocalPlayback),
     /// Receivers seen on the local network that Spotify has not listed.
@@ -738,7 +755,17 @@ impl Backend {
     }
 
     pub fn send(&self, command: Command) {
-        if self.offline && !matches!(command, Command::Accent { .. } | Command::Shutdown) {
+        if self.offline
+            && !matches!(
+                command,
+                Command::Accent { .. }
+                    | Command::Shutdown
+                    | Command::CheckForUpdates { .. }
+                    | Command::InspectUpdate
+                    | Command::DownloadUpdate { .. }
+                    | Command::InstallUpdate { .. }
+            )
+        {
             return;
         }
         let _ = self.commands.send(command);
@@ -1085,7 +1112,47 @@ impl Worker {
                 Command::Reconnect => self.reconnect_engine(),
                 Command::DiscoverReceivers => self.discover_receivers(),
                 Command::ActivateReceiver(receiver) => self.activate_receiver(*receiver),
-                Command::CheckForUpdates { manual } => self.check_for_updates(manual),
+                Command::CheckForUpdates { manual, source } => {
+                    self.check_for_updates(manual, source)
+                }
+                Command::InspectUpdate => {
+                    let events = self.events.clone();
+                    let waker = self.waker.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let _ = events.send(Event::UpdateSupport(
+                            crate::updates::install::detect().map_err(|error| format!("{error:#}")),
+                        ));
+                        waker.wake();
+                    });
+                }
+                Command::DownloadUpdate { release, source } => {
+                    let events = self.events.clone();
+                    let waker = self.waker.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let result =
+                            crate::updates::download(&release, &source, |received, total| {
+                                let _ = events.send(Event::UpdateProgress { received, total });
+                                waker.wake();
+                            })
+                            .map(Box::new)
+                            .map_err(|error| format!("{error:#}"));
+                        let _ = events.send(Event::UpdateDownloaded(result));
+                        waker.wake();
+                    });
+                }
+                Command::InstallUpdate {
+                    prepared,
+                    arguments,
+                } => {
+                    let events = self.events.clone();
+                    let waker = self.waker.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let result = crate::updates::install::handoff(&prepared, arguments)
+                            .map_err(|error| format!("{error:#}"));
+                        let _ = events.send(Event::UpdateInstalling(result));
+                        waker.wake();
+                    });
+                }
                 Command::Lyrics(request) => self.fetch_lyrics(*request),
                 Command::Rootlist => self.fetch_rootlist(),
                 Command::VerifyResume => self.verify_resume(),
@@ -1912,12 +1979,12 @@ impl Worker {
         });
     }
 
-    fn check_for_updates(&self, manual: bool) {
+    fn check_for_updates(&self, manual: bool, source: crate::updates::Source) {
         let http = self.http.clone();
         let events = self.events.clone();
         let waker = self.waker.clone();
         tokio::spawn(async move {
-            let result = crate::updates::newer_release(&http)
+            let result = crate::updates::newer_release_from(&http, &source)
                 .await
                 .map_err(|error| format!("{error:#}"));
             let _ = events.send(Event::UpdateChecked { manual, result });

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,24 @@ struct Cli {
     #[arg(short, long)]
     verbose: bool,
 
+    #[arg(long, hide = true)]
+    update_receipt: Option<std::path::PathBuf>,
+
+    #[arg(long, hide = true)]
+    update_error: Option<String>,
+
     /// Start with sample data and no Spotify connection (for screenshots).
     #[cfg(feature = "demo")]
     #[arg(long)]
     demo: bool,
+
+    #[cfg(feature = "demo")]
+    #[arg(long, requires = "demo")]
+    demo_update_feed: Option<String>,
+
+    #[cfg(feature = "demo")]
+    #[arg(long, requires = "demo")]
+    demo_data: Option<std::path::PathBuf>,
 
     /// Page to open in demo mode, e.g. `home`, `playlist:pl1`, `artist:art0`.
     #[cfg(feature = "demo")]
@@ -281,6 +295,14 @@ fn format_devices(snapshot: &str) -> String {
 }
 
 fn main() -> eframe::Result<()> {
+    let arguments: Vec<_> = std::env::args_os().collect();
+    if arguments.len() == 3 && arguments[1] == "--apply-update" {
+        let result = fastpotify::updates::install::run_helper(std::path::Path::new(&arguments[2]));
+        if let Err(error) = &result {
+            eprintln!("{error:#}");
+        }
+        std::process::exit(if result.is_ok() { 0 } else { 1 });
+    }
     // A MilkDrop child launch is a bare visualiser window, not the app: it has
     // its own event loop and OpenGL context, reads the sound from a shared
     // buffer, and never touches the app's state. Handle it before anything
@@ -314,6 +336,16 @@ fn main() -> eframe::Result<()> {
         "warn,fastpotify=info"
     };
     let dirs = paths::AppDirs::discover();
+    #[cfg(feature = "demo")]
+    let dirs = cli
+        .demo_data
+        .as_ref()
+        .map(|base| paths::AppDirs {
+            config: base.join("config"),
+            state: base.join("state"),
+            cache: base.join("cache"),
+        })
+        .unwrap_or(dirs);
     let dirs_ready = dirs.ensure();
     let mut logger =
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default_filter));
@@ -388,6 +420,10 @@ fn main() -> eframe::Result<()> {
     let desktop_surfaces = options.media_controls;
     #[allow(unused_mut)]
     let mut app = app::App::new(&waker, dirs, settings, options);
+    app.update_receipt = cli.update_receipt;
+    if let Some(error) = cli.update_error {
+        app.report_update_failure(error);
+    }
     if let Some(guard) = &instance {
         app.set_remote_control(guard);
     }
@@ -398,6 +434,22 @@ fn main() -> eframe::Result<()> {
     if demo {
         fastpotify::demo::populate(&mut app);
         fastpotify::demo::apply_flags(&mut app, cli.demo_page.as_deref(), cli.demo_show.as_deref());
+        if let Some(feed) = &cli.demo_update_feed {
+            match fastpotify::updates::Source::local(feed) {
+                Ok(source) => app.update_source = source,
+                Err(error) => {
+                    eprintln!("{error:#}");
+                    std::process::exit(2);
+                }
+            }
+            app.update_restart_arguments =
+                vec!["--demo".into(), "--demo-page".into(), "settings".into()];
+            if let Some(base) = &cli.demo_data {
+                app.update_restart_arguments
+                    .extend(["--demo-data".into(), base.to_string_lossy().into_owned()]);
+            }
+            app.actions.push(fastpotify::model::Action::CheckForUpdates);
+        }
         if let Some(locale) = cli.demo_language {
             app.locale = locale;
         }
@@ -951,6 +1003,13 @@ impl eframe::App for Shell {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         if let Some(app) = self.app.as_mut() {
             app.frame_ui(ui);
+            if let Some(receipt) = app.update_receipt.take() {
+                std::thread::spawn(move || {
+                    if let Err(error) = fastpotify::updates::install::acknowledge(&receipt) {
+                        log::error!("Could not confirm the update: {error:#}");
+                    }
+                });
+            }
             #[cfg(windows)]
             self.thumbbar
                 .sync(app.thumb_state(ui.ctx().system_theme() != Some(egui::Theme::Light)));

--- a/src/model.rs
+++ b/src/model.rs
@@ -841,6 +841,9 @@ pub enum Action {
     ToggleDevicesPopup,
     /// Ask GitHub for the latest release and report the result to the user.
     CheckForUpdates,
+    ShowUpdate,
+    DownloadUpdate,
+    InstallUpdate,
     SettingsChanged,
     SetLibrarySort {
         shelf: crate::settings::LibraryShelf,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -132,6 +132,7 @@ pub struct Settings {
     pub keep_playing_in_background: bool,
     /// Ask GitHub once a day whether a newer release exists.
     pub check_for_updates: bool,
+    pub download_updates_automatically: bool,
     /// Context URIs and the local Liked Songs key, in pin order.
     pub pinned_contexts: Vec<String>,
     /// Older settings keep Liked Songs first until it is moved or unpinned.
@@ -227,6 +228,7 @@ impl Default for Settings {
             playback_authorized: false,
             keep_playing_in_background: true,
             check_for_updates: true,
+            download_updates_automatically: false,
             pinned_contexts: Vec::new(),
             liked_songs_pinned: true,
             sidebar_order: Vec::new(),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod settings;
 pub mod show;
 pub mod sidebar;
 pub mod topbar;
+mod update;
 pub mod widgets;
 pub mod winamp;
 
@@ -39,6 +40,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         || (app.is_connected() && app.user.is_none());
     if !signed_in {
         login::show(app, ui, connecting);
+        update::show(app, ctx);
         toasts(app, ctx, 20.0);
         window_controls(ui, &app.palette);
         window_resize(ui);
@@ -57,6 +59,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     central(app, ui);
     devices::popup(app, ctx);
     dialogs::show(app, ctx);
+    update::show(app, ctx);
     widgets::drag_ghost(ctx, &app.palette);
     toasts(app, ctx, theme::PLAYER_BAR_HEIGHT + 16.0);
     window_controls(ui, &app.palette);

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -368,6 +368,24 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 }
             },
         );
+        widgets::setting_row(
+            ui,
+            &palette,
+            "Download updates automatically",
+            "Downloads in the background. You choose when to restart.",
+            |ui| {
+                if widgets::switch(
+                    ui,
+                    &palette,
+                    "Download updates automatically",
+                    &mut app.settings.download_updates_automatically,
+                )
+                .changed()
+                {
+                    changed = true;
+                }
+            },
+        );
         if cfg!(target_os = "linux") {
             widgets::setting_row(
                 ui,

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -107,8 +107,22 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             }
             ui.add_space(8.0);
 
+            let update_galley = app.update.as_ref().map(|update| {
+                let label = match &app.update_download {
+                    crate::updates::DownloadState::Ready(_) => "Update ready".into(),
+                    crate::updates::DownloadState::Downloading { .. } => {
+                        "Downloading update…".into()
+                    }
+                    _ => format!("Update to {}", update.version),
+                };
+                ui.painter()
+                    .layout_no_wrap(label, theme::medium(12.5), palette.accent)
+            });
+            let update_width = update_galley.as_ref().map_or(0.0, |galley| {
+                galley.size().x + 32.0 + ui.spacing().item_spacing.x
+            });
             let search_room = (ui.available_width() - window_controls.topbar_width).max(0.0);
-            let search_width = (search_room * 0.5).clamp(200.0, 440.0);
+            let search_width = ((search_room * 0.5).clamp(200.0, 440.0) - update_width).max(80.0);
             let id = egui::Id::new("global-search");
             let before = app.search.query.clone();
             let response = super::widgets::search_field(
@@ -333,15 +347,18 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 }
                 // A newer release. Most people never visit a releases page,
                 // so the app says so, quietly, until they do.
-                if let Some(update) = app.update.clone() {
-                    let label = format!("Update to {}", update.version);
-                    let galley =
-                        ui.painter()
-                            .layout_no_wrap(label, theme::medium(12.5), palette.accent);
+                if let (Some(galley), Some(update)) = (update_galley, app.update.clone()) {
                     // The text starts 24 px in; leave 8 px after it to match
                     // the space before the icon.
                     let size = galley.size() + vec2(32.0, 12.0);
                     let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+                    response.widget_info(|| {
+                        egui::WidgetInfo::labeled(
+                            egui::WidgetType::Button,
+                            ui.is_enabled(),
+                            &galley.job.text,
+                        )
+                    });
                     ui.painter().rect_filled(
                         rect,
                         CornerRadius::same(14),
@@ -361,13 +378,10 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                     );
                     if response
                         .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text(format!(
-                            "Version {} is available. Open the download page.",
-                            update.version
-                        ))
+                        .on_hover_text(format!("Version {} is available.", update.version))
                         .clicked()
                     {
-                        app.actions.push(Action::OpenUrl(update.url));
+                        app.actions.push(Action::ShowUpdate);
                     }
                 }
             });

--- a/src/ui/update.rs
+++ b/src/ui/update.rs
@@ -1,0 +1,107 @@
+use egui::{Align, CornerRadius, Frame, Layout, Margin, RichText, Stroke};
+
+use crate::app::App;
+use crate::model::Action;
+use crate::theme::{self, Icon};
+use crate::updates::DownloadState;
+
+pub fn show(app: &mut App, ctx: &egui::Context) {
+    if !app.show_update {
+        return;
+    }
+    let Some(release) = app.update.clone() else {
+        app.show_update = false;
+        return;
+    };
+    let palette = app.palette;
+    let mut close = ctx.input(|input| input.key_pressed(egui::Key::Escape));
+    let frame = Frame::new()
+        .fill(palette.overlay)
+        .stroke(Stroke::new(1.0, palette.outline))
+        .corner_radius(CornerRadius::same(theme::RADIUS + 4))
+        .inner_margin(Margin::same(24))
+        .shadow(egui::epaint::Shadow {
+            offset: [0, 10],
+            blur: 40,
+            spread: 0,
+            color: palette.shadow,
+        });
+    egui::Window::new("Update Fastpotify")
+        .id(egui::Id::new("fastpotify-update"))
+        .title_bar(false)
+        .resizable(false)
+        .auto_sized()
+        .frame(frame)
+        .default_width(420.0)
+        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+        .show(ctx, |ui| {
+            ui.set_width(420.0_f32.min((ctx.content_rect().width() - 64.0).max(240.0)));
+            ui.horizontal(|ui| {
+                theme::text(ui, "Update Fastpotify", theme::bold(20.0), palette.text);
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    close |= theme::icon_button(ui, Icon::X, 18.0, palette.secondary, palette.text, "Close update").clicked();
+                });
+            });
+            ui.add_space(4.0);
+            theme::text(ui, format!("{} → {}", env!("CARGO_PKG_VERSION"), release.version), theme::regular(14.0), palette.secondary);
+            ui.add_space(20.0);
+            let mut action = None;
+            let mut release_link = "Release notes";
+            match &app.update_download {
+                DownloadState::Downloading { received, total } => {
+                    let checking = *total > 0 && received == total;
+                    theme::text(ui, if checking { "Checking download…" } else { "Downloading update…" }, theme::medium(14.0), palette.text);
+                    ui.add_space(8.0);
+                    if *total > 0 {
+                        ui.add(egui::ProgressBar::new(*received as f32 / *total as f32).fill(palette.accent).desired_height(6.0));
+                        ui.add_space(6.0);
+                        theme::text(ui, format!("{:.1} of {:.1} MB", *received as f64 / 1_000_000.0, *total as f64 / 1_000_000.0), theme::regular(12.0), palette.secondary);
+                    } else {
+                        theme::spinner(ui, 16.0, palette.accent);
+                    }
+                }
+                DownloadState::Ready(_) => {
+                    theme::text(ui, "Ready to install", theme::semibold(14.0), palette.text);
+                    ui.add_space(6.0);
+                    ui.add(egui::Label::new(RichText::new("Music playing on this computer will stop when Fastpotify restarts.").font(theme::regular(14.0)).color(palette.secondary)).wrap());
+                    action = Some(("Restart to update", Action::InstallUpdate));
+                }
+                DownloadState::Installing => {
+                    ui.horizontal(|ui| {
+                        theme::spinner(ui, 16.0, palette.accent);
+                        theme::text(ui, "Preparing to restart…", theme::regular(14.0), palette.text);
+                    });
+                }
+                DownloadState::Idle | DownloadState::Failed(_) => {
+                    if let DownloadState::Failed(error) = &app.update_download {
+                        ui.add(egui::Label::new(RichText::new(error).font(theme::regular(14.0)).color(palette.danger)).wrap());
+                        ui.add_space(8.0);
+                    }
+                    match &app.update_support {
+                        None => { theme::spinner(ui, 16.0, palette.accent); }
+                        Some(Err(reason)) => {
+                            ui.add(egui::Label::new(RichText::new(reason).font(theme::regular(14.0)).color(palette.secondary)).wrap());
+                            release_link = "Download from GitHub";
+                        }
+                        Some(Ok(_)) => {
+                            action = Some((if matches!(app.update_download, DownloadState::Failed(_)) { "Retry download" } else { "Download update" }, Action::DownloadUpdate));
+                        }
+                    }
+                }
+            }
+            ui.add_space(16.0);
+            ui.horizontal(|ui| {
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                if let Some((label, action)) = action
+                    && theme::pill_button(ui, &palette, label, true).clicked() {
+                    app.actions.push(action);
+                }
+                ui.add_space(8.0);
+                ui.add(egui::Hyperlink::from_label_and_url(RichText::new(release_link).font(theme::medium(13.0)).color(palette.secondary), &release.url));
+            });
+            });
+        });
+    if close {
+        app.show_update = false;
+    }
+}

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -5,6 +5,25 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+pub mod install;
+#[cfg(target_os = "macos")]
+mod macos;
+mod transfer;
+pub use transfer::{Source, download};
+
+#[derive(Default)]
+pub enum DownloadState {
+    #[default]
+    Idle,
+    Downloading {
+        received: u64,
+        total: u64,
+    },
+    Ready(Box<install::Prepared>),
+    Installing,
+    Failed(String),
+}
+
 const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/crmne/fastpotify/releases/latest";
 
 /// Update-check interval.
@@ -26,8 +45,15 @@ struct LatestRelease {
 
 /// The newest release, when it is newer than this build.
 pub async fn newer_release(http: &reqwest::Client) -> Result<Option<Release>> {
+    newer_release_from(http, &Source::default()).await
+}
+
+pub async fn newer_release_from(
+    http: &reqwest::Client,
+    source: &Source,
+) -> Result<Option<Release>> {
     let latest: LatestRelease = http
-        .get(LATEST_RELEASE_URL)
+        .get(source.latest())
         .header("Accept", "application/vnd.github+json")
         .send()
         .await?
@@ -53,10 +79,8 @@ fn parse(version: &str) -> Option<([u64; 3], bool)> {
         None => (version, false),
     };
     let mut parts = numbers.split('.').map(|part| part.parse::<u64>().ok());
-    Some((
-        [parts.next()??, parts.next()??, parts.next()??],
-        pre_release,
-    ))
+    let numbers = [parts.next()??, parts.next()??, parts.next()??];
+    parts.next().is_none().then_some((numbers, pre_release))
 }
 
 /// Whether `candidate` is a newer stable version than `current`.

--- a/src/updates/install.rs
+++ b/src/updates/install.rs
@@ -403,7 +403,7 @@ pub fn replace(prepared: &Prepared) -> Result<()> {
         Kind::MacBundle => super::macos::replace(prepared)?,
         Kind::Portable => {
             ensure!(!backup.exists(), "This update was already applied");
-            fs::copy(target, &backup).context("Cannot back up the current app")?;
+            backup_current(target, &backup).context("Cannot back up the current app")?;
             #[cfg(windows)]
             fs::remove_file(target).context("The app is still running or cannot be replaced")?;
             if let Err(error) = fs::rename(&prepared.payload, target) {
@@ -413,7 +413,7 @@ pub fn replace(prepared: &Prepared) -> Result<()> {
             }
         }
         Kind::WindowsInstaller => {
-            fs::copy(target, &backup)?;
+            backup_current(target, &backup).context("Cannot back up the current app")?;
             let mut command = Command::new(&prepared.payload);
             command
                 .args([
@@ -437,6 +437,44 @@ pub fn replace(prepared: &Prepared) -> Result<()> {
                 "The installer failed. See the update installer log."
             );
         }
+    }
+    Ok(())
+}
+
+fn backup_current(target: &Path, backup: &Path) -> Result<()> {
+    let mut source = File::open(target)?;
+    let permissions = source.metadata()?.permissions();
+    write_backup(&mut source, backup, permissions)
+}
+
+/// Rollback recognizes only `previous`. Publish that name after the complete
+/// copy has been synced, so a failed copy cannot replace a working executable
+/// with the partial backup it left behind.
+fn write_backup(source: &mut impl Read, backup: &Path, permissions: fs::Permissions) -> Result<()> {
+    ensure!(
+        fs::symlink_metadata(backup)
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound),
+        "This update already has a backup"
+    );
+    let partial = backup.with_extension("partial");
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&partial)?;
+    let result = (|| -> Result<()> {
+        std::io::copy(source, &mut output)?;
+        output.sync_all()?;
+        fs::set_permissions(&partial, permissions)?;
+        Ok(())
+    })();
+    drop(output);
+    if let Err(error) = result {
+        let _ = fs::remove_file(&partial);
+        return Err(error);
+    }
+    if let Err(error) = fs::rename(&partial, backup) {
+        let _ = fs::remove_file(&partial);
+        return Err(error.into());
     }
     Ok(())
 }
@@ -568,6 +606,45 @@ pub fn acknowledge(job: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_interrupted_backup_is_never_available_to_rollback() {
+        struct InterruptedCopy(bool);
+        impl Read for InterruptedCopy {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                if self.0 {
+                    return Err(std::io::Error::other("injected copy failure"));
+                }
+                self.0 = true;
+                buffer[0] = b'p';
+                Ok(1)
+            }
+        }
+        let directory =
+            std::env::temp_dir().join(format!("fastpotify-backup-test-{}", rand::random::<u64>()));
+        fs::create_dir(&directory).unwrap();
+        let target = directory.join("fastpotify");
+        fs::write(&target, b"working executable").unwrap();
+        let backup = directory.join("previous");
+        let permissions = fs::metadata(&target).unwrap().permissions();
+        assert!(write_backup(&mut InterruptedCopy(false), &backup, permissions).is_err());
+        assert!(
+            !backup.exists(),
+            "rollback must not see the incomplete copy"
+        );
+        assert!(!backup.with_extension("partial").exists());
+        assert_eq!(fs::read(&target).unwrap(), b"working executable");
+        backup_current(&target, &backup).unwrap();
+        assert_eq!(fs::read(&backup).unwrap(), b"working executable");
+        fs::write(&target, b"new executable").unwrap();
+        assert!(backup_current(&target, &backup).is_err());
+        assert_eq!(
+            fs::read(&backup).unwrap(),
+            b"working executable",
+            "a retry keeps the known backup"
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[cfg(target_os = "linux")]
     #[test]

--- a/src/updates/install.rs
+++ b/src/updates/install.rs
@@ -1,0 +1,638 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail, ensure};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const LIMIT: u64 = 2 * 1024 * 1024 * 1024;
+#[cfg(not(target_os = "macos"))]
+const MARKER: &str = "fastpotify-portable-v1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Kind {
+    Portable,
+    WindowsInstaller,
+    #[cfg(target_os = "macos")]
+    MacBundle,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Installation {
+    pub executable: PathBuf,
+    pub kind: Kind,
+}
+
+impl Installation {
+    fn root(&self) -> Result<&Path> {
+        #[cfg(target_os = "macos")]
+        if self.kind == Kind::MacBundle {
+            return super::macos::bundle_root(&self.executable);
+        }
+        Ok(&self.executable)
+    }
+}
+
+pub fn detect() -> Result<Installation> {
+    detect_at(&std::env::current_exe()?.canonicalize()?)
+}
+
+pub fn detect_at(executable: &Path) -> Result<Installation> {
+    let path = executable.to_string_lossy().replace('\\', "/");
+    let lower = path.to_lowercase();
+    if std::env::var_os("FLATPAK_ID").is_some() || path.starts_with("/app/") {
+        bail!("Update this installation through your software center or flatpak update.");
+    }
+    if std::env::var_os("SNAP").is_some() || path.starts_with("/snap/") {
+        bail!("Update this installation with snap refresh.");
+    }
+    if lower.contains("/.cargo/") {
+        bail!("Update this installation with cargo install.");
+    }
+    if path.starts_with("/nix/") || lower.contains("/cellar/") || lower.contains("/caskroom/") {
+        bail!("Update this installation with Nix or Homebrew.");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        for (program, arguments, instruction) in [
+            ("dpkg-query", vec!["-S"], "apt"),
+            ("rpm", vec!["-qf"], "dnf"),
+            ("pacman", vec!["-Qo"], "pacman"),
+        ] {
+            if Command::new(program)
+                .args(arguments)
+                .arg(executable)
+                .output()
+                .is_ok_and(|output| output.status.success())
+            {
+                bail!("Update this installation through {instruction} or your software center.");
+            }
+        }
+        if path.starts_with("/usr/") || path.starts_with("/bin/") || path.starts_with("/sbin/") {
+            bail!(
+                "This installation is in a system directory. Use your package manager or the download page."
+            );
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    let directory = executable
+        .parent()
+        .context("The application has no installation directory")?;
+    #[cfg(windows)]
+    {
+        let installed = std::env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .map(|base| base.join("Programs/Fastpotify/fastpotify.exe"));
+        if fs::read_to_string(directory.join("fastpotify-installer.txt"))
+            .is_ok_and(|value| value.trim() == "fastpotify-installer-v1")
+            || (installed
+                .and_then(|path| path.canonicalize().ok())
+                .as_deref()
+                == Some(executable)
+                && directory.join("unins000.exe").is_file())
+        {
+            return Ok(Installation {
+                executable: executable.to_owned(),
+                kind: Kind::WindowsInstaller,
+            });
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        super::macos::detect(executable)?;
+        Ok(Installation {
+            executable: executable.to_owned(),
+            kind: Kind::MacBundle,
+        })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        ensure!(
+            fs::read_to_string(directory.join("fastpotify-portable.txt"))
+                .is_ok_and(|value| value.trim() == MARKER),
+            "This installation does not identify itself as a portable download. Use the download page to install an update-enabled build."
+        );
+        Ok(Installation {
+            executable: executable.to_owned(),
+            kind: Kind::Portable,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Prepared {
+    pub installation: Installation,
+    pub directory: PathBuf,
+    pub payload: PathBuf,
+    pub sha256: String,
+    pub version: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Handoff {
+    prepared: Prepared,
+    parent: u32,
+    arguments: Vec<String>,
+}
+
+pub fn hash(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hash = Sha256::new();
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hash.update(&buffer[..count]);
+    }
+    Ok(format!("{:x}", hash.finalize()))
+}
+
+pub fn staging(installation: &Installation) -> Result<PathBuf> {
+    let parent = installation
+        .root()?
+        .parent()
+        .context("Missing installation directory")?;
+    let directory = parent.join(format!(".fastpotify-update-{:016x}", rand::random::<u64>()));
+    fs::create_dir(&directory).context("Cannot write to the installation directory")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(directory)
+}
+
+pub fn extract(archive: &Path, entry: &str, destination: &Path) -> Result<()> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)?;
+    let mut command = Command::new("tar");
+    command
+        .arg("-xOf")
+        .arg(archive)
+        .arg(entry)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    hidden(&mut command);
+    let mut child = command
+        .spawn()
+        .context("Cannot run tar to unpack the update")?;
+    let result = (|| -> Result<()> {
+        let mut stdout = child
+            .stdout
+            .take()
+            .context("Missing archive stream")?
+            .take(LIMIT + 1);
+        let mut file = file;
+        let count = std::io::copy(&mut stdout, &mut file)?;
+        ensure!(
+            count > 0 && count <= LIMIT,
+            "The update executable has an invalid size"
+        );
+        ensure!(
+            child.wait()?.success(),
+            "Cannot unpack the update executable"
+        );
+        file.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    result?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(destination, fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}
+
+pub fn hidden(command: &mut Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000);
+    }
+    #[cfg(not(windows))]
+    let _ = command;
+}
+
+pub fn verify_version(executable: &Path, expected: &str) -> Result<()> {
+    let mut command = Command::new(executable);
+    command
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    hidden(&mut command);
+    let mut child = command
+        .spawn()
+        .context("The downloaded app cannot run on this computer")?;
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            ensure!(
+                status.success(),
+                "The downloaded app failed its startup check"
+            );
+            let mut version = String::new();
+            child
+                .stdout
+                .take()
+                .context("Missing version output")?
+                .take(4096)
+                .read_to_string(&mut version)?;
+            ensure!(
+                version.trim() == format!("fastpotify {expected}"),
+                "The downloaded app has the wrong version"
+            );
+            return Ok(());
+        }
+        if start.elapsed() >= Duration::from_secs(10) {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!("The downloaded app did not answer its startup check");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+pub fn handoff(prepared: &Prepared, arguments: Vec<String>) -> Result<()> {
+    ensure!(
+        hash(&prepared.payload)? == prepared.sha256,
+        "The staged update changed. Download it again."
+    );
+    let helper = prepared.directory.join(if cfg!(windows) {
+        "helper.exe"
+    } else {
+        "helper"
+    });
+    fs::copy(std::env::current_exe()?, &helper)?;
+    let job = prepared.directory.join("handoff.json");
+    let mut file = File::create(&job)?;
+    serde_json::to_writer(
+        &mut file,
+        &Handoff {
+            prepared: prepared.clone(),
+            parent: std::process::id(),
+            arguments,
+        },
+    )?;
+    file.flush()?;
+    file.sync_all()?;
+    let mut command = Command::new(helper);
+    command
+        .arg("--apply-update")
+        .arg(&job)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    hidden(&mut command);
+    let mut child = command.spawn().context("Cannot start the update helper")?;
+    let ready = prepared.directory.join("ready");
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(10) {
+        if ready.exists() {
+            return Ok(());
+        }
+        ensure!(
+            child.try_wait()?.is_none(),
+            "The update helper exited before it was ready"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    bail!("The update helper did not start. Try again.")
+}
+
+fn wait_for_parent(parent: u32, ready: &Path) -> Result<()> {
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_SYNCHRONIZE, WaitForSingleObject,
+        };
+        let process = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, parent) };
+        ensure!(!process.is_null(), "Cannot watch the running app");
+        let result = fs::write(ready, b"ready");
+        if result.is_err() {
+            unsafe {
+                CloseHandle(process);
+            }
+        }
+        result?;
+        let outcome = unsafe { WaitForSingleObject(process, 60_000) };
+        unsafe {
+            CloseHandle(process);
+        }
+        ensure!(
+            outcome == WAIT_OBJECT_0,
+            "The app did not close within one minute"
+        );
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let process = PathBuf::from(format!("/proc/{parent}/stat"));
+        let original = fs::read_to_string(&process).context("Cannot watch the running app")?;
+        let identity = process_identity(&original).context("Cannot identify the running app")?;
+        fs::write(ready, b"ready")?;
+        let start = Instant::now();
+        loop {
+            let current = match fs::read_to_string(&process) {
+                Ok(current) => current,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+                Err(error) => return Err(error).context("Cannot watch the running app"),
+            };
+            if process_identity(&current) != Some(identity)
+                || current
+                    .rsplit_once(')')
+                    .is_some_and(|(_, fields)| fields.trim_start().starts_with('Z'))
+            {
+                break;
+            }
+            ensure!(
+                start.elapsed() < Duration::from_secs(60),
+                "The app did not close within one minute"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+    #[cfg(not(any(windows, target_os = "linux")))]
+    {
+        fs::write(ready, b"ready")?;
+        let start = Instant::now();
+        while Command::new("/bin/kill")
+            .args(["-0", &parent.to_string()])
+            .stderr(Stdio::null())
+            .status()?
+            .success()
+        {
+            ensure!(
+                start.elapsed() < Duration::from_secs(60),
+                "The app did not close within one minute"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn process_identity(stat: &str) -> Option<&str> {
+    stat.rsplit_once(')')?.1.split_whitespace().nth(19)
+}
+
+pub fn replace(prepared: &Prepared) -> Result<()> {
+    ensure!(
+        hash(&prepared.payload)? == prepared.sha256,
+        "The staged update checksum changed"
+    );
+    let target = &prepared.installation.executable;
+    let backup = prepared.directory.join("previous");
+    match prepared.installation.kind {
+        #[cfg(target_os = "macos")]
+        Kind::MacBundle => super::macos::replace(prepared)?,
+        Kind::Portable => {
+            ensure!(!backup.exists(), "This update was already applied");
+            fs::copy(target, &backup).context("Cannot back up the current app")?;
+            #[cfg(windows)]
+            fs::remove_file(target).context("The app is still running or cannot be replaced")?;
+            if let Err(error) = fs::rename(&prepared.payload, target) {
+                #[cfg(windows)]
+                fs::copy(&backup, target).context("Could not restore the previous app")?;
+                return Err(error).context("Could not replace the app");
+            }
+        }
+        Kind::WindowsInstaller => {
+            fs::copy(target, &backup)?;
+            let mut command = Command::new(&prepared.payload);
+            command
+                .args([
+                    "/VERYSILENT",
+                    "/SUPPRESSMSGBOXES",
+                    "/NORESTART",
+                    "/CLOSEAPPLICATIONS",
+                    "/NORESTARTAPPLICATIONS",
+                ])
+                .arg(format!(
+                    "/DIR={}",
+                    installer_path(target.parent().context("Missing installation directory")?)
+                ))
+                .arg(format!(
+                    "/LOG={}",
+                    installer_path(&prepared.directory.join("installer.log"))
+                ));
+            hidden(&mut command);
+            ensure!(
+                command.status()?.success(),
+                "The installer failed. See the update installer log."
+            );
+        }
+    }
+    Ok(())
+}
+
+fn installer_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    if let Some(unc) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{unc}")
+    } else {
+        path.strip_prefix(r"\\?\").unwrap_or(&path).to_owned()
+    }
+}
+
+pub fn run_helper(job: &Path) -> Result<()> {
+    let handoff: Handoff = serde_json::from_reader(File::open(job)?)?;
+    let prepared = &handoff.prepared;
+    ensure!(
+        job.parent() == Some(prepared.directory.as_path()),
+        "Invalid update job directory"
+    );
+    ensure!(
+        prepared.payload.parent() == Some(prepared.directory.as_path()),
+        "Invalid staged payload"
+    );
+    ensure!(
+        prepared.directory.parent() == prepared.installation.root()?.parent(),
+        "Invalid installation directory"
+    );
+    ensure!(
+        hash(&prepared.payload)? == prepared.sha256,
+        "The staged update checksum changed"
+    );
+    wait_for_parent(handoff.parent, &prepared.directory.join("ready"))?;
+    let result = replace(prepared);
+    if let Err(error) = result {
+        restore_and_restart(prepared, &handoff.arguments)?;
+        fs::write(
+            prepared.directory.join("result.txt"),
+            format!("Update failed: {error:#}"),
+        )?;
+        return Err(error);
+    }
+    let mut command = Command::new(&prepared.installation.executable);
+    command
+        .args(&handoff.arguments)
+        .arg("--update-receipt")
+        .arg(job);
+    hidden(&mut command);
+    let launch = (|| -> Result<()> {
+        let mut child = command
+            .spawn()
+            .context("Could not launch the updated app")?;
+        let start = Instant::now();
+        loop {
+            if prepared.directory.join("started").is_file() {
+                return Ok(());
+            }
+            ensure!(
+                child.try_wait()?.is_none(),
+                "The updated app exited before opening its window"
+            );
+            if start.elapsed() >= Duration::from_secs(60) {
+                let _ = child.kill();
+                let _ = child.wait();
+                bail!("The updated app did not open its window within one minute");
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    })();
+    if let Err(error) = launch {
+        restore_and_restart(prepared, &handoff.arguments)?;
+        fs::write(
+            prepared.directory.join("result.txt"),
+            format!("Update failed; restored the previous app: {error:#}"),
+        )?;
+        return Err(error);
+    }
+    fs::write(
+        prepared.directory.join("result.txt"),
+        format!("Updated to {}", prepared.version),
+    )?;
+    Ok(())
+}
+
+fn restore_and_restart(prepared: &Prepared, arguments: &[String]) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    if prepared.installation.kind == Kind::MacBundle {
+        super::macos::restore(prepared)?;
+    }
+    let backup = prepared.directory.join("previous");
+    if backup.is_file() {
+        fs::copy(&backup, &prepared.installation.executable)
+            .context("Could not restore the previous app")?;
+    }
+    let mut command = Command::new(&prepared.installation.executable);
+    command.args(arguments).args([
+        "--update-error",
+        "The update could not start. The previous version has been restored.",
+    ]);
+    hidden(&mut command);
+    command
+        .spawn()
+        .context("Could not restart the previous app")?;
+    Ok(())
+}
+
+pub fn acknowledge(job: &Path) -> Result<()> {
+    let handoff: Handoff = serde_json::from_reader(File::open(job)?)?;
+    ensure!(
+        job.parent() == Some(handoff.prepared.directory.as_path()),
+        "Invalid update receipt directory"
+    );
+    ensure!(
+        std::env::current_exe()?.canonicalize()?
+            == handoff.prepared.installation.executable.canonicalize()?,
+        "The receipt belongs to a different installation"
+    );
+    ensure!(
+        env!("CARGO_PKG_VERSION") == handoff.prepared.version,
+        "The updated app reports the wrong version"
+    );
+    fs::write(
+        handoff.prepared.directory.join("started"),
+        env!("CARGO_PKG_VERSION"),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn process_identity_handles_spaces_and_parentheses_in_names() {
+        let fields = "S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 98765 20";
+        assert_eq!(
+            process_identity(&format!("42 (app (test)) {fields}")),
+            Some("98765")
+        );
+        assert_eq!(process_identity("42 (app) S"), None);
+        let current = fs::read_to_string(format!("/proc/{}/stat", std::process::id())).unwrap();
+        assert!(process_identity(&current).unwrap().parse::<u64>().is_ok());
+    }
+
+    #[test]
+    fn unknown_and_package_managed_paths_are_not_portable() {
+        for path in [
+            "/usr/bin/fastpotify",
+            "/nix/store/package/bin/fastpotify",
+            "/home/test/.cargo/bin/fastpotify",
+            "/unknown/fastpotify",
+        ] {
+            assert!(detect_at(Path::new(path)).is_err());
+        }
+    }
+
+    #[test]
+    fn installer_arguments_use_paths_inno_setup_accepts() {
+        assert_eq!(
+            installer_path(Path::new(r"\\?\C:\Users\test\Fastpotify")),
+            r"C:\Users\test\Fastpotify"
+        );
+        assert_eq!(
+            installer_path(Path::new(r"\\?\UNC\server\share\Fastpotify")),
+            r"\\server\share\Fastpotify"
+        );
+    }
+
+    #[test]
+    fn replacement_verifies_before_touching_the_current_executable() {
+        let directory =
+            std::env::temp_dir().join(format!("fastpotify-updater-test-{}", rand::random::<u64>()));
+        fs::create_dir(&directory).unwrap();
+        let target = directory.join("fastpotify");
+        fs::write(&target, b"old").unwrap();
+        let installation = Installation {
+            executable: target.clone(),
+            kind: Kind::Portable,
+        };
+        let stage = staging(&installation).unwrap();
+        let payload = stage.join("next");
+        fs::write(&payload, b"new").unwrap();
+        let mut prepared = Prepared {
+            installation,
+            directory: stage.clone(),
+            payload: payload.clone(),
+            sha256: "wrong".into(),
+            version: "1.0.0".into(),
+        };
+        assert!(replace(&prepared).is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"old");
+        prepared.sha256 = hash(&payload).unwrap();
+        replace(&prepared).unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"new");
+        assert_eq!(fs::read(stage.join("previous")).unwrap(), b"old");
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/src/updates/macos.rs
+++ b/src/updates/macos.rs
@@ -134,6 +134,9 @@ impl Mounted {
             .parent()
             .context("Missing update directory")?
             .join("mounted");
+        if mount.exists() {
+            let _ = fs::remove_dir_all(&mount);
+        }
         fs::create_dir(&mount)?;
         let output = Command::new("/usr/bin/hdiutil")
             .args(["attach", "-readonly", "-nobrowse", "-mountpoint"])

--- a/src/updates/macos.rs
+++ b/src/updates/macos.rs
@@ -1,0 +1,310 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, ensure};
+
+use super::install::{self, Installation, Prepared};
+
+const IDENTIFIER: &str = "me.paolino.fastpotify";
+
+pub(super) fn bundle_root(executable: &Path) -> Result<&Path> {
+    let root = executable
+        .ancestors()
+        .nth(3)
+        .context("Missing app bundle")?;
+    ensure!(
+        root.extension().is_some_and(|extension| extension == "app")
+            && root.join("Contents/MacOS/fastpotify") == executable,
+        "Move Fastpotify.app to Applications, then open it to update."
+    );
+    Ok(root)
+}
+
+fn plist(bundle: &Path, key: &str) -> Result<String> {
+    let output = Command::new("/usr/libexec/PlistBuddy")
+        .args(["-c", &format!("Print :{key}")])
+        .arg(bundle.join("Contents/Info.plist"))
+        .output()?;
+    ensure!(output.status.success(), "The app bundle is missing {key}");
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn identity(bundle: &Path) -> Result<()> {
+    ensure!(
+        plist(bundle, "CFBundleIdentifier")? == IDENTIFIER
+            && plist(bundle, "CFBundleExecutable")? == "fastpotify"
+            && plist(bundle, "CFBundlePackageType")? == "APPL",
+        "The download is not a Fastpotify app bundle"
+    );
+    Ok(())
+}
+
+pub(super) fn detect(executable: &Path) -> Result<()> {
+    ensure!(
+        !executable.starts_with("/Volumes")
+            && !executable
+                .components()
+                .any(|part| part.as_os_str() == "AppTranslocation"),
+        "Move Fastpotify.app to Applications, then open it to update."
+    );
+    let bundle = bundle_root(executable)?;
+    let prefixes = [
+        Some(PathBuf::from("/opt/homebrew")),
+        Some(PathBuf::from("/usr/local")),
+        std::env::var_os("HOMEBREW_PREFIX").map(PathBuf::from),
+    ];
+    for prefix in prefixes.into_iter().flatten() {
+        ensure!(
+            !cask_owns(&prefix.join("Caskroom/fastpotify"), bundle),
+            "Update this installation with Homebrew."
+        );
+    }
+    identity(bundle)
+}
+
+fn cask_owns(cask: &Path, bundle: &Path) -> bool {
+    let Ok(bundle) = bundle.canonicalize() else {
+        return false;
+    };
+    fs::read_dir(cask).is_ok_and(|versions| {
+        versions.flatten().any(|version| {
+            version
+                .path()
+                .join("Fastpotify.app")
+                .canonicalize()
+                .is_ok_and(|installed| installed == bundle)
+        })
+    })
+}
+
+fn team(bundle: &Path) -> Result<Option<String>> {
+    let verify = Command::new("/usr/bin/codesign")
+        .args(["--verify", "--deep", "--strict"])
+        .arg(bundle)
+        .output()?;
+    ensure!(
+        verify.status.success(),
+        "The app signature could not be verified"
+    );
+    let output = Command::new("/usr/bin/codesign")
+        .args(["--display", "--verbose=4"])
+        .arg(bundle)
+        .output()?;
+    ensure!(
+        output.status.success(),
+        "Cannot read the app signing identity"
+    );
+    Ok(String::from_utf8(output.stderr)?
+        .lines()
+        .find_map(|line| line.strip_prefix("TeamIdentifier="))
+        .filter(|value| *value != "not set")
+        .map(str::to_owned))
+}
+
+fn validate(bundle: &Path, installation: &Installation, version: &str) -> Result<()> {
+    identity(bundle)?;
+    ensure!(
+        plist(bundle, "CFBundleShortVersionString")? == version,
+        "The app bundle has the wrong version"
+    );
+    let incoming = team(bundle)?;
+    if let Some(current) = team(bundle_root(&installation.executable)?)? {
+        ensure!(
+            incoming.as_deref() == Some(current.as_str()),
+            "The update was signed by a different publisher"
+        );
+        let assessment = Command::new("/usr/sbin/spctl")
+            .args(["--assess", "--type", "execute"])
+            .arg(bundle)
+            .output()?;
+        ensure!(
+            assessment.status.success(),
+            "macOS could not approve this update for launch"
+        );
+    }
+    install::verify_version(&bundle.join("Contents/MacOS/fastpotify"), version)
+}
+
+struct Mounted(PathBuf);
+
+impl Mounted {
+    fn open(archive: &Path) -> Result<Self> {
+        let mount = archive
+            .parent()
+            .context("Missing update directory")?
+            .join("mounted");
+        fs::create_dir(&mount)?;
+        let output = Command::new("/usr/bin/hdiutil")
+            .args(["attach", "-readonly", "-nobrowse", "-mountpoint"])
+            .arg(&mount)
+            .arg(archive)
+            .output()?;
+        if !output.status.success() {
+            let _ = fs::remove_dir(&mount);
+            anyhow::bail!("macOS could not open the downloaded disk image");
+        }
+        Ok(Self(mount))
+    }
+
+    fn bundle(&self) -> Result<PathBuf> {
+        let bundle = self.0.join("Fastpotify.app");
+        ensure!(
+            bundle.is_dir() && !fs::symlink_metadata(&bundle)?.file_type().is_symlink(),
+            "The disk image has no Fastpotify app bundle"
+        );
+        Ok(bundle)
+    }
+}
+
+impl Drop for Mounted {
+    fn drop(&mut self) {
+        let detached = Command::new("/usr/bin/hdiutil")
+            .arg("detach")
+            .arg(&self.0)
+            .output()
+            .is_ok_and(|output| output.status.success());
+        if detached {
+            let _ = fs::remove_dir(&self.0);
+        }
+    }
+}
+
+pub(super) fn validate_download(
+    archive: &Path,
+    installation: &Installation,
+    version: &str,
+) -> Result<()> {
+    let mounted = Mounted::open(archive)?;
+    validate(&mounted.bundle()?, installation, version)
+}
+
+pub(super) fn replace(prepared: &Prepared) -> Result<()> {
+    let target = bundle_root(&prepared.installation.executable)?;
+    let backup = prepared.directory.join("previous");
+    let candidate = prepared.directory.join("Fastpotify.app");
+    ensure!(
+        !backup.exists() && !candidate.exists(),
+        "This update was already applied"
+    );
+    let mounted = Mounted::open(&prepared.payload)?;
+    let source = mounted.bundle()?;
+    validate(&source, &prepared.installation, &prepared.version)?;
+    let copy = Command::new("/usr/bin/ditto")
+        .arg(&source)
+        .arg(&candidate)
+        .output()?;
+    ensure!(
+        copy.status.success(),
+        "Could not copy the downloaded app bundle"
+    );
+    validate(&candidate, &prepared.installation, &prepared.version)?;
+    drop(mounted);
+    fs::rename(target, &backup).context("Cannot back up the current app bundle")?;
+    if let Err(error) = fs::rename(&candidate, target) {
+        fs::rename(&backup, target).context("Could not restore the previous app bundle")?;
+        return Err(error).context("Could not replace the app bundle");
+    }
+    Ok(())
+}
+
+pub(super) fn restore(prepared: &Prepared) -> Result<()> {
+    let backup = prepared.directory.join("previous");
+    if backup.is_dir() {
+        let target = bundle_root(&prepared.installation.executable)?;
+        if target.exists() {
+            fs::rename(target, prepared.directory.join("failed.app"))
+                .context("Could not move the failed update aside")?;
+        }
+        fs::rename(backup, target).context("Could not restore the previous app bundle")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn homebrew_app_symlink_does_not_claim_other_copies() {
+        let directory =
+            std::env::temp_dir().join(format!("fastpotify-cask-test-{}", rand::random::<u64>()));
+        let installed = directory.join("Applications/Fastpotify.app");
+        let cask = directory.join("Caskroom/fastpotify");
+        let copy = directory.join("dev/Fastpotify.app");
+        for path in [&installed, &copy, &cask.join("0.7.1")] {
+            fs::create_dir_all(path).unwrap();
+        }
+        std::os::unix::fs::symlink(&installed, cask.join("0.7.1/Fastpotify.app")).unwrap();
+        assert!(cask_owns(&cask, &installed));
+        assert!(!cask_owns(&cask, &copy));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rollback_restores_resources_and_executable_together() {
+        let directory =
+            std::env::temp_dir().join(format!("fastpotify-mac-test-{}", rand::random::<u64>()));
+        let app = directory.join("Fastpotify.app");
+        fs::create_dir_all(app.join("Contents/MacOS")).unwrap();
+        fs::write(app.join("Contents/MacOS/fastpotify"), b"new executable").unwrap();
+        fs::write(app.join("Contents/Info.plist"), b"new metadata").unwrap();
+        let installation = Installation {
+            executable: app.join("Contents/MacOS/fastpotify"),
+            kind: install::Kind::MacBundle,
+        };
+        let stage = install::staging(&installation).unwrap();
+        assert_eq!(stage.parent(), Some(directory.as_path()));
+        let backup = stage.join("previous");
+        fs::create_dir_all(backup.join("Contents/MacOS")).unwrap();
+        fs::write(backup.join("Contents/MacOS/fastpotify"), b"old executable").unwrap();
+        fs::write(backup.join("Contents/Info.plist"), b"old metadata").unwrap();
+        let prepared = Prepared {
+            installation,
+            directory: stage.clone(),
+            payload: stage.join("update.dmg"),
+            sha256: String::new(),
+            version: "0.7.2".into(),
+        };
+        restore(&prepared).unwrap();
+        assert_eq!(
+            fs::read(app.join("Contents/MacOS/fastpotify")).unwrap(),
+            b"old executable"
+        );
+        assert_eq!(
+            fs::read(app.join("Contents/Info.plist")).unwrap(),
+            b"old metadata"
+        );
+        assert_eq!(
+            fs::read(stage.join("failed.app/Contents/Info.plist")).unwrap(),
+            b"new metadata"
+        );
+        assert!(!backup.exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn only_expected_bundle_layout_is_accepted() {
+        assert_eq!(
+            bundle_root(Path::new(
+                "/Applications/Fastpotify.app/Contents/MacOS/fastpotify"
+            ))
+            .unwrap(),
+            Path::new("/Applications/Fastpotify.app")
+        );
+        for path in [
+            "/Applications/Fastpotify.app/fastpotify",
+            "/tmp/Contents/MacOS/fastpotify",
+            "/usr/local/bin/fastpotify",
+        ] {
+            assert!(bundle_root(Path::new(path)).is_err());
+        }
+        assert!(
+            detect(Path::new(
+                "/Volumes/Fastpotify/Fastpotify.app/Contents/MacOS/fastpotify"
+            ))
+            .is_err()
+        );
+        assert!(detect(Path::new("/private/var/folders/test/AppTranslocation/test/Fastpotify.app/Contents/MacOS/fastpotify")).is_err());
+    }
+}

--- a/src/updates/macos.rs
+++ b/src/updates/macos.rs
@@ -128,16 +128,20 @@ fn validate(bundle: &Path, installation: &Installation, version: &str) -> Result
 
 struct Mounted(PathBuf);
 
+fn mountpoint(archive: &Path) -> Result<PathBuf> {
+    let mount = archive
+        .parent()
+        .context("Missing update directory")?
+        .join(format!("mounted-{:016x}", rand::random::<u64>()));
+    fs::create_dir(&mount)?;
+    Ok(mount)
+}
+
 impl Mounted {
     fn open(archive: &Path) -> Result<Self> {
-        let mount = archive
-            .parent()
-            .context("Missing update directory")?
-            .join("mounted");
-        if mount.exists() {
-            let _ = fs::remove_dir_all(&mount);
-        }
-        fs::create_dir(&mount)?;
+        // A failed detach can leave the previous attempt mounted. Never
+        // traverse that volume or reuse its directory on a later attempt.
+        let mount = mountpoint(archive)?;
         let output = Command::new("/usr/bin/hdiutil")
             .args(["attach", "-readonly", "-nobrowse", "-mountpoint"])
             .arg(&mount)
@@ -227,6 +231,24 @@ pub(super) fn restore(prepared: &Prepared) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn another_mount_attempt_leaves_the_previous_volume_alone() {
+        let directory =
+            std::env::temp_dir().join(format!("fastpotify-mount-test-{}", rand::random::<u64>()));
+        fs::create_dir(&directory).unwrap();
+        let archive = directory.join("update.dmg");
+        let first = mountpoint(&archive).unwrap();
+        fs::write(first.join("still-mounted"), b"existing volume").unwrap();
+        let second = mountpoint(&archive).unwrap();
+        assert_ne!(first, second);
+        assert_eq!(
+            fs::read(first.join("still-mounted")).unwrap(),
+            b"existing volume"
+        );
+        assert!(second.is_dir());
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn homebrew_app_symlink_does_not_claim_other_copies() {

--- a/src/updates/transfer.rs
+++ b/src/updates/transfer.rs
@@ -1,0 +1,405 @@
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail, ensure};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use super::{Release, install};
+
+const DOWNLOAD_LIMIT: u64 = 2 * 1024 * 1024 * 1024;
+
+#[derive(Clone, Debug, Default)]
+pub enum Source {
+    #[default]
+    GitHub,
+    #[cfg(feature = "demo")]
+    Local(String),
+}
+
+impl Source {
+    pub fn latest(&self) -> String {
+        match self {
+            Self::GitHub => super::LATEST_RELEASE_URL.into(),
+            #[cfg(feature = "demo")]
+            Self::Local(base) => format!("{base}/latest.json"),
+        }
+    }
+
+    fn release(&self, version: &str) -> String {
+        match self {
+            Self::GitHub => {
+                format!("https://api.github.com/repos/crmne/fastpotify/releases/tags/v{version}")
+            }
+            #[cfg(feature = "demo")]
+            Self::Local(base) => format!("{base}/latest.json"),
+        }
+    }
+
+    #[cfg(feature = "demo")]
+    pub fn local(value: &str) -> Result<Self> {
+        let url = reqwest::Url::parse(value)?;
+        ensure!(
+            url.scheme() == "http"
+                && matches!(url.host_str(), Some("127.0.0.1" | "[::1]"))
+                && url.username().is_empty()
+                && url.password().is_none()
+                && url.query().is_none()
+                && url.fragment().is_none(),
+            "The demo update feed must use a loopback HTTP address"
+        );
+        Ok(Self::Local(value.trim_end_matches('/').into()))
+    }
+
+    fn allowed(&self, url: &reqwest::Url) -> bool {
+        match self {
+            Self::GitHub => {
+                url.scheme() == "https"
+                    && url.username().is_empty()
+                    && url.password().is_none()
+                    && matches!(
+                        url.host_str(),
+                        Some(
+                            "api.github.com"
+                                | "github.com"
+                                | "release-assets.githubusercontent.com"
+                                | "objects.githubusercontent.com"
+                        )
+                    )
+            }
+            #[cfg(feature = "demo")]
+            Self::Local(base) => {
+                reqwest::Url::parse(base).is_ok_and(|base| url.origin() == base.origin())
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Metadata {
+    tag_name: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+    assets: Vec<Asset>,
+}
+
+#[derive(Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+    size: u64,
+}
+
+fn asset<'a>(metadata: &'a Metadata, name: &str) -> Result<&'a Asset> {
+    let matches: Vec<_> = metadata
+        .assets
+        .iter()
+        .filter(|asset| asset.name == name)
+        .collect();
+    ensure!(
+        matches.len() == 1,
+        "The release has no unique {name} download"
+    );
+    let asset = matches[0];
+    ensure!(
+        asset.size > 0 && asset.size <= DOWNLOAD_LIMIT,
+        "Invalid update download size"
+    );
+    Ok(asset)
+}
+
+fn checksum(text: &str, name: &str) -> Result<String> {
+    let mut found = None;
+    for line in text.lines() {
+        let mut fields = line.split_whitespace();
+        if let (Some(digest), Some(file), None) = (fields.next(), fields.next(), fields.next())
+            && file.trim_start_matches('*') == name
+        {
+            ensure!(found.is_none(), "Duplicate checksum for the update");
+            ensure!(
+                digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()),
+                "Invalid update checksum"
+            );
+            found = Some(digest.to_ascii_lowercase());
+        }
+    }
+    found.context("The release is missing the update checksum")
+}
+
+pub fn download(
+    release: &Release,
+    source: &Source,
+    progress: impl Fn(u64, u64),
+) -> Result<install::Prepared> {
+    let installation = install::detect()?;
+    download_for(release, source, installation, progress)
+}
+
+pub fn download_for(
+    release: &Release,
+    source: &Source,
+    installation: install::Installation,
+    progress: impl Fn(u64, u64),
+) -> Result<install::Prepared> {
+    ensure!(
+        super::parse(&release.version).is_some_and(|(_, pre)| !pre)
+            && release
+                .version
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || byte == b'.'),
+        "Invalid release version"
+    );
+    let policy = source.clone();
+    let http = reqwest::blocking::Client::builder()
+        .user_agent(concat!("Fastpotify/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(15 * 60))
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() < 5 && policy.allowed(attempt.url()) {
+                attempt.follow()
+            } else {
+                attempt.error("Update redirect is not allowed")
+            }
+        }))
+        .build()?;
+    let metadata: Metadata = serde_json::from_reader(
+        http.get(source.release(&release.version))
+            .send()?
+            .error_for_status()?
+            .take(1024 * 1024),
+    )?;
+    ensure!(
+        !metadata.draft
+            && !metadata.prerelease
+            && metadata.tag_name == format!("v{}", release.version),
+        "The release changed. Check for updates again."
+    );
+    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+        ("windows", "aarch64") => "aarch64-pc-windows-msvc",
+        ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
+        ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
+        ("macos", "aarch64" | "x86_64") => "macos-universal",
+        _ => bail!("Use the download page for this operating system or architecture"),
+    };
+    let stem = format!("fastpotify-v{}-{target}", release.version);
+    let name = match installation.kind {
+        #[cfg(target_os = "macos")]
+        install::Kind::MacBundle => format!("{stem}.dmg"),
+        install::Kind::WindowsInstaller => format!("{stem}-setup.exe"),
+        install::Kind::Portable if cfg!(windows) => format!("{stem}.zip"),
+        install::Kind::Portable => format!("{stem}.tar.gz"),
+    };
+    let package = asset(&metadata, &name)?;
+    let checksums = asset(&metadata, "checksums.txt")?;
+    for candidate in [package, checksums] {
+        let url = reqwest::Url::parse(&candidate.browser_download_url)?;
+        ensure!(
+            source.allowed(&url),
+            "Update download is not on the release host"
+        );
+        if matches!(source, Source::GitHub) {
+            ensure!(
+                url.host_str() == Some("github.com")
+                    && url.path()
+                        == format!(
+                            "/crmne/fastpotify/releases/download/v{}/{}",
+                            release.version, candidate.name
+                        ),
+                "Update asset does not belong to this release"
+            );
+        }
+    }
+    let mut checksum_text = String::new();
+    http.get(&checksums.browser_download_url)
+        .send()?
+        .error_for_status()?
+        .take(1024 * 1024)
+        .read_to_string(&mut checksum_text)?;
+    let expected = checksum(&checksum_text, &name)?;
+    let directory = install::staging(&installation)?;
+    let result = (|| -> Result<install::Prepared> {
+        let archive = directory.join(&name);
+        let mut output = File::create(&archive)?;
+        let mut response = http
+            .get(&package.browser_download_url)
+            .send()?
+            .error_for_status()?;
+        let mut hash = Sha256::new();
+        let mut received = 0;
+        let mut buffer = [0; 64 * 1024];
+        loop {
+            let count = response.read(&mut buffer)?;
+            if count == 0 {
+                break;
+            }
+            received += count as u64;
+            ensure!(
+                received <= package.size,
+                "Update download exceeds its published size"
+            );
+            hash.update(&buffer[..count]);
+            output.write_all(&buffer[..count])?;
+            if received % (1024 * 1024) < count as u64 || received == package.size {
+                progress(received, package.size);
+            }
+        }
+        output.sync_all()?;
+        drop(output);
+        ensure!(
+            received == package.size,
+            "The update download was interrupted"
+        );
+        ensure!(
+            format!("{:x}", hash.finalize()) == expected,
+            "The download couldn't be verified. Try downloading it again."
+        );
+        #[cfg(target_os = "macos")]
+        if installation.kind == install::Kind::MacBundle {
+            super::macos::validate_download(&archive, &installation, &release.version)?;
+            return Ok(install::Prepared {
+                sha256: expected.clone(),
+                installation,
+                directory: directory.clone(),
+                payload: archive,
+                version: release.version.clone(),
+            });
+        }
+        let payload = if installation.kind == install::Kind::WindowsInstaller {
+            archive.clone()
+        } else {
+            let executable = if cfg!(windows) {
+                "fastpotify.exe"
+            } else {
+                "fastpotify"
+            };
+            let payload = directory.join(executable);
+            install::extract(&archive, &format!("{stem}/{executable}"), &payload)?;
+            install::verify_version(&payload, &release.version)?;
+            fs::remove_file(&archive)?;
+            payload
+        };
+        Ok(install::Prepared {
+            sha256: install::hash(&payload)?,
+            installation,
+            directory: directory.clone(),
+            payload,
+            version: release.version.clone(),
+        })
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&directory);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(all(feature = "demo", any(target_os = "windows", target_os = "linux")))]
+    #[test]
+    fn damaged_and_interrupted_downloads_preserve_the_installation() {
+        use std::net::TcpListener;
+        for interrupted in [false, true] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let base = format!("http://{}", listener.local_addr().unwrap());
+            let platform = if cfg!(windows) {
+                "pc-windows-msvc.zip"
+            } else {
+                "unknown-linux-gnu.tar.gz"
+            };
+            let name = format!("fastpotify-v0.8.0-{}-{platform}", std::env::consts::ARCH);
+            let payload = b"damaged download";
+            let hash = if interrupted {
+                format!("{:x}", Sha256::digest(payload))
+            } else {
+                "0".repeat(64)
+            };
+            let checksums = format!("{hash}  {name}\n");
+            let metadata = serde_json::json!({"tag_name":"v0.8.0", "assets":[
+                {"name":name,"size":payload.len() + usize::from(interrupted),"browser_download_url":format!("{base}/package")},
+                {"name":"checksums.txt","size":checksums.len(),"browser_download_url":format!("{base}/checksums")}
+            ]}).to_string();
+            let server = std::thread::spawn(move || {
+                for body in [
+                    metadata.into_bytes(),
+                    checksums.into_bytes(),
+                    payload.to_vec(),
+                ] {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    let mut request = [0; 4096];
+                    assert!(stream.read(&mut request).unwrap() > 0);
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    )
+                    .unwrap();
+                    stream.write_all(&body).unwrap();
+                }
+            });
+            let directory = std::env::temp_dir().join(format!(
+                "fastpotify-download-test-{}",
+                rand::random::<u64>()
+            ));
+            fs::create_dir(&directory).unwrap();
+            let target = directory.join("fastpotify");
+            fs::write(&target, b"original").unwrap();
+            let installation = install::Installation {
+                executable: target.clone(),
+                kind: install::Kind::Portable,
+            };
+            let release = Release {
+                version: "0.8.0".into(),
+                url: base.clone(),
+            };
+            let error = download_for(
+                &release,
+                &Source::local(&base).unwrap(),
+                installation,
+                |_, _| {},
+            )
+            .unwrap_err();
+            assert!(
+                error.to_string().contains(if interrupted {
+                    "interrupted"
+                } else {
+                    "verified"
+                }),
+                "{error:#}"
+            );
+            assert_eq!(fs::read(&target).unwrap(), b"original");
+            assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+            server.join().unwrap();
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn checksums_must_be_unique_valid_and_for_the_exact_asset() {
+        let digest = "a".repeat(64);
+        let valid = format!("{digest}  app.zip\n");
+        assert_eq!(checksum(&valid, "app.zip").unwrap(), digest);
+        assert!(checksum(&valid, "other.zip").is_err());
+        assert!(checksum(&(valid.clone() + &valid), "app.zip").is_err());
+        assert!(checksum("invalid app.zip", "app.zip").is_err());
+    }
+
+    #[test]
+    fn redirects_cannot_leave_release_hosts() {
+        for address in [
+            "http://github.com/file",
+            "https://github.com.attacker.invalid/file",
+            "https://example.com/file",
+        ] {
+            assert!(!Source::GitHub.allowed(&reqwest::Url::parse(address).unwrap()));
+        }
+        assert!(Source::GitHub.allowed(
+            &reqwest::Url::parse("https://release-assets.githubusercontent.com/file").unwrap()
+        ));
+    }
+}


### PR DESCRIPTION
Fastpotify currently sends users to the release page when they click the update pill. This adds downloading and installing updates inside the app on Windows, macOS, and Linux. Restarting always stays under the user's control.

**Tested on Windows, macOS, and Linux**, including downloading a real GitHub release, verifying the installed files, and opening the updated app.

### What changes for users

- Clicking **Update to …** opens a small update window styled with the existing app palette, typography, and buttons. Update checks never open it automatically.
- **Download update** shows download progress and verifies the file before offering **Restart to update**. Closing the window keeps the download running.
- **Download updates automatically** is an optional setting, off by default. It downloads in the background and waits for the user to restart.
- **Release notes** opens the GitHub release page for the offered version.
- Failed downloads offer **Retry download** and leave the running installation intact. The restart screen explains that local music playback will stop.

### Installing the update

The downloader selects the release asset for the operating system, CPU architecture, and installation type. It checks the release version, published file size, and SHA-256 checksum before staging the update beside the installation.

| Installation | Update behavior |
| --- | --- |
| Windows portable | Replace the executable after the app exits, then restart it |
| Windows installer | Run the downloaded installer against the existing installation, then restart |
| Linux portable | Replace the executable after exit, then restart |
| macOS app bundle | Install the complete bundle from the universal DMG after checking its identity, version, and signature. Developer ID installations also require the same signing team and macOS approval |
| Package-managed or unrecognized | Show package-manager guidance or the release download page |

A helper keeps a backup and waits for the updated app to confirm that its first window frame has rendered. If startup fails or times out, it restores the previous executable or Mac bundle and reopens it with an error message. Settings and sign-in files remain in place.

Release packaging adds installation markers so portable downloads and Windows installer builds can be identified. Older releases need one manual installation of an update-enabled build before using this flow. No new dependencies are added.

### Live-release test

![Downloading and installing the actual 0.7.1 release on Windows](https://github.com/user-attachments/assets/01038e24-0f39-4c8e-b2b3-7724d8aca734)

The Windows test starts from an isolated development build labelled **0.7.0** and installs the **actual GitHub 0.7.1 release**. Published 0.7.1 predates the new startup-confirmation protocol, so that particular test uses an external native-window and executable-hash check. That compatibility override is confined to the test copy and is **not included in this PR**. The normal startup confirmation and rollback paths were tested separately with updater-enabled builds.

### Validation

- Real GitHub 0.7.1 download, replacement, matching installed hashes, and visible restarted windows on Windows x64 portable, an Ubuntu 24.04 VM running locally on the Windows PC, and an ARM64 MacBook. The Mac installation also matched every file in the published bundle.
- Updater-enabled build tests covered the Windows installer, damaged downloads and retry, failed-start rollback, and background downloads without opening the popup or restarting automatically.
- Debian 13, Fedora 44, and Arch userspace tests ran inside the local VM under Xvfb, including package-manager ownership checks. These share the VM's kernel.
- Windows formatting, Clippy, and all-target tests passed with `--no-default-features --features demo`. Linux and Mac default/all-feature checks, doctests, Rust documentation, Node assessment tests, and the Jekyll build passed.

Not exercised locally: Windows/Linux ARM execution, Intel Mac execution, Wayland, Windows MilkDrop builds, or a notarized Developer ID upgrade. The public-release run used Windows portable, not the public Windows installer.

Related: #379 proposes Linux hand-install updates. This is a separate implementation covering Windows and macOS too, with explicit restart confirmation and startup rollback.
