### PR TITLE
Add local JSON themes and an appearance picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ on Linux). They include the Connect device name, bitrate, normalisation,
 autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
 from artwork, and the mini player's skin and size.
+Custom JSON palettes go in a `themes` folder beside `settings.json` and appear
+in the Theme picker after restarting. See [custom themes](docs/_reference/settings-and-files.md#custom-themes).
 Playback settings apply when you press **Apply and restart playback**.
 You can also check for a new release from Settings. On macOS, the same command
 is in the application menu.

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -145,7 +145,8 @@ main fields are:
 | `gapless` | `true` | Gapless playback |
 | `audio_backend` | platform | `pulseaudio` or `rodio` on Linux |
 | `audio_cache_mb` | `1024` | On-disk audio cache budget |
-| `theme` | `dark` | `dark`, `light`, or `system` |
+| `theme` | `dark` | `dark`, `light`, or `system`; fallback for unavailable custom themes |
+| `custom_theme` | `null` | Selected JSON filename from the `themes` folder |
 | `accent_from_art` | `true` | Tint pages with album art |
 | `library_sort` | `{}` | Per-section Library order overrides, after 0.7.1: `library`, `recently_played`, `name`, `recently_added`, `local`, or `spotify`, where supported |
 | `sidebar_order` | `[]` | Saved local playlist arrangement, including an unpinned Liked Songs, retained when another sort is selected |
@@ -224,3 +225,38 @@ cargo run --release --features demo -- \
 The image uses the current window size. `--demo-size WIDTHxHEIGHT` sets that
 size for a shot (for example `760x800` or `1240x800`). `--demo-shot-delay <MS>`
 sets how long to wait for cover art before taking it.
+
+## Custom themes
+
+Create a `themes` folder beside `settings.json` and put JSON files in it.
+Restart Fastpotify, then select the filename under **Settings → Appearance → Theme**.
+The picker includes the built-in Dark, Light, and Follow system choices.
+Choosing a built-in theme clears the custom selection.
+
+For example, `themes/gruvbox.json`:
+
+```json
+{
+  "base": "dark",
+  "colors": {
+    "window": "#282828",
+    "panel": "#1d2021",
+    "surface": "#32302f",
+    "text": "#ebdbb2",
+    "accent": "#b8bb26"
+  }
+}
+```
+
+`base` is `dark` (the default) or `light`. Omitted colors inherit that palette.
+Supported colors are `window`, `panel`, `surface`, `surface_hover`,
+`surface_active`, `outline`, `text`, `secondary`, `dim`, `accent`,
+`accent_hover`, `on_accent`, `danger`, `warning`, `overlay`, and `shadow`.
+Values must be `#RRGGBB` or `#RRGGBBAA`.
+
+Files are read at startup. Restart after adding or editing a theme.
+Invalid files are skipped with a warning in the log. If the selected file
+is removed or invalid, the built-in theme applies without resetting other
+preferences. Album-art tinting remains an independent setting; turn it off
+for fixed colors throughout. These palettes apply to the main window;
+Winamp skins remain separate.

--- a/src/app.rs
+++ b/src/app.rs
@@ -206,6 +206,7 @@ pub struct App {
     #[cfg(any(test, feature = "demo"))]
     pub demo_windows_controls: bool,
     applied_dark: Option<bool>,
+    pub custom_themes: Vec<theme::CustomTheme>,
 
     pub auth: AuthStatus,
     pub user: Option<User>,
@@ -509,7 +510,9 @@ impl App {
             .filter(|page| !matches!(page, Page::Settings | Page::Queue))
             .unwrap_or(Page::Home);
 
+        let custom_themes = theme::load_custom_themes(&dirs.config.join("themes"));
         let mut app = Self {
+            custom_themes,
             dirs,
             settings,
             settings_dirty: false,
@@ -2332,12 +2335,20 @@ impl App {
 
     fn apply_theme(&mut self, ctx: &egui::Context) {
         let dark = ctx.theme() == egui::Theme::Dark;
-        if self.applied_dark != Some(dark) {
-            self.palette = if dark {
-                Palette::dark()
-            } else {
-                Palette::light()
-            };
+        let palette = self
+            .custom_themes
+            .iter()
+            .find(|theme| Some(&theme.filename) == self.settings.custom_theme.as_ref())
+            .map(|theme| theme.palette)
+            .unwrap_or_else(|| {
+                if dark {
+                    Palette::dark()
+                } else {
+                    Palette::light()
+                }
+            });
+        if self.applied_dark != Some(dark) || self.palette != palette {
+            self.palette = palette;
             theme::apply(ctx, &self.palette);
             self.applied_dark = Some(dark);
             self.accents.clear();
@@ -9024,6 +9035,31 @@ mod tests {
                 tray: false,
             },
         )
+    }
+
+    #[test]
+    fn custom_theme_switches_immediately_and_missing_files_use_the_builtin() {
+        let mut app = test_app("custom-theme");
+        let ctx = egui::Context::default();
+        ctx.set_theme(egui::ThemePreference::Dark);
+        let mut palette = Palette::light();
+        palette.accent = egui::Color32::RED;
+        app.custom_themes.push(theme::CustomTheme {
+            filename: "local.json".into(),
+            palette,
+        });
+        app.settings.custom_theme = Some("local.json".into());
+        app.apply_theme(&ctx);
+        assert_eq!(app.palette, palette);
+        assert_eq!(ctx.global_style().visuals.panel_fill, palette.panel);
+        app.settings.custom_theme = Some("missing.json".into());
+        app.apply_theme(&ctx);
+        assert_eq!(app.palette, Palette::dark());
+        app.settings.custom_theme = Some("local.json".into());
+        app.apply_theme(&ctx);
+        app.settings.custom_theme = None;
+        app.apply_theme(&ctx);
+        assert_eq!(app.palette, Palette::dark());
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -101,6 +101,8 @@ pub struct Settings {
     pub audio_cache: bool,
     pub audio_cache_mb: u64,
     pub theme: ThemeChoice,
+    /// Filename in the local themes directory; absent or unavailable uses `theme`.
+    pub custom_theme: Option<String>,
     /// Tint the interface with the colour of the playing album's art.
     pub accent_from_art: bool,
     /// Last local volume, 0..=65535.
@@ -210,6 +212,7 @@ impl Default for Settings {
             audio_cache: true,
             audio_cache_mb: 1024,
             theme: ThemeChoice::Dark,
+            custom_theme: None,
             accent_from_art: true,
             volume: (u16::MAX as u32 * 70 / 100) as u16,
             sidebar_visible: true,
@@ -328,6 +331,16 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::Settings;
+
+    #[test]
+    fn custom_theme_is_optional_and_round_trips() {
+        let mut settings: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(settings.custom_theme, None);
+        settings.custom_theme = Some("gruvbox.json".into());
+        let json = serde_json::to_string(&settings).unwrap();
+        let restored: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, settings);
+    }
 
     #[test]
     fn older_settings_keep_the_sidebar_visible() {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -93,6 +93,119 @@ impl Palette {
     }
 }
 
+/// A local JSON palette, identified by its filename in the themes directory.
+#[derive(Clone, Debug)]
+pub struct CustomTheme {
+    pub filename: String,
+    pub palette: Palette,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ThemeBase {
+    #[default]
+    Dark,
+    Light,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ThemeFile {
+    #[serde(default)]
+    base: ThemeBase,
+    #[serde(default)]
+    colors: std::collections::BTreeMap<String, String>,
+}
+
+fn parse_palette(text: &str) -> Result<Palette, String> {
+    let file: ThemeFile = serde_json::from_str(text).map_err(|error| error.to_string())?;
+    let mut palette = match file.base {
+        ThemeBase::Dark => Palette::dark(),
+        ThemeBase::Light => Palette::light(),
+    };
+    for (name, value) in file.colors {
+        let hex = value
+            .strip_prefix('#')
+            .ok_or_else(|| format!("{name}: expected #RRGGBB or #RRGGBBAA"))?;
+        if !matches!(hex.len(), 6 | 8) || !hex.bytes().all(|c| c.is_ascii_hexdigit()) {
+            return Err(format!("{name}: expected #RRGGBB or #RRGGBBAA"));
+        }
+        let color = u32::from_str_radix(hex, 16).map_err(|error| error.to_string())?;
+        let color = if hex.len() == 6 {
+            Color32::from_rgb((color >> 16) as u8, (color >> 8) as u8, color as u8)
+        } else {
+            Color32::from_rgba_unmultiplied(
+                (color >> 24) as u8,
+                (color >> 16) as u8,
+                (color >> 8) as u8,
+                color as u8,
+            )
+        };
+        match name.as_str() {
+            "window" => palette.window = color,
+            "panel" => palette.panel = color,
+            "surface" => palette.surface = color,
+            "surface_hover" => palette.surface_hover = color,
+            "surface_active" => palette.surface_active = color,
+            "outline" => palette.outline = color,
+            "text" => palette.text = color,
+            "secondary" => palette.secondary = color,
+            "dim" => palette.dim = color,
+            "accent" => palette.accent = color,
+            "accent_hover" => palette.accent_hover = color,
+            "on_accent" => palette.on_accent = color,
+            "danger" => palette.danger = color,
+            "warning" => palette.warning = color,
+            "overlay" => palette.overlay = color,
+            "shadow" => palette.shadow = color,
+            _ => return Err(format!("unknown color: {name}")),
+        }
+    }
+    Ok(palette)
+}
+
+/// Read once at startup, never during a frame. Invalid themes stay out of the picker.
+pub fn load_custom_themes(dir: &std::path::Path) -> Vec<CustomTheme> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                log::warn!("unable to read themes at {}: {error}", dir.display());
+            }
+            return Vec::new();
+        }
+    };
+    let mut themes = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                log::warn!("unable to read theme entry: {error}");
+                continue;
+            }
+        };
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        match std::fs::read_to_string(&path)
+            .map_err(|error| error.to_string())
+            .and_then(|text| parse_palette(&text))
+        {
+            Ok(palette) => themes.push(CustomTheme {
+                filename: filename.to_owned(),
+                palette,
+            }),
+            Err(error) => log::warn!("unable to load theme {}: {error}", path.display()),
+        }
+    }
+    themes.sort_by(|a, b| a.filename.cmp(&b.filename));
+    themes
+}
+
 pub const RADIUS: u8 = 8;
 pub const RADIUS_SMALL: u8 = 4;
 pub const ROW_HEIGHT: f32 = 56.0;
@@ -894,5 +1007,61 @@ mod tests {
             assert!(galley.rows[0].glyphs.len() >= 5);
         });
         output.textures_delta.clear();
+    }
+}
+
+#[cfg(test)]
+mod custom_theme_tests {
+    use super::*;
+
+    #[test]
+    fn overrides_inherit_the_base_and_support_alpha() {
+        let palette =
+            parse_palette(r##"{"base":"light","colors":{"text":"#ebdbb2","shadow":"#00000080"}}"##)
+                .unwrap();
+        assert_eq!(palette.window, Palette::light().window);
+        assert!(!palette.dark);
+        assert_eq!(palette.text, Color32::from_rgb(235, 219, 178));
+        assert_eq!(palette.shadow, Color32::from_black_alpha(128));
+        assert_eq!(parse_palette("{}").unwrap(), Palette::dark());
+    }
+
+    #[test]
+    fn invalid_themes_are_rejected() {
+        for text in [
+            r##"{"colors":{"text":"#fff"}}"##,
+            r##"{"colors":{"text":"#zzzzzz"}}"##,
+            r##"{"colors":{"typo":"#ffffff"}}"##,
+            r#"{"base":"system"}"#,
+            r#"{"typo":true}"#,
+            "not json",
+        ] {
+            assert!(parse_palette(text).is_err(), "{text}");
+        }
+    }
+
+    #[test]
+    fn discovery_sorts_valid_files_and_skips_invalid_files() {
+        let dir = std::env::temp_dir().join(format!("fastpotify-themes-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(load_custom_themes(&dir).is_empty());
+        std::fs::create_dir_all(&dir).unwrap();
+        for (name, text) in [
+            ("z.json", "{}"),
+            ("a.json", "{}"),
+            ("bad.json", "invalid"),
+            ("ignored.txt", "{}"),
+        ] {
+            std::fs::write(dir.join(name), text).unwrap();
+        }
+        let themes = load_custom_themes(&dir);
+        assert_eq!(
+            themes
+                .iter()
+                .map(|theme| theme.filename.as_str())
+                .collect::<Vec<_>>(),
+            ["a.json", "z.json"]
+        );
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -480,24 +480,40 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
 
     section(ui, &palette, "Appearance", |ui| {
         widgets::setting_row(ui, &palette, "Theme", "", |ui| {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                for choice in ThemeChoice::ALL {
-                    if theme::soft_button(
-                        ui,
-                        &palette,
-                        None,
-                        choice.label(),
-                        app.settings.theme == choice,
-                    )
-                    .clicked()
-                        && app.settings.theme != choice
-                    {
-                        app.settings.theme = choice;
-                        changed = true;
+            let custom = app
+                .custom_themes
+                .iter()
+                .find(|theme| Some(&theme.filename) == app.settings.custom_theme.as_ref());
+            let selected = custom.map_or_else(
+                || app.settings.theme.label(),
+                |theme| theme.filename.as_str(),
+            );
+            egui::ComboBox::from_id_salt("appearance_theme")
+                .selected_text(selected)
+                .show_ui(ui, |ui| {
+                    for choice in ThemeChoice::ALL {
+                        if ui
+                            .selectable_label(
+                                custom.is_none() && app.settings.theme == choice,
+                                choice.label(),
+                            )
+                            .clicked()
+                        {
+                            app.settings.theme = choice;
+                            app.settings.custom_theme = None;
+                            changed = true;
+                        }
                     }
-                }
-            });
+                    for theme in &app.custom_themes {
+                        changed |= ui
+                            .selectable_value(
+                                &mut app.settings.custom_theme,
+                                Some(theme.filename.clone()),
+                                &theme.filename,
+                            )
+                            .changed();
+                    }
+                });
         });
         widgets::setting_row(
             ui,


### PR DESCRIPTION
Sorry but I need themes so badly.... hopefully this is a lightweight option you can accept, tried to make this as minimal as possible so it can be easily superseded by a more comprehensive theming system. I've been doing this on my fork for a while, so thought it would be good to open a PR. 

0-- how it works -0>
Load custom color palettes from JSON files in a `themes` folder beside `settings.json`, and select them in Appearance's Theme picker. Files inherit a dark/light palette; invalid or missing themes fall back to the built-in choice. No new dependencies.

Validated on macOS: 483 core/demo tests passed (one native credential-store test ignored), strict Clippy, rustfmt, Rust docs, and 27 assessment-script tests. Visually checked built-in and custom palettes in an isolated demo config.

Full-feature checks are blocked locally by MilkDrop's missing Boost dependency; the website build needs Bundler 4.0.16. Linux/Windows remain for CI.

