### PR TITLE
fix(topbar): stop badges from overlapping the search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ everyday use, and connection details.
   after 0.7.1).
 - **Search** across songs, artists, albums, playlists, podcasts, and episodes,
   with a top result and per-type views. Right-click results and cards for their actions.
+  On `main`, after 0.7.1, the search field stays clear of the device and update
+  badges in narrow windows; hover their icons to read the labels.
 - **Home** with Made for you, Recently played, your top artists and songs, and
   recommendations. Right-click playlist shortcuts and shelf cards for their actions.
 - **Artist pages** with popular songs, a filterable discography, and related

--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -113,6 +113,11 @@ Changing the option while the mini player is open replaces that window while
 playback continues. This setting is available on Windows; it does not change
 Linux panels or the macOS Dock.
 
+On `main`, after 0.7.1, the top bar reserves room for the device and update
+badges beside Search. In narrow windows those badges show only their icons.
+Hover to read the device name or available version; click to open the device
+picker or download page.
+
 ## Recent
 
 The queue panel's second tab combines Spotify's history with tracks played

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -4311,4 +4311,83 @@ mod tests {
         app.backend.shutdown();
         let _ = std::fs::remove_dir_all(root);
     }
+
+    /// The badges at the right end of the top bar sit in a right-to-left
+    /// layout, which does not wrap and does not clip: anything that does not
+    /// fit marches left over the search field. Draw the real bar and check
+    /// that it never does.
+    #[test]
+    fn the_top_bar_badges_never_cover_the_search_field() {
+        use egui::accesskit::Role;
+        // `widgets::search_field` insets its text this far from the pill's
+        // right edge, so the pill reaches past the rect the field reports.
+        const FIELD_RIGHT_INSET: f32 = 30.0;
+        let (ctx, mut app) = accessible_app("topbar-badges");
+        for update in [None, Some("9.9.9")] {
+            app.update = update.map(|version| crate::updates::Release {
+                version: version.into(),
+                url: "https://example.invalid/releases".into(),
+            });
+            // From the narrowest window the app allows up to a wide one,
+            // across the width where the badges give up their labels.
+            for width in [
+                760.0_f32, 800.0, 860.0, 900.0, 1000.0, 1080.0, 1200.0, 1280.0, 1440.0, 1600.0,
+                1920.0,
+            ] {
+                let mut draw = || {
+                    let mut output = ctx.run_ui(
+                        egui::RawInput {
+                            screen_rect: Some(egui::Rect::from_min_size(
+                                egui::Pos2::ZERO,
+                                egui::vec2(width, 620.0),
+                            )),
+                            ..Default::default()
+                        },
+                        |ui| app.frame_ui(ui),
+                    );
+                    output.textures_delta.clear();
+                    output
+                        .platform_output
+                        .accesskit_update
+                        .expect("screen-reader tree")
+                };
+                // The first frame settles the new window size.
+                draw();
+                let tree = draw();
+                let badge = |label: &str| {
+                    tree.nodes
+                        .iter()
+                        .find(|(_, node)| {
+                            node.role() == Role::Button
+                                && node.label().is_some_and(|name| name.starts_with(label))
+                        })
+                        .and_then(|(_, node)| node.bounds())
+                        .map(|bounds| bounds.x0 as f32)
+                };
+                let field = ctx
+                    .read_response(egui::Id::new("global-search"))
+                    .expect("the search field")
+                    .rect
+                    .right()
+                    + FIELD_RIGHT_INSET;
+                // Collapsed to an icon a badge keeps its label for a screen
+                // reader, so it is found at every width.
+                let device = badge("Playing on").expect("the device badge");
+                assert!(
+                    device >= field,
+                    "the device badge covers {} px of the search field at {width} px",
+                    field - device
+                );
+                if update.is_some() {
+                    let release = badge("Update to").expect("the update badge");
+                    assert!(
+                        release >= field,
+                        "the update badge covers {} px of the search field at {width} px",
+                        field - release
+                    );
+                }
+            }
+        }
+        app.backend.shutdown();
+    }
 }

