### PR TITLE
Add a refresh control on playlist pages

### DIFF
--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -270,11 +270,10 @@ pub fn actions_row(
                             )
                         });
                         if ui.is_rect_visible(rect) {
-                            let mut child = ui.new_child(
-                                egui::UiBuilder::new().max_rect(rect).layout(
+                            let mut child =
+                                ui.new_child(egui::UiBuilder::new().max_rect(rect).layout(
                                     Layout::centered_and_justified(egui::Direction::LeftToRight),
-                                ),
-                            );
+                                ));
                             theme::spinner(&mut child, 22.0, palette.secondary);
                         }
                         response.on_hover_text("Refreshing…");

--- a/src/ui/collection.rs
+++ b/src/ui/collection.rs
@@ -116,6 +116,9 @@ pub struct Actions<'a> {
     pub saved_icons: (Icon, Icon),
     pub saved_tooltips: (&'a str, &'a str),
     pub owned_playlist: Option<Playlist>,
+    /// When set, a refresh control sits by the filter. The bool is true while
+    /// that page is already reloading.
+    pub reload: Option<(Page, bool)>,
     pub name: &'a str,
 }
 
@@ -241,16 +244,53 @@ pub fn actions_row(
                     )
                 });
         }
-        if let Some(filter) = filter {
+        if filter.is_some() || actions.reload.is_some() {
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                widgets::search_field(
-                    ui,
-                    &palette,
-                    egui::Id::new(("collection-filter", actions.name)),
-                    filter,
-                    "Filter",
-                    220.0,
-                );
+                ui.spacing_mut().item_spacing.x = 10.0;
+                if let Some(filter) = filter {
+                    widgets::search_field(
+                        ui,
+                        &palette,
+                        egui::Id::new(("collection-filter", actions.name)),
+                        filter,
+                        "Filter",
+                        220.0,
+                    );
+                }
+                if let Some((page, loading)) = &actions.reload {
+                    if *loading {
+                        let edge = 38.0;
+                        let (rect, response) =
+                            ui.allocate_exact_size(Vec2::splat(edge), Sense::hover());
+                        response.widget_info(|| {
+                            egui::WidgetInfo::labeled(
+                                egui::WidgetType::ProgressIndicator,
+                                ui.is_enabled(),
+                                "Refreshing…",
+                            )
+                        });
+                        if ui.is_rect_visible(rect) {
+                            let mut child = ui.new_child(
+                                egui::UiBuilder::new().max_rect(rect).layout(
+                                    Layout::centered_and_justified(egui::Direction::LeftToRight),
+                                ),
+                            );
+                            theme::spinner(&mut child, 22.0, palette.secondary);
+                        }
+                        response.on_hover_text("Refreshing…");
+                    } else if theme::icon_button(
+                        ui,
+                        Icon::Refresh,
+                        26.0,
+                        palette.secondary,
+                        palette.text,
+                        "Refresh",
+                    )
+                    .clicked()
+                    {
+                        app.actions.push(Action::Reload(page.clone()));
+                    }
+                }
             });
         }
     });
@@ -949,6 +989,7 @@ pub fn playlist(app: &mut App, ui: &mut egui::Ui, id: &str) {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("Add to Your Library", "Remove from Your Library"),
                     owned_playlist: owned.then_some(playlist_clone),
+                    reload: Some((Page::Playlist(id.to_string()), page.items.loading)),
                     name: &playlist.name,
                 },
                 Some(&mut page.filter),
@@ -1065,6 +1106,7 @@ pub fn album(app: &mut App, ui: &mut egui::Ui, id: &str) {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("Save to Your Library", "Remove from Your Library"),
                     owned_playlist: None,
+                    reload: None,
                     name: &album.name,
                 },
                 None,
@@ -1265,6 +1307,7 @@ pub fn liked(app: &mut App, ui: &mut egui::Ui) {
             saved_icons: (Icon::Heart, Icon::HeartFilled),
             saved_tooltips: ("", ""),
             owned_playlist: None,
+            reload: None,
             name: "Liked Songs",
         },
         Some(&mut filter),
@@ -1624,6 +1667,7 @@ mod tests {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
+                    reload: None,
                     name: "Test",
                 },
                 None,
@@ -1669,6 +1713,7 @@ mod tests {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
+                    reload: None,
                     name: "Test",
                 },
                 None,
@@ -1718,6 +1763,7 @@ mod tests {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
+                    reload: None,
                     name: "Test",
                 },
                 None,
@@ -1763,6 +1809,7 @@ mod tests {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
+                    reload: None,
                     name: "Test",
                 },
                 None,
@@ -1813,6 +1860,7 @@ mod tests {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
+                    reload: None,
                     name: "Test",
                 },
                 Some(&mut filter),
@@ -1858,6 +1906,7 @@ mod tests {
                     saved_icons: (Icon::CirclePlus, Icon::CircleCheck),
                     saved_tooltips: ("", ""),
                     owned_playlist: None,
+                    reload: None,
                     name: "Test",
                 },
                 Some(&mut filter),


### PR DESCRIPTION
## Why

I was using Fastpotify and liked how focused and fast it feels. After adding a
few songs to a playlist outside the app (or from another client), those tracks
never showed up no matter what I tried inside Fastpotify. Closing and reopening
the app was the only reliable way to see the update.

Keeping playlists from constantly re-fetching makes sense for performance, and
that priority is part of why this project works well. Still, needing a full
restart just to refresh one playlist is awkward. A small Refresh control on the
playlist page felt like the right balance: on demand, no background polling, and
no change to the rest of the app.

## What changed

- `Actions` in `src/ui/collection.rs` accepts an optional `reload: Option<(Page, bool)>`.
- Playlist pages pass that page and its loading flag; album and Liked Songs leave it `None`.
- A Refresh control sits next to the Filter field.
- While reloading, the control shows a spinner, is not clickable, and uses the Refreshing… tooltip.
- Uses the existing `Action::Reload(Page)` path.

## Verification

- Platform: Windows
- `cargo check --locked --no-default-features`
- `cargo run --locked --no-default-features`
- Opened a playlist, clicked Refresh, confirmed the spinner and updated tracks.

### Screenshots
**Before**
<img width="2557" height="1437" alt="F brefore" src="https://github.com/user-attachments/assets/821be9d4-de50-4d5a-a34d-7117b84708b0" />

**After**
<img width="2562" height="1437" alt="F after" src="https://github.com/user-attachments/assets/9cef917c-2d24-4ca8-80c7-3acfac78e739" />

**Refreshing**
<img width="2557" height="1437" alt="F while" src="https://github.com/user-attachments/assets/ab20be95-f28a-499d-8767-5311f13f8221" />

## Relation to #271

This is complementary to #271 rather than dependent on it. #271 changes how eligible playlist reads are served; this PR provides an explicit way to trigger a new read for a playlist that is already loaded in memory.

If #271 lands, manual refreshes can benefit from its session-backed read path automatically. The control remains useful independently of it, since it only triggers the existing `Action::Reload(Page)` path and adds no background polling.

- [x] I read `CONTRIBUTING.md` and kept this pull request to one concern.
- [ ] I added or updated tests for behaviour that can regress.
- [x] I ran formatting, Clippy, and the relevant tests locally.
- [ ] I updated documentation for user-visible behaviour, settings, files, or network access.
- [x] I understand and take responsibility for every submitted line, including AI-assisted code.

Docs are unchecked on purpose until the Refresh control placement is confirmed in review.