### PR TITLE
Play a Library sidebar row on double-click

### DIFF
--- a/docs/_guide/using-fastpotify.md
+++ b/docs/_guide/using-fastpotify.md
@@ -33,6 +33,13 @@ of the playlist scrolls to positions beyond the visible rows.
 The Library sidebar also scrolls near its edges when you drag a song toward a
 playlist or reorder its entries. Only the list under the pointer scrolls.
 
+## Playing from the sidebar
+
+Double-click a playlist, Liked Songs, album, artist, or podcast row in the
+Library sidebar to start playing it. A single click still opens the row's page.
+Pointing at a row's cover art also shows a play button, but only when the
+sidebar is not in compact mode.
+
 ## Keyboard and screen readers
 
 The main window provides screen-reader names for playback controls, library

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -2018,6 +2018,33 @@ mod tests {
         ]
     }
 
+    /// The painted rect of a sidebar label, for pointer tests against the
+    /// sidebar's private rows.
+    fn sidebar_text(painted: &[(String, egui::Rect)], label: &str) -> egui::Rect {
+        painted
+            .iter()
+            .find(|(text, _)| text == label)
+            .map(|(_, rect)| *rect)
+            .unwrap_or_else(|| panic!("missing sidebar text {label:?}"))
+    }
+
+    fn double_click(pos: egui::Pos2) -> [Vec<egui::Event>; 2] {
+        [
+            pointer_click(pos, egui::PointerButton::Primary),
+            pointer_click(pos, egui::PointerButton::Primary),
+        ]
+    }
+
+    fn played_contexts(app: &App) -> Vec<String> {
+        app.actions
+            .iter()
+            .filter_map(|action| match action {
+                Action::PlayContext { uri, .. } => Some(uri.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn search_top_result_opens_the_menu_for_its_item() {
         for kind in ["track", "artist", "album", "playlist", "show"] {
@@ -3138,6 +3165,121 @@ mod tests {
         assert!(dropped, "no sweep position landed on an owned playlist row");
         app.backend.shutdown();
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Double-clicking a playable Library row plays its context, in both the
+    /// normal and compact sidebar modes. The first click still opens the page.
+    #[test]
+    fn double_clicking_a_sidebar_row_plays_its_context() {
+        for compact in [false, true] {
+            let (ctx, mut app) = accessible_app(&format!("sidebar-double-click-{compact}"));
+            app.settings.sidebar_compact = compact;
+            let view = crate::ui::sidebar::show;
+            view_frame(&ctx, &mut app, vec![], view);
+            let painted = view_frame(&ctx, &mut app, vec![], view);
+            let name = sidebar_text(&painted, "Sunday morning").center();
+            app.actions.clear();
+            let [first, second] = double_click(name);
+            view_frame(&ctx, &mut app, first, view);
+            view_frame(&ctx, &mut app, second, view);
+            assert_eq!(played_contexts(&app), ["spotify:playlist:pl2"]);
+            assert!(
+                app.actions.iter().any(
+                    |action| matches!(action, Action::Open(Page::Playlist(id)) if id == "pl2")
+                ),
+                "double click must still open the page"
+            );
+            app.backend.shutdown();
+        }
+    }
+
+    /// A single Library row click keeps navigating and never starts playback.
+    #[test]
+    fn single_clicking_a_sidebar_row_only_navigates() {
+        let (ctx, mut app) = accessible_app("sidebar-single-click");
+        let view = crate::ui::sidebar::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let painted = view_frame(&ctx, &mut app, vec![], view);
+        let name = sidebar_text(&painted, "Sunday morning").center();
+        app.actions.clear();
+        view_frame(
+            &ctx,
+            &mut app,
+            pointer_click(name, egui::PointerButton::Primary),
+            view,
+        );
+        assert!(played_contexts(&app).is_empty());
+        assert!(
+            app.actions
+                .iter()
+                .any(|action| matches!(action, Action::Open(Page::Playlist(id)) if id == "pl2"))
+        );
+        app.backend.shutdown();
+    }
+
+    #[test]
+    fn double_clicking_a_sidebar_liked_row_plays_the_collection() {
+        let (ctx, mut app) = accessible_app("sidebar-double-click-liked");
+        let view = crate::ui::sidebar::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let painted = view_frame(&ctx, &mut app, vec![], view);
+        let name = sidebar_text(&painted, "Liked Songs").center();
+        app.actions.clear();
+        let [first, second] = double_click(name);
+        view_frame(&ctx, &mut app, first, view);
+        view_frame(&ctx, &mut app, second, view);
+        assert_eq!(played_contexts(&app), ["spotify:user:demo:collection"]);
+        app.backend.shutdown();
+    }
+
+    #[test]
+    fn double_clicking_a_sidebar_folder_plays_nothing() {
+        use crate::player::RootlistEntry;
+        let (ctx, mut app) = accessible_app("sidebar-double-click-folder");
+        app.rootlist = vec![
+            RootlistEntry::FolderStart {
+                id: "f1".into(),
+                name: "Focus".into(),
+            },
+            RootlistEntry::Playlist("spotify:playlist:pl1".into()),
+            RootlistEntry::Playlist("spotify:playlist:pl2".into()),
+            RootlistEntry::FolderEnd,
+        ];
+        let view = crate::ui::sidebar::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let painted = view_frame(&ctx, &mut app, vec![], view);
+        let name = sidebar_text(&painted, "Focus").center();
+        app.actions.clear();
+        let [first, second] = double_click(name);
+        view_frame(&ctx, &mut app, first, view);
+        view_frame(&ctx, &mut app, second, view);
+        assert!(played_contexts(&app).is_empty(), "folders must not play");
+        app.backend.shutdown();
+    }
+
+    /// The cover play button sits on top of its row. A double click on it
+    /// sends one play command, not one for each click plus the row's.
+    #[test]
+    fn double_clicking_a_sidebar_cover_plays_once() {
+        let (ctx, mut app) = accessible_app("sidebar-double-click-cover");
+        let view = crate::ui::sidebar::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let painted = view_frame(&ctx, &mut app, vec![], view);
+        let name = sidebar_text(&painted, "Sunday morning");
+        // The cover is the 44 point square centered 34 points left of the
+        // name and on the row's centre, nine points below the name line.
+        let cover = egui::pos2(name.left() - 34.0, name.center().y + 9.0);
+        app.actions.clear();
+        let [first, second] = double_click(cover);
+        view_frame(&ctx, &mut app, first, view);
+        assert_eq!(played_contexts(&app), ["spotify:playlist:pl2"]);
+        view_frame(&ctx, &mut app, second, view);
+        assert_eq!(
+            played_contexts(&app),
+            ["spotify:playlist:pl2"],
+            "the second click must not play again"
+        );
+        app.backend.shutdown();
     }
 
     /// The cover and title in the bottom-left player are a song source, not

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -43,6 +43,21 @@ impl Entry {
     }
 }
 
+/// The context a library row plays, matching the cover play button and the
+/// right-click menu. Liked Songs has no URI of its own and plays the
+/// account's collection instead.
+fn entry_play_uri(app: &App, entry: &Entry) -> Option<String> {
+    if entry.liked {
+        app.user
+            .as_ref()
+            .map(|user| format!("spotify:user:{}:collection", user.id))
+    } else if entry.uri.is_empty() {
+        None
+    } else {
+        Some(entry.uri.clone())
+    }
+}
+
 fn liked_entry(app: &App) -> Entry {
     Entry {
         image: None,
@@ -945,6 +960,9 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                     0.12,
                 );
                 let rect = rect.translate(vec2(0.0, shift));
+                // Set when the cover play button takes a click, so a double
+                // click on it does not also play from the row.
+                let mut cover_took_click = false;
                 if ui.is_rect_visible(rect) {
                     if active {
                         ui.painter()
@@ -1117,15 +1135,15 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                                 play.clone().on_hover_cursor(egui::CursorIcon::PointingHand);
                             }
                         }
-                        if play_response.is_some_and(|play| play.clicked()) {
-                            let uri = if entry.liked {
-                                app.user
-                                    .as_ref()
-                                    .map(|user| format!("spotify:user:{}:collection", user.id))
-                            } else {
-                                Some(entry.uri.clone())
-                            };
-                            if let Some(uri) = uri {
+                        if let Some(play) = &play_response
+                            && play.clicked()
+                        {
+                            cover_took_click = true;
+                            // The first click of a double click plays; the
+                            // second must not play again.
+                            if !play.double_clicked()
+                                && let Some(uri) = entry_play_uri(app, entry)
+                            {
                                 app.actions.push(Action::PlayContext {
                                     uri,
                                     offset_uri: None,
@@ -1190,6 +1208,19 @@ fn contents(app: &mut App, ui: &mut egui::Ui) {
                     } else {
                         app.actions.push(Action::Open(entry.page.clone()));
                     }
+                }
+                // A double click plays the row's context. Folders only
+                // collapse, and the cover button handled its own click.
+                if response.double_clicked()
+                    && entry.folder.is_none()
+                    && !cover_took_click
+                    && let Some(uri) = entry_play_uri(app, entry)
+                {
+                    app.actions.push(Action::PlayContext {
+                        uri,
+                        offset_uri: None,
+                        offset_index: None,
+                    });
                 }
                 if !entry.uri.is_empty() {
                     let owned_playlist = entry


### PR DESCRIPTION
This implements #385, double-clicking on a playlist entry now starts playing the playlist. Double-clicking on the play icon/cover starts playing once.