### PR TITLE
fix(window): reopen the main window maximized when it was left that way

### DIFF
--- a/docs/_reference/settings-and-files.md
+++ b/docs/_reference/settings-and-files.md
@@ -112,6 +112,12 @@ may ignore saved positions. On Windows, a position
 whose title bar is no longer on an available monitor's work area is discarded
 when reopening the window, keeping its initial on-screen placement instead.
 
+On `main`, for the release after 0.7.1, a main window left maximized or full
+screen reopens that way, and comes back that way from the mini player. The
+remembered size and position describe an ordinary window and are not applied
+to one that already fills the screen, because sizing or moving such a window
+restores it down.
+
 Large playlist pages also have a **Go to song** control. Entering a song
 number loads its 50-item page directly, without requesting every earlier page.
 Filtering or sorting still covers the whole playlist, so either action returns

--- a/src/app.rs
+++ b/src/app.rs
@@ -756,7 +756,13 @@ impl App {
             }
             return;
         }
-        if let Some(size) = self.session_window_size.take() {
+        // The session's geometry describes an ordinary window; applying it to
+        // one eframe restored maximized or full screen would restore it down.
+        let filling_the_screen =
+            ctx.input(|input| crate::window::fills_the_screen(input.viewport()));
+        if let Some(size) = self.session_window_size.take()
+            && !filling_the_screen
+        {
             // Clamp to a sane range so a stale session never creates an
             // unusable window; the OS will further clamp to the monitor.
             if (400.0..=3000.0).contains(&size[0]) && (300.0..=2000.0).contains(&size[1]) {
@@ -767,6 +773,7 @@ impl App {
         }
         // If the saved position is off-screen, leave the window where eframe put it.
         if let Some(pos) = self.session_window_pos.take()
+            && !filling_the_screen
             && crate::window::can_restore(pos, ctx.pixels_per_point())
         {
             ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(
@@ -7907,6 +7914,45 @@ mod tests {
         );
         assert_eq!(app.session_window_size, Some([1024.0, 768.0]));
         assert_eq!(app.session_window_pos, Some([100.0, 100.0]));
+    }
+
+    /// A window left maximized or full screen comes back that way, instead of
+    /// being restored down by the session's size and position.
+    #[test]
+    fn a_window_that_fills_the_screen_keeps_its_state_over_the_session_geometry() {
+        for (name, maximized, fullscreen) in [
+            ("maximized", Some(true), None),
+            ("full screen", None, Some(true)),
+        ] {
+            let mut app = headless_app();
+            app.session_window_size = Some([1024.0, 768.0]);
+            app.session_window_pos = Some([100.0, 150.0]);
+
+            let ctx = egui::Context::default();
+            let mut raw_input = egui::RawInput::default();
+            let viewport = raw_input
+                .viewports
+                .entry(egui::ViewportId::ROOT)
+                .or_default();
+            viewport.maximized = maximized;
+            viewport.fullscreen = fullscreen;
+
+            let mut output = ctx.run_ui(raw_input, |_ui| app.attach(&ctx));
+            output.textures_delta.clear();
+            let commands = &output
+                .viewport_output
+                .get(&egui::ViewportId::ROOT)
+                .expect("the root viewport")
+                .commands;
+            assert!(
+                !commands.iter().any(|command| matches!(
+                    command,
+                    egui::ViewportCommand::InnerSize(_) | egui::ViewportCommand::OuterPosition(_)
+                )),
+                "a {name} window is neither resized nor moved: {commands:?}"
+            );
+            app.backend.shutdown();
+        }
     }
 
     /// The song the last session ended on is shown, paused, at the position

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,6 +12,14 @@ pub fn supports_window_level(display: raw_window_handle::RawDisplayHandle) -> bo
     !matches!(display, raw_window_handle::RawDisplayHandle::Wayland(_))
 }
 
+/// Whether the window already covers the screen, maximized or full screen.
+///
+/// eframe restores that state as it creates the window, and sizing or moving
+/// the window afterwards restores it down again.
+pub fn fills_the_screen(viewport: &egui::ViewportInfo) -> bool {
+    viewport.maximized.unwrap_or(false) || viewport.fullscreen.unwrap_or(false)
+}
+
 /// Checks a position in egui points against the fixed coordinate limits.
 #[cfg(not(windows))]
 pub fn can_restore(pos: [f32; 2], _pixels_per_point: f32) -> bool {
@@ -111,6 +119,22 @@ mod tests {
     fn logical_coordinates_are_scaled_to_monitor_pixels() {
         assert!(reachable([900.0, 100.0], 2.0, [0.0, 0.0, 1920.0, 1080.0]));
         assert!(!reachable([1000.0, 100.0], 2.0, [0.0, 0.0, 1920.0, 1080.0]));
+    }
+
+    #[test]
+    fn only_a_maximized_or_full_screen_window_fills_the_screen() {
+        let state = |maximized, fullscreen| {
+            fills_the_screen(&egui::ViewportInfo {
+                maximized,
+                fullscreen,
+                ..Default::default()
+            })
+        };
+        assert!(state(Some(true), Some(false)));
+        assert!(state(Some(false), Some(true)));
+        assert!(!state(Some(false), Some(false)));
+        // A backend that does not report the state leaves the window ordinary.
+        assert!(!state(None, None));
     }
 
     #[test]


### PR DESCRIPTION

## Why

A window closed while maximized came back as an ordinary window, and the same
happened every time you went to the mini player and back. Fastpotify already
remembers where and how big its window is; maximized was the one thing that
did not survive a restart.

What made this confusing to diagnose is that the state was being saved
correctly all along. `app.ron` said `maximized: true`, and editing it by hand
changed nothing.

## What changed

Fixes #351.

The state was restored and then immediately thrown away by our own code.
eframe reads its saved geometry and creates the window with
`.with_maximized(true)`. `App::attach` then runs and asks for the inner size
and outer position saved in `session.json`. Either of those reaches winit as
`request_inner_size` or `set_outer_position`, and both take a maximized window
straight back out of that state on the first frame. The geometry in
#351 hits both: the size passes the sanity clamp and the position passes
`can_restore`.

So `attach` now applies the remembered size and position only to a window that
is not already maximized or full screen (`window::fills_the_screen`). eframe
puts the root viewport info in place before the app is created, so the state
is already known there. Nothing else about the restore changes, and the mini
player round trip is fixed by the same guard since it goes through the same
`attach`.

No new session fields. eframe was already persisting this, we just had to
stop overriding it. Documented next to the existing note on remembered window
positions.

## Verification

macOS 15 (Apple silicon), toolchain from `rust-toolchain.toml`:

```sh
node --test .github/scripts/issue-assessment.test.cjs
cargo fmt --all --check
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --all-targets                   # 523 passed
cargo test --locked --all-targets --all-features    # 531 passed
cargo test --locked --all-features --doc
RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps
```

Two new tests: one for the predicate, one that attaches with the viewport
reporting maximized and then full screen and asserts neither `InnerSize` nor
`OuterPosition` goes out. Removing the guard makes the second fail with
`[InnerSize([1024.0 768.0]), OuterPosition([100.0 150.0])]`, which is the bug.
`closing_winamp_frame_does_not_overwrite_main_window_geometry` still covers
the ordinary window, so that path is unchanged.

No screenshots, since nothing drawn changes. Demo mode would not help either,
as it never writes session state and this only shows up across restarts.

I don't have a Windows machine to confirm the reporter's case end to end, and
`bundle exec jekyll build` wouldn't run here (system Ruby is older than the
pinned bundler); the docs change is one plain paragraph in an existing page.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [x] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [x] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.
