### PR TITLE
Add JSON configuration for Home shelves

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ on Linux). They include the Connect device name, bitrate, normalisation,
 autoplay, gapless playback, the audio backend (PulseAudio/PipeWire or ALSA on
 Linux), audio cache size, theme, sidebar state, whether pages take colour
 from artwork, and the mini player's skin and size.
+Home shelves and playlist sources can also be configured in JSON; see
+[Home layout](docs/_reference/settings-and-files.md#home-layout).
 Playback settings apply when you press **Apply and restart playback**.
 You can also check for a new release from Settings. On macOS, the same command
 is in the application menu.

--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -224,3 +224,45 @@ cargo run --release --features demo -- \
 The image uses the current window size. `--demo-size WIDTHxHEIGHT` sets that
 size for a shot (for example `760x800` or `1240x800`). `--demo-shot-delay <MS>`
 sets how long to wait for cover art before taking it.
+
+## Home layout
+
+Quit Fastpotify before editing `settings.json`, then restart it. Add a `home`
+object to hide shelves, limit their displayed items, or choose playlist sources:
+
+```json
+"home": {
+  "quick_access": {
+    "limit": 12,
+    "liked_songs": true,
+    "discover_weekly": true,
+    "release_radar": true,
+    "pinned_playlists": true,
+    "library_playlists": false
+  },
+  "made_for_you": {
+    "limit": 7,
+    "discover_weekly": false,
+    "release_radar": false
+  },
+  "recently_played": { "limit": 7 },
+  "top_artists": { "visible": false },
+  "top_songs": { "visible": false },
+  "recommendations": { "visible": false }
+}
+```
+
+Every section accepts `visible` and `limit` (0 to 255). Setting `visible` to
+`false` or `limit` to `0` hides it. Omitted preferences retain the standard
+layout. Limits cap loaded items; they do not request more data from Spotify.
+Hidden shelves still refresh in the background.
+
+Quick Access defaults to Liked Songs followed by library playlists, up to eight
+items. Optional Discover Weekly and Release Radar come next after Liked Songs,
+then pinned playlists in local pin order, then library playlists. Duplicates
+are omitted. Pins must be playlists present in the loaded library.
+
+Made for You defaults to all four sources: `discover_weekly`, `release_radar`,
+`daily_mixes`, and `daylist`. Each can be disabled separately. Recently Played
+defaults to 16 items, Top Songs to 10, and Recommendations to 20. Made for You
+and Top Artists show all currently fetched items by default (up to 255).

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -2315,6 +2315,67 @@ mod tests {
     }
 
     #[test]
+    fn home_json_hides_shelves_and_limits_quick_access() {
+        let (ctx, mut app) = accessible_app("home-json-limits");
+        app.settings.home = serde_json::from_str(
+            r#"{
+            "quick_access": {"limit": 1},
+            "made_for_you": {"visible": false},
+            "recently_played": {"limit": 0},
+            "top_artists": {"visible": false},
+            "top_songs": {"visible": false},
+            "recommendations": {"visible": false}
+        }"#,
+        )
+        .unwrap();
+        let view = crate::ui::home::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let text = view_frame(&ctx, &mut app, vec![], view);
+        assert!(text.iter().any(|(text, _)| text == "Liked Songs"));
+        for absent in [
+            "Made for you",
+            "Recently played",
+            "Your top artists",
+            "Your top songs",
+            "Recommended for you",
+            &playlist(0).name,
+        ] {
+            assert!(!text.iter().any(|(text, _)| text == absent), "{absent}");
+        }
+        app.backend.shutdown();
+    }
+
+    #[test]
+    fn home_json_pinned_playlists_are_first_and_not_duplicated() {
+        let (ctx, mut app) = accessible_app("home-json-pins");
+        app.settings.home.quick_access.liked_songs = false;
+        app.settings.home.quick_access.pinned_playlists = true;
+        app.settings.home.quick_access.limit = 3;
+        app.settings.pinned_contexts = vec![playlist(1).uri];
+        app.settings.home.made_for_you.visible = false;
+        app.settings.home.recently_played.visible = false;
+        app.settings.home.top_artists.visible = false;
+        app.settings.home.top_songs.visible = false;
+        app.settings.home.recommendations.visible = false;
+        let view = crate::ui::home::show;
+        view_frame(&ctx, &mut app, vec![], view);
+        let text = view_frame(&ctx, &mut app, vec![], view);
+        let names: Vec<_> = text
+            .iter()
+            .filter(|(name, _)| {
+                name == &playlist(0).name || name == &playlist(1).name || name == &playlist(2).name
+            })
+            .map(|(name, _)| name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            [playlist(1).name, playlist(0).name, playlist(2).name]
+        );
+        assert!(!text.iter().any(|(text, _)| text == "Liked Songs"));
+        app.backend.shutdown();
+    }
+
+    #[test]
     fn home_cards_open_item_menus() {
         for (section, title, uri, labels) in [
             (

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -47,6 +47,83 @@ pub enum ThemeChoice {
     System,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HomeShelfSettings {
+    pub visible: bool,
+    pub limit: Option<u8>,
+}
+
+impl Default for HomeShelfSettings {
+    fn default() -> Self {
+        Self {
+            visible: true,
+            limit: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct QuickAccessSettings {
+    pub visible: bool,
+    pub limit: u8,
+    pub liked_songs: bool,
+    pub discover_weekly: bool,
+    pub release_radar: bool,
+    pub pinned_playlists: bool,
+    pub library_playlists: bool,
+}
+
+impl Default for QuickAccessSettings {
+    fn default() -> Self {
+        Self {
+            visible: true,
+            limit: 8,
+            liked_songs: true,
+            discover_weekly: false,
+            release_radar: false,
+            pinned_playlists: false,
+            library_playlists: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MadeForYouSettings {
+    pub visible: bool,
+    pub limit: u8,
+    pub daily_mixes: bool,
+    pub daylist: bool,
+    pub discover_weekly: bool,
+    pub release_radar: bool,
+}
+
+impl Default for MadeForYouSettings {
+    fn default() -> Self {
+        Self {
+            visible: true,
+            limit: 255,
+            daily_mixes: true,
+            daylist: true,
+            discover_weekly: true,
+            release_radar: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HomeSettings {
+    pub quick_access: QuickAccessSettings,
+    pub made_for_you: MadeForYouSettings,
+    pub recently_played: HomeShelfSettings,
+    pub top_artists: HomeShelfSettings,
+    pub top_songs: HomeShelfSettings,
+    pub recommendations: HomeShelfSettings,
+}
+
 /// Mini-player visualizer mode.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -101,6 +178,7 @@ pub struct Settings {
     pub audio_cache: bool,
     pub audio_cache_mb: u64,
     pub theme: ThemeChoice,
+    pub home: HomeSettings,
     /// Tint the interface with the colour of the playing album's art.
     pub accent_from_art: bool,
     /// Last local volume, 0..=65535.
@@ -210,6 +288,7 @@ impl Default for Settings {
             audio_cache: true,
             audio_cache_mb: 1024,
             theme: ThemeChoice::Dark,
+            home: HomeSettings::default(),
             accent_from_art: true,
             volume: (u16::MAX as u32 * 70 / 100) as u16,
             sidebar_visible: true,
@@ -328,6 +407,42 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::Settings;
+
+    #[test]
+    fn partial_home_settings_preserve_other_preferences() {
+        let settings: Settings = serde_json::from_str(
+            r#"{
+            "volume": 12345,
+            "home": {
+                "quick_access": {"library_playlists": false},
+                "recently_played": {"visible": false},
+                "top_songs": {"limit": 3}
+            }
+        }"#,
+        )
+        .unwrap();
+        assert_eq!(settings.volume, 12345);
+        assert_eq!(settings.home.quick_access.limit, 8);
+        assert!(settings.home.quick_access.liked_songs);
+        assert!(!settings.home.quick_access.library_playlists);
+        assert!(!settings.home.recently_played.visible);
+        assert_eq!(settings.home.recently_played.limit, None);
+        assert_eq!(settings.home.top_songs.limit, Some(3));
+        assert!(settings.home.top_songs.visible);
+        assert_eq!(
+            settings.home.made_for_you,
+            super::MadeForYouSettings::default()
+        );
+        let encoded = serde_json::to_string(&settings).unwrap();
+        assert_eq!(
+            serde_json::from_str::<Settings>(&encoded).unwrap(),
+            settings
+        );
+        assert_eq!(
+            serde_json::from_str::<Settings>("{}").unwrap().home,
+            super::HomeSettings::default()
+        );
+    }
 
     #[test]
     fn older_settings_keep_the_sidebar_visible() {

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -6,7 +6,7 @@ use egui::{CornerRadius, Rect, Sense, Vec2, pos2, vec2};
 
 use crate::api::models::{PlayableItem, Playlist, pick_image};
 use crate::app::App;
-use crate::model::{Action, DISCOVER_TERMS, Loadable, Page, RowContext};
+use crate::model::{Action, Loadable, Page, RowContext};
 use crate::theme::{self, Icon};
 
 use super::widgets::{self, TrackRow};
@@ -16,14 +16,29 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     ui.add_space(6.0);
     theme::text(ui, crate::util::greeting(), theme::bold(30.0), palette.text);
     ui.add_space(12.0);
-    quick_access(app, ui);
-    ui.add_space(16.0);
-
-    made_for_you(app, ui);
-    recently_played(app, ui);
-    top_artists(app, ui);
-    top_tracks(app, ui);
-    recommendations(app, ui);
+    if app.settings.home.quick_access.visible && app.settings.home.quick_access.limit > 0 {
+        quick_access(app, ui);
+        ui.add_space(16.0);
+    }
+    if app.settings.home.made_for_you.visible && app.settings.home.made_for_you.limit > 0 {
+        made_for_you(app, ui);
+    }
+    if app.settings.home.recently_played.visible
+        && app.settings.home.recently_played.limit != Some(0)
+    {
+        recently_played(app, ui);
+    }
+    if app.settings.home.top_artists.visible && app.settings.home.top_artists.limit != Some(0) {
+        top_artists(app, ui);
+    }
+    if app.settings.home.top_songs.visible && app.settings.home.top_songs.limit != Some(0) {
+        top_tracks(app, ui);
+    }
+    if app.settings.home.recommendations.visible
+        && app.settings.home.recommendations.limit != Some(0)
+    {
+        recommendations(app, ui);
+    }
 }
 
 struct Tile {
@@ -35,33 +50,92 @@ struct Tile {
     owned_playlist: Option<Playlist>,
 }
 
+fn playlist_tile(app: &App, playlist: &Playlist) -> Tile {
+    Tile {
+        image: pick_image(&playlist.images, 64).map(str::to_string),
+        name: playlist.name.clone(),
+        page: Page::Playlist(playlist.id.clone()),
+        uri: Some(playlist.uri.clone()),
+        liked: false,
+        owned_playlist: app
+            .user_id()
+            .is_some_and(|id| playlist.owned_by(id))
+            .then(|| playlist.clone()),
+    }
+}
+
 fn quick_access(app: &mut App, ui: &mut egui::Ui) {
     let palette = app.palette;
-    let mut tiles: Vec<Tile> = vec![Tile {
-        image: None,
-        name: "Liked Songs".to_string(),
-        page: Page::LikedSongs,
-        uri: app
-            .user
-            .as_ref()
-            .map(|user| format!("spotify:user:{}:collection", user.id)),
-        liked: true,
-        owned_playlist: None,
-    }];
-    if let Some(playlists) = app.library.playlists.get() {
-        for playlist in playlists.iter().take(7) {
-            tiles.push(Tile {
-                image: pick_image(&playlist.images, 64).map(str::to_string),
-                name: playlist.name.clone(),
-                page: Page::Playlist(playlist.id.clone()),
-                uri: Some(playlist.uri.clone()),
-                liked: false,
-                owned_playlist: app
-                    .user_id()
-                    .is_some_and(|id| playlist.owned_by(id))
-                    .then(|| playlist.clone()),
-            });
+    let settings = app.settings.home.quick_access;
+    let mut tiles: Vec<Tile> = Vec::new();
+    if settings.liked_songs {
+        tiles.push(Tile {
+            image: None,
+            name: "Liked Songs".to_string(),
+            page: Page::LikedSongs,
+            uri: app
+                .user
+                .as_ref()
+                .map(|user| format!("spotify:user:{}:collection", user.id)),
+            liked: true,
+            owned_playlist: None,
+        });
+    }
+    for (name, enabled) in [
+        ("Discover Weekly", settings.discover_weekly),
+        ("Release Radar", settings.release_radar),
+    ] {
+        if enabled
+            && let Some(playlist) = app
+                .home
+                .discover
+                .get(name)
+                .and_then(Loadable::get)
+                .and_then(|playlists| {
+                    playlists
+                        .iter()
+                        .find(|playlist| playlist.name.eq_ignore_ascii_case(name))
+                })
+        {
+            tiles.push(playlist_tile(app, playlist));
         }
+    }
+    if settings.pinned_playlists
+        && let Some(playlists) = app.library.playlists.get()
+    {
+        for uri in &app.settings.pinned_contexts {
+            if tiles.len() >= settings.limit as usize {
+                break;
+            }
+            if tiles
+                .iter()
+                .any(|tile| tile.uri.as_deref() == Some(uri.as_str()))
+            {
+                continue;
+            }
+            if let Some(playlist) = playlists.iter().find(|playlist| playlist.uri == *uri) {
+                tiles.push(playlist_tile(app, playlist));
+            }
+        }
+    }
+    if settings.library_playlists
+        && let Some(playlists) = app.library.playlists.get()
+    {
+        for playlist in playlists {
+            if tiles.len() >= settings.limit as usize {
+                break;
+            }
+            if !tiles
+                .iter()
+                .any(|tile| tile.uri.as_deref() == Some(playlist.uri.as_str()))
+            {
+                tiles.push(playlist_tile(app, playlist));
+            }
+        }
+    }
+    tiles.truncate(settings.limit as usize);
+    if tiles.is_empty() {
+        return;
     }
     let available = ui.available_width();
     let columns = ((available / 300.0).floor() as usize).clamp(2, 4);
@@ -177,8 +251,17 @@ fn made_for_you(app: &mut App, ui: &mut egui::Ui) {
     let mut playlists: Vec<Playlist> = Vec::new();
     let mut loading = false;
     let mut failed = false;
-    for term in DISCOVER_TERMS {
-        match app.home.discover.get(*term) {
+    let settings = app.settings.home.made_for_you;
+    for (term, enabled) in [
+        ("Discover Weekly", settings.discover_weekly),
+        ("Release Radar", settings.release_radar),
+        ("Daily Mix", settings.daily_mixes),
+        ("daylist", settings.daylist),
+    ] {
+        if !enabled {
+            continue;
+        }
+        match app.home.discover.get(term) {
             Some(Loadable::Loaded(list)) => {
                 for playlist in list {
                     let duplicate = playlists.iter().any(|existing| {
@@ -195,6 +278,7 @@ fn made_for_you(app: &mut App, ui: &mut egui::Ui) {
             _ => {}
         }
     }
+    playlists.truncate(settings.limit as usize);
     if playlists.is_empty() && !loading && !failed {
         return;
     }
@@ -275,7 +359,7 @@ fn recently_played(app: &mut App, ui: &mut egui::Ui) {
                 .as_ref()
                 .is_some_and(|id| seen.insert(id.clone()))
         })
-        .take(16)
+        .take(app.settings.home.recently_played.limit.unwrap_or(16) as usize)
         .collect();
     if tracks.is_empty() {
         return;
@@ -336,7 +420,10 @@ fn top_artists(app: &mut App, ui: &mut egui::Ui) {
         return;
     }
     widgets::shelf(ui, &palette, "top-artists", "Your top artists", |ui| {
-        for artist in &artists {
+        for artist in artists
+            .iter()
+            .take(app.settings.home.top_artists.limit.unwrap_or(255) as usize)
+        {
             let card = widgets::card(
                 ui,
                 app,
@@ -454,7 +541,7 @@ fn top_tracks(app: &mut App, ui: &mut egui::Ui) {
         ui,
         "Your top songs",
         tracks,
-        10,
+        app.settings.home.top_songs.limit.unwrap_or(10) as usize,
         Some(Page::TopSongs),
         Some("Show more top songs"),
     );
@@ -462,5 +549,13 @@ fn top_tracks(app: &mut App, ui: &mut egui::Ui) {
 
 fn recommendations(app: &mut App, ui: &mut egui::Ui) {
     let tracks = app.home.recommendations.clone();
-    track_list(app, ui, "Recommended for you", tracks, 20, None, None);
+    track_list(
+        app,
+        ui,
+        "Recommended for you",
+        tracks,
+        app.settings.home.recommendations.limit.unwrap_or(20) as usize,
+        None,
+        None,
+    );
 }


### PR DESCRIPTION
one of the coolest things possible w a custom spotify player is the ability to hide the spotify slop that always appears on the homepage

this adds a small `home` config in `settings.json` so you can hide shelves, cap item counts, and choose what shows up in Quick Access / Made for You.

kept it JSON-only, no settings editor or new dependencies. defaults keep the current layout. quit the app, edit the file, restart. this only changes what's displayed, hidden shelves still fetch normally.

QA: 481 core/demo tests + 27 script tests passed, Clippy/fmt/Rust docs clean. checked default + customized Home in the native macOS demo. full MilkDrop checks need Boost and the website build needs Bundler, so those still need CI.