--- a/src/ui/topbar.rs
+++ b/src/ui/topbar.rs
@@ -1,11 +1,125 @@
 //! Navigation arrows, search, and the account menu above every page.
 
-use egui::{Align, CornerRadius, Layout, Sense, Vec2, pos2, vec2};
+use std::sync::Arc;
+
+use egui::{Align, CornerRadius, Galley, Layout, Sense, Vec2, pos2, vec2};
 
 use crate::api::models::pick_image;
 use crate::app::App;
 use crate::model::{Action, Page};
 use crate::theme::{self, Icon, Palette};
+
+/// The gap the bar keeps between everything it lays out.
+const ITEM_SPACING: f32 = 8.0;
+/// The account avatar, and the icon in each of the three buttons beside it.
+const AVATAR_SIZE: f32 = 36.0;
+const ICON_BUTTON_ICON: f32 = 19.0;
+/// `theme::icon_button` pads its icon by 12 px.
+const ICON_BUTTON_SIZE: f32 = ICON_BUTTON_ICON + 12.0;
+const SPINNER_SIZE: f32 = 15.0;
+/// A badge is as tall as its text plus this, and as wide as its text plus
+/// the padding its own label needs.
+const BADGE_PADDING_Y: f32 = 12.0;
+const DEVICE_BADGE_PADDING: f32 = 28.0;
+/// The text starts 24 px in; leave 8 px after it to match the space before
+/// the icon.
+const UPDATE_BADGE_PADDING: f32 = 32.0;
+/// The width the search field aims for, the most it ever takes, and the
+/// least it shrinks to before the badges give up their labels instead.
+const SEARCH_IDEAL: f32 = 200.0;
+const SEARCH_MAX: f32 = 440.0;
+const SEARCH_FLOOR: f32 = 130.0;
+/// Everything at the right end whose width never changes: the page padding,
+/// the avatar, the gap the account menu leaves, the three icon buttons, and
+/// the spacing between them. The cursor stops at the left edge of the last
+/// button, so this counts three gaps, not four. The spinner and the badges
+/// are measured on top of it because they come and go.
+const RIGHT_CONTROLS_WIDTH: f32 =
+    super::widgets::PAGE_PADDING + AVATAR_SIZE + 4.0 + 3.0 * ICON_BUTTON_SIZE + 3.0 * ITEM_SPACING;
+
+/// How the top bar divides itself for one window width.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TopbarFit {
+    /// How wide the search field may be.
+    search: f32,
+    /// Whether the badges have the room to spell themselves out.
+    labels: bool,
+}
+
+/// Divide the bar. The search field keeps the half it has always had, but
+/// never so much that the right end has to reach over it, and the badges
+/// fall back to their icons before the field shrinks past reading size.
+///
+/// `labelled` and `icons` are what the badges ask for with and without their
+/// text, each already including the spacing that precedes it.
+fn topbar_fit(room: f32, controls: f32, labelled: f32, icons: f32) -> TopbarFit {
+    // SEARCH_IDEAL is above SEARCH_FLOOR, so the clamp below is well ordered.
+    let ideal = (room * 0.5).clamp(SEARCH_IDEAL, SEARCH_MAX);
+    let labels = room - controls - labelled >= SEARCH_FLOOR;
+    let badges = if labels { labelled } else { icons };
+    TopbarFit {
+        search: (room - controls - badges).clamp(SEARCH_FLOOR, ideal),
+        labels,
+    }
+}
+
+/// What a badge asks of the bar, including the spacing before it.
+fn badge_width(galley: Option<&Arc<Galley>>, padding: f32, labels: bool) -> f32 {
+    galley.map_or(0.0, |galley| {
+        ITEM_SPACING
+            + if labels {
+                galley.size().x + padding
+            } else {
+                galley.size().y + BADGE_PADDING_Y
+            }
+    })
+}
+
+/// A pill at the right end of the bar: an icon with its label, or the icon
+/// alone once the bar is too narrow to spare the room for words.
+fn badge(
+    ui: &mut egui::Ui,
+    palette: &Palette,
+    icon: Icon,
+    galley: Arc<Galley>,
+    padding: f32,
+    labels: bool,
+) -> egui::Response {
+    let height = galley.size().y + BADGE_PADDING_Y;
+    let size = if labels {
+        vec2(galley.size().x + padding, height)
+    } else {
+        Vec2::splat(height)
+    };
+    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+    // Collapsed to its icon the badge has no text on screen, so its label
+    // reaches a screen reader as the widget's name.
+    response.widget_info(|| {
+        egui::WidgetInfo::labeled(egui::WidgetType::Button, ui.is_enabled(), galley.text())
+    });
+    ui.painter().rect_filled(
+        rect,
+        CornerRadius::same(14),
+        palette.accent.gamma_multiply(0.16),
+    );
+    let icon_center = if labels {
+        pos2(rect.left() + 14.0, rect.center().y)
+    } else {
+        rect.center()
+    };
+    icon.image(palette.accent, 13.0).paint_at(
+        ui,
+        egui::Rect::from_center_size(icon_center, Vec2::splat(13.0)),
+    );
+    if labels {
+        ui.painter().galley(
+            pos2(rect.left() + 24.0, rect.center().y - galley.size().y / 2.0),
+            galley,
+            palette.accent,
+        );
+    }
+    response.on_hover_cursor(egui::CursorIcon::PointingHand)
+}
 
 fn nav_button(
     ui: &mut egui::Ui,
@@ -71,7 +185,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         Layout::left_to_right(Align::Center),
         |ui| {
             ui.add_space(super::widgets::PAGE_PADDING);
-            ui.spacing_mut().item_spacing.x = 8.0;
+            ui.spacing_mut().item_spacing.x = ITEM_SPACING;
             if !app.settings.sidebar_visible {
                 if nav_button(
                     ui,
@@ -107,8 +221,44 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             }
             ui.add_space(8.0);
 
+            // The badges sit at the right end but grow with their text, so
+            // measure them here, before the search field takes its share.
+            let device_galley = app.now_playing().filter(|now| !now.local).map(|now| {
+                let label = format!(
+                    "Playing on {}",
+                    now.device_name.unwrap_or_else(|| "another device".into())
+                );
+                ui.painter()
+                    .layout_no_wrap(label, theme::medium(12.5), palette.accent)
+            });
+            let update = app.update.clone();
+            let update_galley = update.as_ref().map(|update| {
+                ui.painter().layout_no_wrap(
+                    format!("Update to {}", update.version),
+                    theme::medium(12.5),
+                    palette.accent,
+                )
+            });
+            // Ask once, so the bar reserves room for exactly the spinner it
+            // then draws.
+            let busy = app
+                .backend
+                .activity()
+                .busy(std::time::Duration::from_millis(1000));
+            let badges = |labels: bool| {
+                badge_width(device_galley.as_ref(), DEVICE_BADGE_PADDING, labels)
+                    + badge_width(update_galley.as_ref(), UPDATE_BADGE_PADDING, labels)
+            };
+            let controls = RIGHT_CONTROLS_WIDTH
+                + if busy {
+                    SPINNER_SIZE + ITEM_SPACING
+                } else {
+                    0.0
+                };
+
             let search_room = (ui.available_width() - window_controls.topbar_width).max(0.0);
-            let search_width = (search_room * 0.5).clamp(200.0, 440.0);
+            let fit = topbar_fit(search_room, controls, badges(true), badges(false));
+            let search_width = fit.search;
             let id = egui::Id::new("global-search");
             let before = app.search.query.clone();
             let response = super::widgets::search_field(
@@ -154,7 +304,8 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         )
                     })
                     .unwrap_or_default();
-                let (rect, response) = ui.allocate_exact_size(Vec2::splat(36.0), Sense::click());
+                let (rect, response) =
+                    ui.allocate_exact_size(Vec2::splat(AVATAR_SIZE), Sense::click());
                 if ui.is_rect_visible(rect) {
                     let fill = if response.hovered() {
                         palette.surface_hover
@@ -241,7 +392,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 if theme::icon_button(
                     ui,
                     Icon::Settings,
-                    19.0,
+                    ICON_BUTTON_ICON,
                     palette.secondary,
                     palette.text,
                     "Settings",
@@ -253,7 +404,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 if theme::icon_button(
                     ui,
                     Icon::AudioLines,
-                    19.0,
+                    ICON_BUTTON_ICON,
                     if app.settings.milkdrop_open {
                         palette.accent
                     } else {
@@ -272,7 +423,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 if theme::icon_button(
                     ui,
                     Icon::Shrink,
-                    19.0,
+                    ICON_BUTTON_ICON,
                     palette.secondary,
                     palette.text,
                     super::keys::platform_shortcut(
@@ -286,89 +437,50 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                 }
                 // A quiet spinner once the app has been talking to Spotify for a
                 // while, long enough that fast requests never flash it.
-                if app
-                    .backend
-                    .activity()
-                    .busy(std::time::Duration::from_millis(1000))
-                {
-                    theme::spinner(ui, 15.0, palette.secondary)
+                if busy {
+                    theme::spinner(ui, SPINNER_SIZE, palette.secondary)
                         .on_hover_text("Waiting for Spotify…");
                 }
                 // Where playback is.
-                if let Some(now) = app.now_playing()
-                    && !now.local
-                {
-                    let label = format!(
-                        "Playing on {}",
-                        now.device_name.unwrap_or_else(|| "another device".into())
-                    );
-                    let galley =
-                        ui.painter()
-                            .layout_no_wrap(label, theme::medium(12.5), palette.accent);
-                    let size = galley.size() + vec2(28.0, 12.0);
-                    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
-                    ui.painter().rect_filled(
-                        rect,
-                        CornerRadius::same(14),
-                        palette.accent.gamma_multiply(0.16),
-                    );
-                    let icon_rect = egui::Rect::from_center_size(
-                        pos2(rect.left() + 14.0, rect.center().y),
-                        Vec2::splat(13.0),
-                    );
-                    Icon::Speaker
-                        .image(palette.accent, 13.0)
-                        .paint_at(ui, icon_rect);
-                    ui.painter().galley(
-                        pos2(rect.left() + 24.0, rect.center().y - galley.size().y / 2.0),
+                if let Some(galley) = device_galley {
+                    let device = galley.text().to_owned();
+                    let response = badge(
+                        ui,
+                        &palette,
+                        Icon::Speaker,
                         galley,
-                        palette.accent,
+                        DEVICE_BADGE_PADDING,
+                        fit.labels,
                     );
-                    if response
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
-                    {
+                    // Without its label the badge still has to say where
+                    // playback went.
+                    let response = if fit.labels {
+                        response
+                    } else {
+                        response.on_hover_text(device)
+                    };
+                    if response.clicked() {
                         app.actions.push(Action::ToggleDevicesPopup);
                     }
                 }
                 // A newer release. Most people never visit a releases page,
                 // so the app says so, quietly, until they do.
-                if let Some(update) = app.update.clone() {
-                    let label = format!("Update to {}", update.version);
-                    let galley =
-                        ui.painter()
-                            .layout_no_wrap(label, theme::medium(12.5), palette.accent);
-                    // The text starts 24 px in; leave 8 px after it to match
-                    // the space before the icon.
-                    let size = galley.size() + vec2(32.0, 12.0);
-                    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
-                    ui.painter().rect_filled(
-                        rect,
-                        CornerRadius::same(14),
-                        palette.accent.gamma_multiply(0.16),
-                    );
-                    let icon_rect = egui::Rect::from_center_size(
-                        pos2(rect.left() + 14.0, rect.center().y),
-                        Vec2::splat(13.0),
-                    );
-                    Icon::Info
-                        .image(palette.accent, 13.0)
-                        .paint_at(ui, icon_rect);
-                    ui.painter().galley(
-                        pos2(rect.left() + 24.0, rect.center().y - galley.size().y / 2.0),
+                if let (Some(galley), Some(update)) = (update_galley, update)
+                    && badge(
+                        ui,
+                        &palette,
+                        Icon::Info,
                         galley,
-                        palette.accent,
-                    );
-                    if response
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text(format!(
-                            "Version {} is available. Open the download page.",
-                            update.version
-                        ))
-                        .clicked()
-                    {
-                        app.actions.push(Action::OpenUrl(update.url));
-                    }
+                        UPDATE_BADGE_PADDING,
+                        fit.labels,
+                    )
+                    .on_hover_text(format!(
+                        "Version {} is available. Open the download page.",
+                        update.version
+                    ))
+                    .clicked()
+                {
+                    app.actions.push(Action::OpenUrl(update.url));
                 }
             });
         },
@@ -380,5 +492,76 @@ fn capitalize(text: &str) -> String {
     match chars.next() {
         Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
         None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod topbar_fit_tests {
+    use super::*;
+
+    // What the badges measure on a bar showing "Playing on MacBook de Luis"
+    // and "Update to 0.7.1", each including the spacing before it.
+    const DEVICE: f32 = ITEM_SPACING + 176.0;
+    const UPDATE: f32 = ITEM_SPACING + 152.0;
+    // Collapsed, a badge is a square chip as tall as its text.
+    const CHIP: f32 = ITEM_SPACING + 15.0 + BADGE_PADDING_Y;
+
+    /// The narrowest bar the app can produce: a 760 px window, its sidebar,
+    /// and the navigation buttons all taken out.
+    const NARROWEST_BAR: f32 = 398.0;
+
+    fn right_end(room: f32, labelled: f32, icons: f32) -> f32 {
+        let fit = topbar_fit(room, RIGHT_CONTROLS_WIDTH, labelled, icons);
+        let badges = if fit.labels { labelled } else { icons };
+        RIGHT_CONTROLS_WIDTH + badges - (room - fit.search)
+    }
+
+    #[test]
+    fn a_wide_bar_keeps_the_field_it_always_had() {
+        let fit = topbar_fit(2000.0, RIGHT_CONTROLS_WIDTH, DEVICE + UPDATE, CHIP * 2.0);
+        assert_eq!(fit.search, SEARCH_MAX);
+        assert!(fit.labels);
+        // Half the room, as before, while half still fits.
+        let fit = topbar_fit(700.0, RIGHT_CONTROLS_WIDTH, 0.0, 0.0);
+        assert_eq!(fit.search, 350.0);
+    }
+
+    #[test]
+    fn the_right_end_never_reaches_over_the_search_field() {
+        let mut room = NARROWEST_BAR;
+        while room <= 2400.0 {
+            for (labelled, icons) in [
+                (0.0, 0.0),
+                (DEVICE, CHIP),
+                (UPDATE, CHIP),
+                (DEVICE + UPDATE, CHIP * 2.0),
+            ] {
+                let over = right_end(room, labelled, icons);
+                assert!(
+                    over <= 0.0,
+                    "badges overlap the field by {over} px on a {room} px bar"
+                );
+            }
+            room += 1.0;
+        }
+    }
+
+    #[test]
+    fn a_narrow_bar_trades_the_badge_labels_for_their_icons() {
+        assert!(topbar_fit(1400.0, RIGHT_CONTROLS_WIDTH, DEVICE, CHIP).labels);
+        // The 1080 px window of the report that started this.
+        assert!(topbar_fit(952.0, RIGHT_CONTROLS_WIDTH, DEVICE + UPDATE, CHIP * 2.0).labels);
+        assert!(!topbar_fit(NARROWEST_BAR, RIGHT_CONTROLS_WIDTH, DEVICE, CHIP).labels);
+    }
+
+    #[test]
+    fn the_field_stays_readable_however_tight_the_bar_gets() {
+        let mut room = NARROWEST_BAR;
+        while room <= 2400.0 {
+            let fit = topbar_fit(room, RIGHT_CONTROLS_WIDTH, DEVICE + UPDATE, CHIP * 2.0);
+            assert!(fit.search >= SEARCH_FLOOR, "field is {} px", fit.search);
+            assert!(fit.search <= SEARCH_MAX);
+            room += 1.0;
+        }
     }
 }


### PR DESCRIPTION
Fixes #378.

## Why

The badges at the right end of the top bar sit in a right-to-left layout.
That layout does not wrap and does not clip, so anything that does not fit
just keeps going left, over the search field. Meanwhile the field always took
half the bar, no matter what the right end needed.

So on a narrow window a long device name, or the update badge next to it,
ends up sitting on top of the search box. #378 shows it with the update badge
at 1080 px. The "Playing on <device>" badge does the same thing any time the
window is not full screen.

## What changed

`src/ui/topbar.rs` now measures the badges first and gives the search field
what is actually left over.

- The field never grows past the half it already had, so wide windows are
  untouched. The 1440x900 renders are byte identical before and after.
- When there is no room for both, the badges drop to just their icon instead
  of squeezing the field. A collapsed badge keeps its name in the tooltip and
  in the screen-reader tree, which the labelled version never exposed at all.
- The device and update badges were near copies of each other. They share one
  `badge` helper now, so the fallback only had to be written once.

Nothing changed beyond the layout, so there is no documentation to update.

## Verification

Every CI check from `CONTRIBUTING.md` passes locally on macOS. I skipped the
Jekyll build since no docs changed, and I have not run this on Windows or
Linux, though nothing in it is platform specific.

New tests:

- Four unit tests for `topbar_fit`, sweeping every bar width from 398 px to
  2400 px against each combination of badges.
- A headless render test in `src/demo.rs` that draws the real top bar from
  760 px to 1920 px and compares the badge and search field rectangles from
  the accessibility tree. On the old code it fails with
  `the device badge covers 181.28125 px of the search field at 760 px`.

### 900x620: the badge used to cover the field, and now sits beside it

|  | Before | After |
| --- | --- | --- |
| Dark | ![Dark 900 px window, the device badge covering the search box](https://github.com/user-attachments/assets/f5b3b004-30f2-4ded-90ab-77bc80f97b04) | ![Dark 900 px window, the search box clear and the badge beside it](https://github.com/user-attachments/assets/0f983e60-bfdc-4526-82bf-374dc2bc3a5a) |
| Light | ![Light 900 px window, the device badge covering the search box](https://github.com/user-attachments/assets/172d6932-0ffc-4c93-ad7c-8fafd92115c2) | ![Light 900 px window, the search box clear and the badge beside it](https://github.com/user-attachments/assets/4837ee7a-f997-4dc7-8be2-d71df1fd4eec) |

### 760x620, the narrowest window allowed: the badge falls back to its icon

|  | Before | After |
| --- | --- | --- |
| Dark | ![Dark 760 px window, the device badge covering the search box](https://github.com/user-attachments/assets/b00fe298-c9c8-478e-9655-f092a9bbee51) | ![Dark 760 px window, the badge collapsed to a speaker icon](https://github.com/user-attachments/assets/0993e490-f8a7-40a5-8b9c-e8748e15252a) |
| Light | ![Light 760 px window, the device badge covering the search box](https://github.com/user-attachments/assets/3575cfc8-99f3-4112-84e0-2290feebd7a7) | ![Light 760 px window, the badge collapsed to a speaker icon](https://github.com/user-attachments/assets/f399c0ca-11ef-4b2b-b8ee-59f86827220e) |

### 1440x900: nothing moves, the renders are byte identical before and after

| Dark | Light |
| --- | --- |
| ![Dark 1440 px window, the top bar unchanged](https://github.com/user-attachments/assets/fb68f5a2-e676-4609-953a-ed0cd4b7634b) | ![Light 1440 px window, the top bar unchanged](https://github.com/user-attachments/assets/bdb6bf40-b4e6-45d4-b3a8-f90f8276fbb7) |

One more thing: this touches the same lines of `topbar.rs` as #383, so the two
will conflict. Happy to rebase onto whichever lands first.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
